### PR TITLE
WIP: Integrate SymSpell for fuzzy search

### DIFF
--- a/purr/Cargo.lock
+++ b/purr/Cargo.lock
@@ -217,7 +217,7 @@ version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -515,12 +515,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -538,11 +562,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.114",
 ]
@@ -555,6 +590,37 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1589,12 +1655,13 @@ dependencies = [
  "parking_lot",
  "r2d2",
  "r2d2_sqlite",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "rusqlite",
  "serde",
  "serde_json",
+ "symspell",
  "tantivy",
  "tempfile",
  "thiserror",
@@ -2045,6 +2112,20 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "symspell"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c8f69794fa4370d8fff17895350e56c8c803576a7ca782a5c6598d434a2646"
+dependencies = [
+ "derive_builder",
+ "serde",
+ "serde_derive",
+ "strsim",
+ "unidecode",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "syn"
@@ -2506,6 +2587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unidecode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402bb19d8e03f1d1a7450e2bd613980869438e0666331be3e073089124aa1adc"
+
+[[package]]
 name = "uniffi"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,6 +2866,8 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]

--- a/purr/Cargo.toml
+++ b/purr/Cargo.toml
@@ -33,6 +33,7 @@ csscolorparser = "*"
 uniffi = { version = "*", features = ["cli"] }
 validator = { version = "0.16", features = ["derive", "unic"] }
 tantivy = "*"
+symspell = "0.4"
 image = { version = "*", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 tokio = { version = "*", features = ["full"] }
 tokio-util = { version = "*", features = ["rt"] }


### PR DESCRIPTION
## Summary
Attempts to integrate SymSpell pre-computed fuzzy matching to replace custom edit distance calculations with O(1) HashMap lookups during ranking and highlighting.

## Changes
- Add symspell 0.4 dependency
- Add SymSpell infrastructure to Indexer: spellchecker field, fuzzy expansion builder
- Update `does_word_match()` to accept pre-computed fuzzy expansion maps instead of calculating edit distances
- Thread fuzzy_expansions through `compute_bucket_score()` and `match_query_words()`
- Update `search()` return type to include fuzzy expansion maps
- Update `search_trigram()` and `highlight_candidate()` to pass fuzzy expansions

## Status
- [x] Compiles (with warnings)
- [ ] Tests updated to pass fuzzy expansions
- [ ] All 117 tests passing

## Notes
This WIP PR shows the structure for integrating SymSpell into the refactored codebase. The test updates to provide fuzzy expansion maps for each test case are pending completion.

The approach maintains the real functions for production use - all fuzzy matching is computed through SymSpell lookups rather than on-demand edit distance calculations.