### PR TITLE
Add 1s wait before screenshots to allow items to load

### DIFF
--- a/Tests/UITests/ClipKittyUITests.swift
+++ b/Tests/UITests/ClipKittyUITests.swift
@@ -375,6 +375,9 @@ final class ClipKittyUITests: XCTestCase {
             return
         }
 
+        // Allow items to fully load before capturing
+        Thread.sleep(forTimeInterval: 1.0)
+
         let frame = window.frame
         let screenShot = XCUIScreen.main.screenshot()
         let image = screenShot.image


### PR DESCRIPTION
## Summary
- Adds a 1-second sleep inside `saveScreenshot()` before capturing, ensuring list items are fully rendered
- Prevents empty or partially-loaded screenshots in CI

## Test plan
- [ ] Run `make marketing-screenshots` and verify all 3 screenshots show fully loaded content