### PR TITLE
Skip file copies in non-sandboxed build

### DIFF
--- a/Sources/App/ClipboardStore.swift
+++ b/Sources/App/ClipboardStore.swift
@@ -394,7 +394,6 @@ final class ClipboardStore {
         if let fileURLs = pasteboard.readObjects(forClasses: [NSURL.self], options: [
             .urlReadingFileURLsOnly: true
         ]) as? [URL], !fileURLs.isEmpty {
-            saveFileItems(urls: fileURLs)
             return
         }
         #endif


### PR DESCRIPTION
## Summary
- File copies (e.g. from Finder) were captured as "file" clipboard entries in the non-sandboxed build, but pasting them back only placed the filename as text — not an actual file copy
- Now file clipboard content is detected and silently skipped, avoiding confusing entries in the history
- Existing file entries in the database and all related infrastructure remain intact

## Test plan
- [ ] Build the non-sandboxed target
- [ ] Copy a file in Finder — it should **not** appear in ClipKitty's history
- [ ] Copy text — should still be captured normally