### PR TITLE
Remove scrollbar config from appstore job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,12 +300,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure macOS scrollbar behavior
-        run: |
-          defaults write -g AppleShowScrollBars -string WhenScrolling
-          killall cfprefsd || true
-          defaults read -g AppleShowScrollBars
-
       - name: Decrypt secrets
         id: secrets
         run: |


### PR DESCRIPTION
The appstore job doesn't take screenshots. The defaults read was crashing on macOS 26 runners.