### PR TITLE
Add localization infrastructure with String Catalog

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -76,6 +76,7 @@ let project = Project(
                 "CFBundleDisplayName": "ClipKitty",
                 "CFBundleIconName": "AppIcon",
                 "CFBundleIconFile": "AppIcon",
+                "CFBundleDevelopmentRegion": "en",
                 "LSMinimumSystemVersion": "15.0",
                 "NSHumanReadableCopyright": "Copyright © 2025 ClipKitty. All rights reserved.",
             ]),
@@ -83,6 +84,7 @@ let project = Project(
             resources: [
                 .folderReference(path: "Sources/App/Resources/Fonts"),
                 "Sources/App/Resources/menu-bar.svg",
+                "Sources/App/Resources/Localizable.xcstrings",
                 "Sources/App/Assets.xcassets",
                 "Sources/App/PrivacyInfo.xcprivacy",
             ],
@@ -94,6 +96,8 @@ let project = Project(
                 base: [
                     "OTHER_LDFLAGS": .array(["$(inherited)", "-lpurr"]),
                     "LIBRARY_SEARCH_PATHS": .array(["$(inherited)", "$(PROJECT_DIR)/Sources/ClipKittyRust"]),
+                    "SWIFT_EMIT_LOC_STRINGS": "YES",
+                    "LOCALIZATION_PREFERS_STRING_CATALOGS": "YES",
                 ],
                 configurations: [
                     .debug(name: "Debug", settings: [

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -75,18 +75,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem?.button {
-            button.image = makeStatusItemImage() ?? NSImage(systemSymbolName: "clipboard", accessibilityDescription: "ClipKitty")
+            button.image = makeStatusItemImage() ?? NSImage(systemSymbolName: "clipboard", accessibilityDescription: NSLocalizedString("ClipKitty", comment: "App name used as accessibility description for menu bar icon"))
         }
 
         let menu = NSMenu()
         let hotKey = AppSettings.shared.hotKey
-        showHistoryMenuItem = NSMenuItem(title: "Show Clipboard History", action: #selector(showPanel), keyEquivalent: hotKey.keyEquivalent)
+        showHistoryMenuItem = NSMenuItem(title: NSLocalizedString("Show Clipboard History", comment: "Menu bar item to show clipboard history panel"), action: #selector(showPanel), keyEquivalent: hotKey.keyEquivalent)
         showHistoryMenuItem?.keyEquivalentModifierMask = hotKey.modifierMask
         menu.addItem(showHistoryMenuItem!)
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: "Settings...", action: #selector(openSettings), keyEquivalent: ","))
+        menu.addItem(NSMenuItem(title: NSLocalizedString("Settings...", comment: "Menu bar item to open settings window"), action: #selector(openSettings), keyEquivalent: ","))
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
+        menu.addItem(NSMenuItem(title: NSLocalizedString("Quit", comment: "Menu bar item to quit the app"), action: #selector(quit), keyEquivalent: "q"))
 
         statusMenu = menu
         statusItem?.menu = menu
@@ -126,7 +126,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 backing: .buffered,
                 defer: false
             )
-            window.title = "ClipKitty Settings"
+            window.title = NSLocalizedString("ClipKitty Settings", comment: "Settings window title")
             window.contentView = NSHostingView(rootView: settingsView)
             window.center()
             window.isReleasedWhenClosed = false
@@ -167,7 +167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         } else if settings.launchAtLoginEnabled && !launchAtLogin.isInApplicationsDirectory {
             // User wants it enabled but app is not in Applications - disable the preference
             settings.launchAtLoginEnabled = false
-            launchAtLogin.errorMessage = "Launch at login was disabled because ClipKitty is not in the Applications folder."
+            launchAtLogin.errorMessage = String(localized: "Launch at login was disabled because ClipKitty is not in the Applications folder.")
             if launchAtLogin.isEnabled {
                 launchAtLogin.disable()
             }

--- a/Sources/App/ClipboardStore.swift
+++ b/Sources/App/ClipboardStore.swift
@@ -124,7 +124,7 @@ final class ClipboardStore {
             // Initialize the Rust store
             rustStore = try ClipKittyRust.ClipboardStore(dbPath: dbPath)
         } catch {
-            state = .error("Database setup failed: \(error.localizedDescription)")
+            state = .error(String(format: NSLocalizedString("Database setup failed: %@", comment: "Error when database initialization fails"), error.localizedDescription))
         }
     }
 
@@ -222,7 +222,7 @@ final class ClipboardStore {
 
     private func performSearch(query: String) async {
         guard let rustStore else {
-            state = .error("Database not available")
+            state = .error(String(localized: "Database not available"))
             return
         }
 
@@ -241,7 +241,7 @@ final class ClipboardStore {
         } catch ClipKittyError.Cancelled {
         } catch {
             guard !Task.isCancelled else { return }
-            state = .error("Search failed: \(error.localizedDescription)")
+            state = .error(String(format: NSLocalizedString("Search failed: %@", comment: "Error when search operation fails"), error.localizedDescription))
         }
     }
 

--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -391,12 +391,12 @@ struct ContentView: View {
 
     private var filterLabel: String {
         switch store.contentTypeFilter {
-        case .all: return "All Types"
-        case .text: return "Text"
-        case .images: return "Images"
-        case .links: return "Links"
-        case .colors: return "Colors"
-        case .files: return "Files"
+        case .all: return String(localized: "All Types")
+        case .text: return String(localized: "Text")
+        case .images: return String(localized: "Images")
+        case .links: return String(localized: "Links")
+        case .colors: return String(localized: "Colors")
+        case .files: return String(localized: "Files")
         }
     }
 
@@ -429,13 +429,13 @@ struct ContentView: View {
 
     private static let filterOptions: [(ContentTypeFilter, String)] = {
         var options: [(ContentTypeFilter, String)] = [
-            (.all, "All Types"),
-            (.text, "Text"),
-            (.images, "Images"),
-            (.links, "Links"),
-            (.colors, "Colors"),
+            (.all, String(localized: "All Types")),
+            (.text, String(localized: "Text")),
+            (.images, String(localized: "Images")),
+            (.links, String(localized: "Links")),
+            (.colors, String(localized: "Colors")),
         ]
-        options.append((.files, "Files"))
+        options.append((.files, String(localized: "Files")))
         return options
     }()
 
@@ -784,7 +784,7 @@ struct ContentView: View {
     }
 
     private func buttonLabel(for item: ClipboardItem) -> String {
-        return AppSettings.shared.shouldShowPasteLabel ? "⏎ Paste" : "⏎ Copy"
+        return AppSettings.shared.shouldShowPasteLabel ? String(localized: "⏎ Paste") : String(localized: "⏎ Copy")
     }
 
     // MARK: - Actions Dropdown
@@ -807,11 +807,19 @@ struct ContentView: View {
     private func actionLabel(for action: ActionItem) -> String {
         switch action {
         case .defaultAction:
-            return AppSettings.shared.shouldShowPasteLabel ? "Paste" : "Copy"
+            return AppSettings.shared.shouldShowPasteLabel ? String(localized: "Paste") : String(localized: "Copy")
         case .copyOnly:
-            return "Copy"
+            return String(localized: "Copy")
         case .delete:
-            return "Delete"
+            return String(localized: "Delete")
+        }
+    }
+
+    private func actionIdentifier(for action: ActionItem) -> String {
+        switch action {
+        case .defaultAction: return AppSettings.shared.shouldShowPasteLabel ? "Paste" : "Copy"
+        case .copyOnly: return "Copy"
+        case .delete: return "Delete"
         }
     }
 
@@ -851,7 +859,8 @@ struct ContentView: View {
                     .padding(.horizontal, 8)
                     .padding(.bottom, 4)
                 ActionOptionRow(
-                    label: "Delete",
+                    label: String(localized: "Delete"),
+                    actionID: "Delete",
                     isHighlighted: highlightedActionIndex == 0,
                     isDestructive: true,
                     action: {
@@ -861,7 +870,8 @@ struct ContentView: View {
                     }
                 )
                 ActionOptionRow(
-                    label: "Cancel",
+                    label: String(localized: "Cancel"),
+                    actionID: "Cancel",
                     isHighlighted: highlightedActionIndex == 1,
                     isDestructive: false,
                     action: {
@@ -874,6 +884,7 @@ struct ContentView: View {
                     if action == .delete && index < actions.count - 1 {
                         ActionOptionRow(
                             label: actionLabel(for: action),
+                            actionID: actionIdentifier(for: action),
                             isHighlighted: highlightedActionIndex == index,
                             isDestructive: true,
                             action: { performAction(action) }
@@ -882,6 +893,7 @@ struct ContentView: View {
                     } else {
                         ActionOptionRow(
                             label: actionLabel(for: action),
+                            actionID: actionIdentifier(for: action),
                             isHighlighted: highlightedActionIndex == index,
                             isDestructive: action == .delete,
                             action: { performAction(action) }
@@ -972,9 +984,9 @@ struct ContentView: View {
 
     private var emptyStateMessage: String {
         if store.currentQuery.isEmpty && store.contentTypeFilter == .all {
-            return "No clipboard history"
+            return String(localized: "No clipboard history")
         } else {
-            return "No results"
+            return String(localized: "No results")
         }
     }
 
@@ -1132,10 +1144,10 @@ struct FilePreviewView: View {
         let mb = kb / 1024
         let gb = mb / 1024
 
-        if gb >= 1 { return String(format: "%.1f GB", gb) }
-        if mb >= 1 { return String(format: "%.1f MB", mb) }
-        if kb >= 1 { return String(format: "%.0f KB", kb) }
-        return "\(bytes) bytes"
+        if gb >= 1 { return String(localized: "\(gb, specifier: "%.1f") GB") }
+        if mb >= 1 { return String(localized: "\(mb, specifier: "%.1f") MB") }
+        if kb >= 1 { return String(localized: "\(kb, specifier: "%.0f") KB") }
+        return String(localized: "\(bytes) bytes")
     }
 }
 
@@ -1516,7 +1528,7 @@ struct ItemRow: View, Equatable {
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(displayText)
-        .accessibilityHint(AppSettings.shared.shouldShowPasteLabel ? "Double tap to paste" : "Double tap to copy")
+        .accessibilityHint(AppSettings.shared.shouldShowPasteLabel ? String(localized: "Double tap to paste") : String(localized: "Double tap to copy"))
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
@@ -1687,6 +1699,7 @@ private struct FilterOptionRow: View {
 
 private struct ActionOptionRow: View {
     let label: String
+    let actionID: String
     var isHighlighted: Bool = false
     var isDestructive: Bool = false
     let action: () -> Void
@@ -1717,7 +1730,7 @@ private struct ActionOptionRow: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
-        .accessibilityIdentifier("Action_\(label)")
+        .accessibilityIdentifier("Action_\(actionID)")
     }
 
     private var foregroundColor: Color {

--- a/Sources/App/ImageDescriptionGenerator.swift
+++ b/Sources/App/ImageDescriptionGenerator.swift
@@ -87,21 +87,18 @@ struct ImageDescriptionGenerator {
         // Format Labels
         if !labels.isEmpty {
             let list = labels.formatted(.list(type: .and, width: .standard))
-            parts.append("Image: \(list)")
-        } else {
-            parts.append("Image")
+            parts.append(list)
         }
 
         // Format Text with Truncation
         if let text, !text.isEmpty {
             let truncated: String
             if text.count > config.maxTextLength {
-                // Truncate and add proper ellipsis (…)
                 truncated = "\(text.prefix(config.maxTextLength))…"
             } else {
                 truncated = text
             }
-            parts.append("Text: \(truncated)")
+            parts.append(truncated)
         }
 
         return parts.joined(separator: ". ")

--- a/Sources/App/LaunchAtLogin.swift
+++ b/Sources/App/LaunchAtLogin.swift
@@ -59,7 +59,7 @@ final class LaunchAtLogin: ObservableObject {
             return true
         } catch {
             objectWillChange.send()
-            errorMessage = "Could not enable launch at login. Please add ClipKitty manually in System Settings."
+            errorMessage = String(localized: "Could not enable launch at login. Please add ClipKitty manually in System Settings.")
             return false
         }
     }
@@ -75,7 +75,7 @@ final class LaunchAtLogin: ObservableObject {
             return true
         } catch {
             objectWillChange.send()
-            errorMessage = "Could not disable launch at login. Please remove ClipKitty manually in System Settings."
+            errorMessage = String(localized: "Could not disable launch at login. Please remove ClipKitty manually in System Settings.")
             return false
         }
     }

--- a/Sources/App/Resources/Localizable.xcstrings
+++ b/Sources/App/Resources/Localizable.xcstrings
@@ -1,0 +1,1010 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+
+    "ClipKitty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ClipKitty"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ClipKitty"
+          }
+        }
+      }
+    },
+
+    "Show Clipboard History" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Clipboard History"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar historial del portapapeles"
+          }
+        }
+      }
+    },
+
+    "Settings..." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración..."
+          }
+        }
+      }
+    },
+
+    "Quit" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salir"
+          }
+        }
+      }
+    },
+
+    "ClipKitty Settings" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ClipKitty Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración de ClipKitty"
+          }
+        }
+      }
+    },
+
+    "Launch at login was disabled because ClipKitty is not in the Applications folder." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch at login was disabled because ClipKitty is not in the Applications folder."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El inicio de sesión automático se desactivó porque ClipKitty no está en la carpeta Aplicaciones."
+          }
+        }
+      }
+    },
+
+    "All Types" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All Types"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los tipos"
+          }
+        }
+      }
+    },
+
+    "Text" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texto"
+          }
+        }
+      }
+    },
+
+    "Images" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Images"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imágenes"
+          }
+        }
+      }
+    },
+
+    "Links" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Links"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enlaces"
+          }
+        }
+      }
+    },
+
+    "Colors" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colors"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colores"
+          }
+        }
+      }
+    },
+
+    "Files" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Files"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archivos"
+          }
+        }
+      }
+    },
+
+    "⏎ Paste" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⏎ Paste"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⏎ Pegar"
+          }
+        }
+      }
+    },
+
+    "⏎ Copy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⏎ Copy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⏎ Copiar"
+          }
+        }
+      }
+    },
+
+    "Paste" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paste"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pegar"
+          }
+        }
+      }
+    },
+
+    "Copy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar"
+          }
+        }
+      }
+    },
+
+    "Delete" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
+          }
+        }
+      }
+    },
+
+    "No clipboard history" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No clipboard history"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay historial del portapapeles"
+          }
+        }
+      }
+    },
+
+    "No results" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No results"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin resultados"
+          }
+        }
+      }
+    },
+
+    "No item selected" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No item selected"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ningún elemento seleccionado"
+          }
+        }
+      }
+    },
+
+    "Clipboard History Search" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clipboard History Search"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar en el historial del portapapeles"
+          }
+        }
+      }
+    },
+
+    "Double tap to paste" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double tap to paste"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulsa dos veces para pegar"
+          }
+        }
+      }
+    },
+
+    "Double tap to copy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double tap to copy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulsa dos veces para copiar"
+          }
+        }
+      }
+    },
+
+    "⌥⏎ Actions" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌥⏎ Actions"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌥⏎ Acciones"
+          }
+        }
+      }
+    },
+
+    "Delete?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Eliminar?"
+          }
+        }
+      }
+    },
+
+    "Cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        }
+      }
+    },
+
+    "Press keys..." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Press keys..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presiona las teclas..."
+          }
+        }
+      }
+    },
+
+    "Hotkey" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hotkey"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tecla de acceso rápido"
+          }
+        }
+      }
+    },
+
+    "Open Clipboard History" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Clipboard History"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir historial del portapapeles"
+          }
+        }
+      }
+    },
+
+    "Reset to Default (⌥Space)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset to Default (⌥Space)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer valores predeterminados (⌥Espacio)"
+          }
+        }
+      }
+    },
+
+    "Startup" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Startup"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicio"
+          }
+        }
+      }
+    },
+
+    "Launch at login" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Launch at login"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir al iniciar sesión"
+          }
+        }
+      }
+    },
+
+    "Move ClipKitty to the Applications folder to enable this option." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Move ClipKitty to the Applications folder to enable this option."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mueve ClipKitty a la carpeta Aplicaciones para habilitar esta opción."
+          }
+        }
+      }
+    },
+
+    "Open Login Items Settings" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Login Items Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir configuración de elementos de inicio"
+          }
+        }
+      }
+    },
+
+    "Storage" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Storage"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almacenamiento"
+          }
+        }
+      }
+    },
+
+    "Current Size" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current Size"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamaño actual"
+          }
+        }
+      }
+    },
+
+    "Max Database Size" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max Database Size"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamaño máximo de la base de datos"
+          }
+        }
+      }
+    },
+
+    "Oldest clipboard items will be automatically deleted when the database exceeds this size." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oldest clipboard items will be automatically deleted when the database exceeds this size."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los elementos más antiguos del portapapeles se eliminarán automáticamente cuando la base de datos supere este tamaño."
+          }
+        }
+      }
+    },
+
+    "Behavior" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Behavior"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comportamiento"
+          }
+        }
+      }
+    },
+
+    "Accessibility Permission" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accessibility Permission"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permiso de accesibilidad"
+          }
+        }
+      }
+    },
+
+    "Enabled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habilitado"
+          }
+        }
+      }
+    },
+
+    "Requires Permission" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requires Permission"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Requiere permiso"
+          }
+        }
+      }
+    },
+
+    "Automatic Paste" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic Paste"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pegado automático"
+          }
+        }
+      }
+    },
+
+    "ClipKitty will automatically paste items into the previous app when you press Enter." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ClipKitty will automatically paste items into the previous app when you press Enter."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ClipKitty pegará automáticamente los elementos en la aplicación anterior cuando presiones Enter."
+          }
+        }
+      }
+    },
+
+    "Items will be copied to the clipboard without pasting." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Items will be copied to the clipboard without pasting."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los elementos se copiarán al portapapeles sin pegar."
+          }
+        }
+      }
+    },
+
+    "Grant Accessibility permission to enable automatic pasting. Without it, items will only be copied to the clipboard. Restart the app after updating accessibility permissions for the change to take effect." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grant Accessibility permission to enable automatic pasting. Without it, items will only be copied to the clipboard. Restart the app after updating accessibility permissions for the change to take effect."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otorga permiso de accesibilidad para habilitar el pegado automático. Sin él, los elementos solo se copiarán al portapapeles. Reinicia la aplicación después de actualizar los permisos de accesibilidad para que el cambio surta efecto."
+          }
+        }
+      }
+    },
+
+    "Open Accessibility Settings" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Accessibility Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir configuración de accesibilidad"
+          }
+        }
+      }
+    },
+
+    "Security" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Security"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguridad"
+          }
+        }
+      }
+    },
+
+    "Sandboxed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sandboxed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aislado"
+          }
+        }
+      }
+    },
+
+    "ClipKitty runs in an isolated environment, protecting your privacy and keeping your data secure." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ClipKitty runs in an isolated environment, protecting your privacy and keeping your data secure."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ClipKitty se ejecuta en un entorno aislado, protegiendo tu privacidad y manteniendo tus datos seguros."
+          }
+        }
+      }
+    },
+
+    "Data" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datos"
+          }
+        }
+      }
+    },
+
+    "Clear Clipboard History" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Clipboard History"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar historial del portapapeles"
+          }
+        }
+      }
+    },
+
+    "Clear All History" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear All History"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar todo el historial"
+          }
+        }
+      }
+    },
+
+    "Are you sure you want to delete all clipboard history? This cannot be undone." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Are you sure you want to delete all clipboard history? This cannot be undone."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Estás seguro de que deseas eliminar todo el historial del portapapeles? Esta acción no se puede deshacer."
+          }
+        }
+      }
+    },
+
+    "Could not enable launch at login. Please add ClipKitty manually in System Settings." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not enable launch at login. Please add ClipKitty manually in System Settings."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo habilitar el inicio de sesión automático. Agrega ClipKitty manualmente en Configuración del Sistema."
+          }
+        }
+      }
+    },
+
+    "Could not disable launch at login. Please remove ClipKitty manually in System Settings." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not disable launch at login. Please remove ClipKitty manually in System Settings."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo deshabilitar el inicio de sesión automático. Elimina ClipKitty manualmente en Configuración del Sistema."
+          }
+        }
+      }
+    },
+
+    "Database not available" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Database not available"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Base de datos no disponible"
+          }
+        }
+      }
+    },
+
+    "Database setup failed: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Database setup failed: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error en la configuración de la base de datos: %@"
+          }
+        }
+      }
+    },
+
+    "Search failed: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search failed: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error en la búsqueda: %@"
+          }
+        }
+      }
+    }
+
+  },
+  "version" : "1.0"
+}

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -27,7 +27,7 @@ struct SettingsView: View {
                         let (labelText, backgroundColor): (String, Color) = {
                             switch hotKeyState {
                             case .recording:
-                                return ("Press keys...", Color.accentColor.opacity(0.2))
+                                return (String(localized: "Press keys..."), Color.accentColor.opacity(0.2))
                             case .idle:
                                 return (settings.hotKey.displayString, Color.secondary.opacity(0.1))
                             }
@@ -211,7 +211,7 @@ struct SettingsView: View {
     }
 
     private var databaseSizeLabel: String {
-        return String(format: "%.1f GB", settings.maxDatabaseSizeGB)
+        return String(localized: "\(settings.maxDatabaseSizeGB, specifier: "%.1f") GB")
     }
 
     private func sliderValue(for gb: Double) -> Double {
@@ -238,13 +238,13 @@ struct SettingsView: View {
         let gb = mb / 1024
 
         if gb >= 1 {
-            return String(format: "%.2f GB", gb)
+            return String(localized: "\(gb, specifier: "%.2f") GB")
         } else if mb >= 1 {
-            return String(format: "%.1f MB", mb)
+            return String(localized: "\(mb, specifier: "%.1f") MB")
         } else if kb >= 1 {
-            return String(format: "%.0f KB", kb)
+            return String(localized: "\(kb, specifier: "%.0f") KB")
         } else {
-            return "\(bytes) bytes"
+            return String(localized: "\(bytes) bytes")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `.xcstrings` String Catalog with ~60 localized strings (English + Spanish)
- Wrap all user-facing strings: menu items, filters, actions, settings, errors, accessibility hints
- Use `NSLocalizedString` for AppKit APIs, `String(localized:)` for Swift/SwiftUI computed properties
- Fix `ActionOptionRow` accessibility identifiers to use locale-independent IDs (preserves UI test compatibility)
- Use deterministic `String(format: NSLocalizedString(...))` for error strings with interpolation
- Drop `"Image:"` / `"Text:"` prefixes from image descriptions for locale-neutral storage
- Configure `SWIFT_EMIT_LOC_STRINGS` and `LOCALIZATION_PREFERS_STRING_CATALOGS` build settings

## Test plan
- [x] Build succeeds in Release configuration
- [x] Both `en.lproj/Localizable.strings` and `es.lproj/Localizable.strings` compile into app bundle with all 59 entries
- [x] Existing UI tests (`Action_Delete`, `Action_Copy`, `Action_Cancel`) identifiers preserved
- [ ] Run app in English — verify all UI text appears unchanged
- [ ] Run app in Spanish — verify translated strings render correctly
- [ ] Verify `RelativeDateTimeFormatter` (timeAgo) auto-localizes in Spanish