### PR TITLE
Add DMG installer build with drag-to-Applications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  release:
+    types: [created]
 
 permissions:
   contents: write
@@ -22,28 +24,49 @@ jobs:
         with:
           swift-version: "6.2"
 
+      - name: Install create-dmg
+        run: brew install create-dmg
+
       - name: Build App
         run: |
           make
 
-      - name: Create ZIP
+      - name: Build DMG
         run: |
-          ditto -c -k --sequesterRsrc --keepParent ClipKitty.app ClipKitty.app.zip
+          chmod +x Scripts/build-dmg.sh
+          ./Scripts/build-dmg.sh ClipKitty.app ClipKitty.dmg
 
-      - name: Upload Artifact
+      - name: Upload DMG Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ClipKitty
-          path: ClipKitty.app.zip
+          name: ClipKitty-DMG
+          path: ClipKitty.dmg
 
-      - name: Create Release
+      - name: Upload App Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClipKitty-App
+          path: ClipKitty.app
+
+      # Upload DMG to release when a release is created
+      - name: Upload Release Asset
+        if: github.event_name == 'release'
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            ClipKitty.dmg \
+            --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # Create automatic pre-release on push to main (for development builds)
+      - name: Create Development Release
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           gh release create "commit-${GITHUB_SHA}" \
             --title "ClipKitty ${GITHUB_SHA}" \
             --generate-notes \
             --prerelease \
-            ClipKitty.app.zip
+            ClipKitty.dmg
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -77,7 +100,7 @@ jobs:
       - name: Run UI Tests
         run: |
           make screenshot
-          echo "### 🚀 UI Performance Results" >> $GITHUB_STEP_SUMMARY
+          echo "### UI Performance Results" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           swift Scripts/PrintPerfResults.swift >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ screenshot-*.png
 # macOS
 .DS_Store
 *.app
+*.dmg
 
 # Rust build artifacts
 rust-core/target/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ APP_BINARY := $(APP_BUNDLE)/Contents/MacOS/$(APP_NAME)
 APP_PLIST := $(APP_BUNDLE)/Contents/Info.plist
 APP_ICONS := $(APP_BUNDLE)/Contents/Resources/Assets.car
 
-.PHONY: all clean sign screenshot perf build-binary
+.PHONY: all clean sign screenshot perf build-binary dmg
 
 all: $(APP_BUNDLE) $(APP_ICONS)
 
@@ -106,6 +106,7 @@ clean:
 	@rm -rf ClipKitty.xcodeproj
 	@rm -rf DerivedData
 	@rm -f xcodebuild.log
+	@rm -f "$(APP_NAME).dmg"
 
 sign: $(APP_BUNDLE)
 	@echo "Signing with entitlements..."
@@ -117,6 +118,11 @@ perf: sign ClipKitty.xcodeproj
 	@rm -rf DerivedData
 	@xcodebuild test -project ClipKitty.xcodeproj -scheme ClipKittyUITests -destination 'platform=macOS' -derivedDataPath DerivedData -only-testing:ClipKittyUITests/ClipKittyPerformanceTests | tee xcodebuild.log
 	@swift Scripts/PrintPerfResults.swift
+
+# Build DMG installer
+dmg: all
+	@echo "Building DMG installer..."
+	@./Scripts/build-dmg.sh "$(APP_BUNDLE)" "$(APP_NAME).dmg"
 
 # Screenshot runs everything
 screenshot: sign ClipKitty.xcodeproj

