### PR TITLE
Fix types dropdown: keyboard nav, focus management, and styling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SIGNING_IDENTITY ?= $(shell security find-identity -v -p codesigning 2>/dev/null
 RUST_MARKER := .make/rust.marker
 RUST_LIB := Sources/ClipKittyRust/libpurr.a
 
-.PHONY: all clean rust rust-force generate build sign list-identities run
+.PHONY: all clean rust rust-force generate build sign list-identities run run-appstore
 
 all: rust generate build
 
@@ -77,6 +77,10 @@ run: all
 	@sleep 0.5
 	@echo "Opening $(APP_NAME)..."
 	@open "$(DERIVED_DATA)/Build/Products/$(CONFIGURATION)/$(APP_NAME).app"
+
+# Build and run the sandboxed App Store variant
+run-appstore:
+	@$(MAKE) run CONFIGURATION=AppStore
 
 clean:
 	@rm -rf .make DerivedData

--- a/Tests/UITests/ClipKittyUITests.swift
+++ b/Tests/UITests/ClipKittyUITests.swift
@@ -285,8 +285,8 @@ final class ClipKittyUITests: XCTestCase {
 
         // 3. Verify popover content appears with filter options
         // FilterOptionRow uses Button, so options appear as buttons in the accessibility tree
-        let linksOption = app.buttons["Links Only"]
-        XCTAssertTrue(linksOption.waitForExistence(timeout: 3), "Popover should show 'Links Only' option")
+        let linksOption = app.buttons["Links"]
+        XCTAssertTrue(linksOption.waitForExistence(timeout: 3), "Popover should show 'Links' option")
 
         // Screenshot: dropdown open
         saveScreenshot(name: "filter_open")
@@ -505,13 +505,17 @@ final class ClipKittyUITests: XCTestCase {
         Thread.sleep(forTimeInterval: 0.5)
         saveScreenshot(name: "marketing_2_search")
 
-        // Screenshot 3: Color swatch search showing preview (matches demo items: #7C3AED, #FF5733, etc.)
+        // Screenshot 3: Filter dropdown open with Images highlighted
         searchField.typeKey("a", modifierFlags: .command)
-        searchField.typeText("#")
+        searchField.typeKey(.delete, modifierFlags: [])
+        Thread.sleep(forTimeInterval: 0.3)
+        let filterButton = app.buttons["FilterDropdown"]
+        filterButton.click()
         Thread.sleep(forTimeInterval: 0.5)
-        // Navigate to show selection
+        // Arrow down twice to highlight "Images" (All Types -> Text -> Images)
+        searchField.typeText(XCUIKeyboardKey.downArrow.rawValue)
         searchField.typeText(XCUIKeyboardKey.downArrow.rawValue)
         Thread.sleep(forTimeInterval: 0.3)
-        saveScreenshot(name: "marketing_3_preview")
+        saveScreenshot(name: "marketing_3_filter")
     }
 }


### PR DESCRIPTION
## Summary
- Remove type-to-search from the filter dropdown popover
- Add proper focus management: Tab from search opens dropdown, Tab/Escape returns to search
- Arrow keys navigate options with accent-color highlight matching item list selection
- Enter confirms selection and refocuses search
- Stroke-only capsule button style (lighter than filled background)
- Divider between "All Types" and specific filters, rounder option rows
- Simplified filter labels (removed "Only" suffix)
- Add `make run-appstore` target for sandboxed builds
- Update marketing screenshot 3 to showcase filter dropdown

## Test plan
- [ ] Open search bar, press Tab — dropdown opens with highlight
- [ ] Arrow up/down moves highlight through options
- [ ] Enter applies selection, search refocused
- [ ] Escape closes dropdown, search refocused
- [ ] Tab from dropdown closes it and returns to search
- [ ] Click filter button — same keyboard nav works
- [ ] `make run-appstore` builds and launches sandboxed variant