### PR TITLE
Add content-type filter dropdown to search bar

### DIFF
--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -312,15 +312,17 @@ struct ContentView: View {
                 Image(systemName: "chevron.down")
                     .font(.system(size: 9, weight: .semibold))
             }
-            .foregroundStyle(store.contentTypeFilter == .all ? .secondary : .primary)
+            .foregroundStyle(.primary.opacity(store.contentTypeFilter == .all ? 0.6 : 1.0))
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(
                 Capsule()
-                    .fill(store.contentTypeFilter == .all ? Color.primary.opacity(0.06) : Color.accentColor.opacity(0.15))
+                    .fill(store.contentTypeFilter == .all ? Color.primary.opacity(0.12) : Color.accentColor.opacity(0.15))
             )
+            .overlay(Capsule().strokeBorder(Color.primary.opacity(0.1)))
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("FilterDropdown")
         .popover(isPresented: $showFilterPopover, arrowEdge: .bottom) {
             filterPopoverContent
         }

--- a/Tests/UITests/ClipKittyUITests.swift
+++ b/Tests/UITests/ClipKittyUITests.swift
@@ -262,6 +262,49 @@ final class ClipKittyUITests: XCTestCase {
                        "Window Y position should not change when clicking preview text")
     }
 
+    /// Tests that the content-type filter dropdown is visible and functional.
+    /// The dropdown capsule must be hittable (rendered with nonzero frame and sufficient contrast),
+    /// open a popover with filter options, and allow selecting a filter.
+    func testFilterDropdownVisible() throws {
+        let window = app.dialogs.firstMatch
+        XCTAssertTrue(window.exists, "Window should be visible")
+
+        // 1. Find the filter dropdown button by accessibility identifier
+        let filterButton = window.buttons["FilterDropdown"]
+        XCTAssertTrue(filterButton.waitForExistence(timeout: 5), "Filter dropdown button should exist")
+        XCTAssertTrue(filterButton.isHittable, "Filter dropdown button should be hittable (visible with nonzero frame)")
+
+        // Screenshot: dropdown closed
+        saveScreenshot(name: "filter_closed")
+
+        // 2. Click to open the popover
+        filterButton.click()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // 3. Verify popover content appears with filter options
+        let allTypesOption = app.staticTexts["All Types"]
+        XCTAssertTrue(allTypesOption.waitForExistence(timeout: 3), "Popover should show 'All Types' option")
+
+        let linksOption = app.staticTexts["Links Only"]
+        XCTAssertTrue(linksOption.exists, "Popover should show 'Links Only' option")
+
+        // Screenshot: dropdown open
+        saveScreenshot(name: "filter_open")
+
+        // 4. Select "Links Only" and verify the button label changes
+        linksOption.click()
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // After selecting, the button label should reflect the new filter
+        let updatedButton = window.buttons["FilterDropdown"]
+        XCTAssertTrue(updatedButton.waitForExistence(timeout: 3), "Filter button should still exist after selection")
+        XCTAssertTrue(updatedButton.isHittable, "Filter button should remain hittable after selection")
+
+        // The button label should now say "Links" instead of "All Types"
+        let linksLabel = updatedButton.staticTexts["Links"]
+        XCTAssertTrue(linksLabel.exists, "Filter button should show 'Links' after selecting Links Only")
+    }
+
     func testTakeScreenshot() throws {
         // Wait for animations and loading - use fixed delay to avoid hanging if items never appear
         Thread.sleep(forTimeInterval: 2.0)


### PR DESCRIPTION
## Summary
- Add content-type filter dropdown (Text, Images, Links, Colors) to the search bar
- Implement filtered search in both short-query and trigram paths via `search_filtered` API
- Fix invisible filter capsule on glass/material backgrounds (increased opacity, added stroke border)
- Add `testFilterDropdownVisible` UI test

## Test plan
- [x] `cargo test` — all tests pass
- [x] `xcodebuild build -scheme ClipKitty -configuration Debug` — builds successfully
- [ ] Manual: Filter dropdown opens, selects filters, shows correct results
- [ ] Visual check: filter capsule visible on both light and dark mode