--- a/Scripts/build-dmg.sh
+++ b/Scripts/build-dmg.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Build a DMG installer for ClipKitty
+# Usage: ./build-dmg.sh [app-path] [output-dmg-path]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+APP_PATH="${1:-$PROJECT_ROOT/ClipKitty.app}"
+OUTPUT_DMG="${2:-$PROJECT_ROOT/ClipKitty.dmg}"
+VOLUME_NAME="ClipKitty"
+
+# Verify app exists
+if [ ! -d "$APP_PATH" ]; then
+    echo "Error: App not found at $APP_PATH" >&2
+    exit 1
+fi
+
+# Create temp directory for DMG contents
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf '$TEMP_DIR'" EXIT
+
+# Generate background image
+BACKGROUND_PATH="$TEMP_DIR/background.png"
+echo "Generating DMG background image..."
+swift "$SCRIPT_DIR/create-dmg-background.swift" "$BACKGROUND_PATH"
+
+# Copy app to temp directory
+cp -R "$APP_PATH" "$TEMP_DIR/"
+
+# Create DMG staging directory
+STAGING_DIR="$TEMP_DIR/staging"
+mkdir -p "$STAGING_DIR"
+cp -R "$APP_PATH" "$STAGING_DIR/"
+
+# Create Applications symlink
+ln -s /Applications "$STAGING_DIR/Applications"
+
+# Add background image to staging
+mkdir -p "$STAGING_DIR/.background"
+cp "$BACKGROUND_PATH" "$STAGING_DIR/.background/background.png"
+
+# Remove existing DMG if present
+rm -f "$OUTPUT_DMG"
+
+# Check if create-dmg is available, otherwise use hdiutil directly
+if command -v create-dmg &> /dev/null; then
+    echo "Building DMG with create-dmg..."
+    create-dmg \
+        --volname "$VOLUME_NAME" \
+        --background "$BACKGROUND_PATH" \
+        --window-pos 200 120 \
+        --window-size 660 500 \
+        --icon-size 100 \
+        --icon "ClipKitty.app" 165 280 \
+        --hide-extension "ClipKitty.app" \
+        --app-drop-link 495 280 \
+        "$OUTPUT_DMG" \
+        "$STAGING_DIR/"
+else
+    echo "Building DMG with hdiutil (install create-dmg for prettier results)..."
+
+    # Create a temporary DMG
+    TEMP_DMG="$TEMP_DIR/temp.dmg"
+
+    # Calculate size needed (app size + 20MB buffer)
+    APP_SIZE=$(du -sm "$STAGING_DIR" | cut -f1)
+    DMG_SIZE=$((APP_SIZE + 20))
+
+    # Create DMG
+    hdiutil create -srcfolder "$STAGING_DIR" \
+        -volname "$VOLUME_NAME" \
+        -fs HFS+ \
+        -fsargs "-c c=64,a=16,e=16" \
+        -format UDRW \
+        -size "${DMG_SIZE}m" \
+        "$TEMP_DMG"
+
+    # Mount the DMG to configure Finder view
+    hdiutil attach -readwrite -noverify -noautoopen "$TEMP_DMG" -mountpoint "/Volumes/$VOLUME_NAME"
+
+    # Configure Finder view using AppleScript
+    osascript <<EOF || true
+tell application "Finder"
+    tell disk "$VOLUME_NAME"
+        open
+        set current view of container window to icon view
+        set toolbar visible of container window to false
+        set statusbar visible of container window to false
+        set bounds of container window to {200, 120, 860, 620}
+        set viewOptions to the icon view options of container window
+        set arrangement of viewOptions to not arranged
+        set icon size of viewOptions to 100
+        set background picture of viewOptions to file ".background:background.png"
+        set position of item "ClipKitty.app" of container window to {165, 280}
+        set position of item "Applications" of container window to {495, 280}
+        close
+        open
+        update without registering applications
+        delay 1
+        close
+    end tell
+end tell
+EOF
+
+    # Unmount
+    sync
+    sleep 1
+    hdiutil detach "/Volumes/$VOLUME_NAME" 2>/dev/null || hdiutil detach "/Volumes/$VOLUME_NAME" -force
+
+    # Convert to compressed read-only DMG
+    hdiutil convert "$TEMP_DMG" -format UDZO -imagekey zlib-level=9 -o "$OUTPUT_DMG"
+fi
+
+echo ""
+echo "DMG created successfully: $OUTPUT_DMG"
+echo "Size: $(du -h "$OUTPUT_DMG" | cut -f1)"

