### PR TITLE
feat(search): first-char penalty, relaxed recall, prefix-aware exactness

### DIFF
--- a/purr/src/indexer.rs
+++ b/purr/src/indexer.rs
@@ -430,9 +430,15 @@ impl Indexer {
             } else if num_terms >= 20 {
                 4 * num_terms / 5
             } else if num_terms >= 7 {
-                (num_terms * 2 / 3).max(5)
+                // A single typo destroys up to 4 trigrams. Allow enough slack
+                // so candidates survive into Phase 2 where the first-character
+                // penalty and bucket ranking filter noise.
+                num_terms.saturating_sub(4).max(2)
             } else {
-                (num_terms + 1) / 2
+                // Short words (3-6 trigrams): a single typo can destroy almost
+                // all overlap. Drop threshold aggressively — Phase 2's
+                // first-character penalty prevents false positives.
+                num_terms.saturating_sub(3).max(1)
             };
             recall_query.set_minimum_number_should_match(min_match);
         }


### PR DESCRIPTION
## Summary

Three search quality improvements grounded in typo statistics:

- **First-character penalty**: ~98% of real typos preserve the first letter. A mismatch on position 0 now incurs +1 edit distance, preventing false positives like "cat"→"bat"/"fat"/"rat" (penalty pushes distance to 2, exceeding max_dist=1). First-two-char transpositions ("hte"→"the") are exempt as common fast-typing errors.

- **Relaxed trigram recall for short queries**: A single typo can destroy 3-4 of a short word's trigrams, causing Phase 1 to drop valid candidates before Phase 2 ever scores them. Thresholds lowered from `(n+1)/2` to `n.saturating_sub(3).max(1)` for 3-6 trigrams and from `2n/3` to `n.saturating_sub(4).max(2)` for 7-19 trigrams. Phase 2's first-character penalty and bucket ranking filter any noise.

- **Prefix matches elevated above fuzzy in exactness**: Prefix matches ("clip"→"clipkitty") indicate "typing in progress" (high intent), while fuzzy matches indicate typos (lower intent). Exactness scale expanded from 0-3 to 0-4, with a new level 2 for prefix-only matches sitting above all-fuzzy (level 0).

## Test plan
- [x] All 121 existing tests pass (updated 3 for new exactness scale)
- [x] New tests: first-char penalty, transposition exemption, prefix exactness, prefix-beats-fuzzy
- [x] `does_word_match("bat", "cat")` → `None` (was `Fuzzy(1)`)
- [x] `does_word_match("teh", "the")` → `Fuzzy(1)` (transposition still works)
- [x] `does_word_match("hte", "the")` → `Fuzzy(1)` (first-char transposition exempt)