### PR TITLE
Fix UI test tantivy index cleanup version

### DIFF
--- a/Tests/UITests/ClipKittyUITests.swift
+++ b/Tests/UITests/ClipKittyUITests.swift
@@ -98,7 +98,7 @@ final class ClipKittyUITests: XCTestCase {
             .deletingLastPathComponent()
         let sqliteSourceURL = projectRoot.appendingPathComponent("distribution/SyntheticData.sqlite")
         let targetURL = appSupportDir.appendingPathComponent("clipboard-screenshot.sqlite")
-        let indexDirURL = appSupportDir.appendingPathComponent("tantivy_index_v2")
+        let indexDirURL = appSupportDir.appendingPathComponent("tantivy_index_v3")
 
         try? FileManager.default.createDirectory(at: appSupportDir, withIntermediateDirectories: true)
 


### PR DESCRIPTION
## Summary
- UI test setup was cleaning up `tantivy_index_v2` but the Rust store now creates `tantivy_index_v3`
- Stale v3 index data from previous runs wasn't removed, causing database initialization failures ("db fault" warning in the app during tests)
- Updated `setupTestDatabase()` to clean up `tantivy_index_v3`

## Test plan
- [x] `testFirstItemSelectedOnOpen` passes
- [x] `testSelectionResetsWhenItemPositionChanges` passes
- [x] `testFilterDropdownVisible` passes