### PR TITLE
Fix bundle binary path resolution in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,13 @@ bundle:
 	@rm -rf "$(APP_NAME).app"
 	@mkdir -p "$(APP_NAME).app/Contents/MacOS"
 	@mkdir -p "$(APP_NAME).app/Contents/Resources"
-	@cp ".build/release/$(APP_NAME)" "$(APP_NAME).app/Contents/MacOS/$(APP_NAME)"
+	@BIN_PATH="$$(swift build -c release $(SWIFT_ARCH_FLAGS) --show-bin-path)"; \
+	if [ -f "$$BIN_PATH/$(APP_NAME)" ]; then \
+		cp "$$BIN_PATH/$(APP_NAME)" "$(APP_NAME).app/Contents/MacOS/$(APP_NAME)"; \
+	else \
+		echo "Error: built binary not found at $$BIN_PATH/$(APP_NAME)" >&2; \
+		exit 1; \
+	fi
 	@if [ -d ".build/release/$(APP_NAME)_$(APP_NAME).bundle" ]; then \
 		cp -R ".build/release/$(APP_NAME)_$(APP_NAME).bundle/Contents/Resources/"* "$(APP_NAME).app/Contents/Resources/" 2>/dev/null || true; \
 	fi


### PR DESCRIPTION
### Motivation
- The `bundle` target assumed the built binary would always be at `.build/release/$(APP_NAME)`, which can be incorrect for different SwiftPM output layouts or when using `--arch` flags.
- Bundling failed with a missing-file error during packaging when the binary wasn't found at the hardcoded path.
- The change aims to reliably locate the SwiftPM build output and provide a clear error when the binary is absent.

### Description
- Update the `bundle` target in `Makefile` to determine `BIN_PATH` with `swift build -c release $(SWIFT_ARCH_FLAGS) --show-bin-path` and copy the binary from `$$BIN_PATH/$(APP_NAME)`.
- Add an explicit error message and `exit 1` if the expected binary is not present at the resolved path.
- Preserve existing behavior for copying resource bundles and generating the app `Info.plist` and icons.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963fdcafb04832999c8555ea83f4971)