### PR TITLE
Revert graceful failure — use ruleset bypass instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,7 @@ jobs:
             sed -i '' "s/\"MARKETING_VERSION\": \"$CURRENT\"/\"MARKETING_VERSION\": \"$VERSION\"/" Project.swift
             git add Project.swift
             git commit -m "bump version to $VERSION"
-            git push origin main || echo "Note: Could not push to main (protected branch). Sync manually or via merge request."
+            git push origin main
           fi
 
   # Upload to App Store Connect via Fastlane


### PR DESCRIPTION
Reverts the graceful failure workaround. Main branch protection is now handled via a ruleset with admin bypass, so the version sync push should succeed.