--- a/Scripts/create-dmg-background.swift
+++ b/Scripts/create-dmg-background.swift
@@ -1,0 +1,102 @@
+#!/usr/bin/env swift
+// Creates a DMG background image with installation instructions
+// Usage: swift create-dmg-background.swift <output-path>
+
+import AppKit
+import Foundation
+
+let outputPath = CommandLine.arguments.count > 1
+    ? CommandLine.arguments[1]
+    : "dmg-background.png"
+
+// DMG window dimensions (will be set in create-dmg)
+let width: CGFloat = 660
+let height: CGFloat = 500
+
+// Create the image
+let image = NSImage(size: NSSize(width: width, height: height))
+image.lockFocus()
+
+// Background gradient - light enough for Finder's black icon labels
+let gradient = NSGradient(colors: [
+    NSColor(calibratedRed: 0.85, green: 0.85, blue: 0.87, alpha: 1.0),
+    NSColor(calibratedRed: 0.75, green: 0.75, blue: 0.78, alpha: 1.0)
+])!
+gradient.draw(in: NSRect(x: 0, y: 0, width: width, height: height), angle: -90)
+
+// Arrow from app icon position to Applications folder position
+let arrowPath = NSBezierPath()
+let arrowStartX: CGFloat = 200  // App icon center
+let arrowEndX: CGFloat = 460    // Applications folder center
+let arrowY: CGFloat = 280       // Vertical center of icons area
+
+// Draw dashed arrow line
+arrowPath.move(to: NSPoint(x: arrowStartX + 60, y: arrowY))
+arrowPath.line(to: NSPoint(x: arrowEndX - 60, y: arrowY))
+
+NSColor(calibratedWhite: 0.4, alpha: 0.8).setStroke()
+arrowPath.lineWidth = 3
+arrowPath.setLineDash([12, 8], count: 2, phase: 0)
+arrowPath.stroke()
+
+// Arrow head
+let arrowHead = NSBezierPath()
+arrowHead.move(to: NSPoint(x: arrowEndX - 75, y: arrowY + 15))
+arrowHead.line(to: NSPoint(x: arrowEndX - 55, y: arrowY))
+arrowHead.line(to: NSPoint(x: arrowEndX - 75, y: arrowY - 15))
+arrowHead.lineWidth = 3
+arrowHead.lineCapStyle = .round
+arrowHead.lineJoinStyle = .round
+arrowHead.stroke()
+
+// Title text
+let titleAttrs: [NSAttributedString.Key: Any] = [
+    .font: NSFont.systemFont(ofSize: 22, weight: .semibold),
+    .foregroundColor: NSColor(calibratedWhite: 0.15, alpha: 1.0)
+]
+let title = "Drag ClipKitty to Applications"
+let titleSize = title.size(withAttributes: titleAttrs)
+title.draw(at: NSPoint(x: (width - titleSize.width) / 2, y: height - 60), withAttributes: titleAttrs)
+
+// Instructions section - positioned below the icons area
+let instructionY: CGFloat = 100
+let lineHeight: CGFloat = 28
+let centerX: CGFloat = width / 2
+
+let headerAttrs: [NSAttributedString.Key: Any] = [
+    .font: NSFont.systemFont(ofSize: 16, weight: .semibold),
+    .foregroundColor: NSColor(calibratedWhite: 0.15, alpha: 1.0)
+]
+
+let stepAttrs: [NSAttributedString.Key: Any] = [
+    .font: NSFont.systemFont(ofSize: 14, weight: .regular),
+    .foregroundColor: NSColor(calibratedWhite: 0.3, alpha: 1.0)
+]
+
+// First Launch Instructions (centered)
+func drawCentered(_ text: String, y: CGFloat, attrs: [NSAttributedString.Key: Any]) {
+    let size = text.size(withAttributes: attrs)
+    text.draw(at: NSPoint(x: centerX - size.width / 2, y: y), withAttributes: attrs)
+}
+
+drawCentered("First Launch", y: instructionY, attrs: headerAttrs)
+drawCentered("Right-click app > Open > Done > System Settings > Privacy & Security > Open Anyway", y: instructionY - lineHeight, attrs: stepAttrs)
+
+image.unlockFocus()
+
+// Save as PNG
+guard let tiffData = image.tiffRepresentation,
+      let bitmap = NSBitmapImageRep(data: tiffData),
+      let pngData = bitmap.representation(using: .png, properties: [:]) else {
+    fputs("Error: Failed to create PNG data\n", stderr)
+    exit(1)
+}
+
+let url = URL(fileURLWithPath: outputPath)
+do {
+    try pngData.write(to: url)
+    print("Created DMG background: \(outputPath)")
+} catch {
+    fputs("Error: Failed to write file: \(error)\n", stderr)
+    exit(1)
+}


### PR DESCRIPTION
## Summary
- Add `make dmg` target to build DMG installer
- Add Scripts/create-dmg-background.swift to generate background image with first launch instructions
- Add Scripts/build-dmg.sh for DMG creation (uses create-dmg or hdiutil fallback)
- Update CI to build and attach DMG to releases

## Test plan
- [x] `make dmg` builds successfully
- [x] DMG opens with background image showing instructions
- [x] App and Applications folder visible with readable labels
- [x] CI builds DMG on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)