### PR TITLE
Fix: unset extraheader so ADMIN_TOKEN is used for push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,6 +264,7 @@ jobs:
           if [ "$CURRENT" != "$VERSION" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
+            git config --unset-all http.https://github.com/.extraheader || true
             git remote set-url origin "https://x-access-token:${ADMIN_TOKEN}@github.com/${{ github.repository }}.git"
             git fetch origin main
             git checkout main


### PR DESCRIPTION
The checkout action sets an extraheader with GITHUB_TOKEN that overrides URL-embedded credentials. Unsetting it lets the ADMIN_TOKEN PAT authenticate the push.