### PR TITLE
Add JSON clipboard detection and collapsible tree preview

### DIFF
--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -283,6 +283,9 @@ struct ContentView: View {
                                     .padding(16)
                             }
                         }
+                    case .json:
+                        JSONTreeView(jsonString: item.contentPreview)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                     default:
                         ScrollView(.vertical, showsIndicators: true) {
                             switch item.content {
@@ -302,7 +305,7 @@ struct ContentView: View {
                                         store.fetchLinkMetadataIfNeeded(for: item)
                                     }
 
-                            case .text, .email, .phone, .address, .date, .transit:
+                            case .text, .json, .email, .phone, .address, .date, .transit:
                                 EmptyView()
                             }
                         }

--- a/Sources/App/JSONTreeView.swift
+++ b/Sources/App/JSONTreeView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import Foundation
+
+struct JSONTreeView: View {
+    let jsonString: String
+
+    private var rootNode: JSONNode? {
+        JSONNode.from(jsonString: jsonString)
+    }
+
+    var body: some View {
+        if let rootNode {
+            ScrollView(.vertical, showsIndicators: true) {
+                OutlineGroup([rootNode], children: \.children) { node in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text(node.name)
+                            .font(.custom(FontManager.mono, size: 14))
+                        if let value = node.valueDescription {
+                            Text(value)
+                                .font(.custom(FontManager.mono, size: 14))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .modifier(IBeamCursorOnHover())
+                }
+                .padding(16)
+            }
+        } else {
+            Text("Invalid JSON")
+                .font(.custom(FontManager.mono, size: 14))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+private struct JSONNode: Identifiable {
+    let id = UUID()
+    let name: String
+    let valueDescription: String?
+    let children: [JSONNode]?
+
+    static func from(jsonString: String) -> JSONNode? {
+        guard let data = jsonString.data(using: .utf8) else { return nil }
+        guard let value = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+            return nil
+        }
+        return buildNode(name: "JSON", value: value)
+    }
+
+    private static func buildNode(name: String, value: Any) -> JSONNode {
+        if let dict = value as? [String: Any] {
+            let children = dict.keys.sorted().map { key in
+                buildNode(name: key, value: dict[key] as Any)
+            }
+            return JSONNode(name: name, valueDescription: "{\(children.count)}", children: children)
+        }
+
+        if let array = value as? [Any] {
+            let children = array.enumerated().map { index, element in
+                buildNode(name: "[\(index)]", value: element)
+            }
+            return JSONNode(name: name, valueDescription: "[\(children.count)]", children: children)
+        }
+
+        if value is NSNull {
+            return JSONNode(name: name, valueDescription: "null", children: nil)
+        }
+
+        if let stringValue = value as? String {
+            return JSONNode(name: name, valueDescription: "\"\(stringValue)\"", children: nil)
+        }
+
+        if let numberValue = value as? NSNumber {
+            let description: String
+            if CFGetTypeID(numberValue) == CFBooleanGetTypeID() {
+                description = numberValue.boolValue ? "true" : "false"
+            } else {
+                description = numberValue.stringValue
+            }
+            return JSONNode(name: name, valueDescription: description, children: nil)
+        }
+
+        return JSONNode(name: name, valueDescription: String(describing: value), children: nil)
+    }
+}

--- a/Sources/Core/ClipboardItem.swift
+++ b/Sources/Core/ClipboardItem.swift
@@ -6,6 +6,7 @@ import GRDB
 /// Type-safe content representation that ensures only valid states are possible
 public enum ClipboardContent: Sendable, Equatable {
     case text(String)
+    case json(String)
     case link(url: String, metadataState: LinkMetadataState)
     case email(address: String)
     case phone(number: String)
@@ -18,6 +19,8 @@ public enum ClipboardContent: Sendable, Equatable {
     public var textContent: String {
         switch self {
         case .text(let text):
+            return text
+        case .json(let text):
             return text
         case .link(let url, _):
             return url
@@ -39,6 +42,7 @@ public enum ClipboardContent: Sendable, Equatable {
     public var icon: String {
         switch self {
         case .text: return "doc.text"
+        case .json: return "curlybraces"
         case .link: return "link"
         case .email: return "envelope"
         case .phone: return "phone"
@@ -53,6 +57,7 @@ public enum ClipboardContent: Sendable, Equatable {
     var databaseType: String {
         switch self {
         case .text: return "text"
+        case .json: return "json"
         case .link: return "link"
         case .email: return "email"
         case .phone: return "phone"
@@ -68,6 +73,8 @@ public enum ClipboardContent: Sendable, Equatable {
     var databaseFields: (String, Data?, String?, Data?) {
         switch self {
         case .text(let text):
+            return (text, nil, nil, nil)
+        case .json(let text):
             return (text, nil, nil, nil)
         case .link(let url, let metadataState):
             // Encode metadata state: nil = pending, empty = failed, value = loaded
@@ -97,6 +104,8 @@ public enum ClipboardContent: Sendable, Equatable {
         linkImageData: Data?
     ) -> ClipboardContent {
         switch databaseType {
+        case "json":
+            return .json(content)
         case "link":
             let metadataState = LinkMetadataState.fromDatabase(title: linkTitle, imageData: linkImageData)
             return .link(url: content, metadataState: metadataState)


### PR DESCRIPTION
### Motivation

- Support JSON as a first-class clipboard content type so JSON pasted to the clipboard is detected and previewed appropriately.
- Persist JSON items in the database via the existing `contentType` column so JSON can be distinguished from plain text.
- Provide a readable, collapsible preview for JSON without hand-rolling a tree component by leveraging built-in SwiftUI components.

### Description

- Added a new `ClipboardContent.json(String)` case and associated DB mapping (`databaseType == "json"`) in `Sources/Core/ClipboardItem.swift`.
- Detect JSON asynchronously after inserting new text items using `JSONSerialization.jsonObject` in `ClipboardStore.detectAndUpdateJSONType`, and update the DB `contentType` to `json` when appropriate in `Sources/App/ClipboardStore.swift`.
- Introduced a `JSONTreeView` component (`Sources/App/JSONTreeView.swift`) which renders the JSON structure using SwiftUI's built-in `OutlineGroup` and a small `JSONNode` helper to build the tree.
- Wired JSON previews into the main preview pane by showing `JSONTreeView(jsonString:)` for `.json` items in `Sources/App/ContentView.swift`.

### Testing

- No automated tests were executed as part of this change.
- Manual verification was not reported in the rollout transcript.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c669ef148329b541403fc7fd4ef2)