### PR TITLE
Add unified appstore-publish make target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,12 +371,8 @@ jobs:
           brew install --formula tuist
           tuist version
 
-      - name: Decode Provisioning Profile
-        run: |
-          echo "$PROVISION_PROFILE_BASE64" | base64 --decode \
-            > "$GITHUB_WORKSPACE/ClipKitty.provisionprofile"
-        env:
-          PROVISION_PROFILE_BASE64: ${{ steps.secrets.outputs.PROVISION_PROFILE_BASE64 }}
+      - name: Install Distribution Dependencies
+        run: ./distribution/install-deps.sh
 
       - name: Download marketing screenshots
         uses: actions/download-artifact@v4
@@ -384,20 +380,11 @@ jobs:
           name: assets
           path: .
 
-      - name: Build App Store Package
+      - name: Build and Publish to App Store Connect
         run: |
-          VERSION="${{ needs.build.outputs.version }}"
-          BUILD_NUMBER="$(git rev-list --count HEAD)"
-          make -C distribution appstore \
-            PROVISIONING_PROFILE="$GITHUB_WORKSPACE/ClipKitty.provisionprofile" \
-            VERSION="$VERSION" \
-            BUILD_NUMBER="$BUILD_NUMBER"
-
-      - name: Install ASC CLI
-        run: brew tap rudrankriyam/tap && brew install rudrankriyam/tap/asc
-
-      - name: Publish to App Store Connect
-        run: make -C distribution publish
+          make -C distribution appstore-publish \
+            VERSION="${{ needs.build.outputs.version }}" \
+            BUILD_NUMBER="$(git rev-list --count HEAD)"
         env:
           AGE_SECRET_KEY: ${{ secrets.AGE_SECRET_KEY }}
 

--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -29,7 +29,7 @@ PROVISIONING_PROFILE ?=
 # All supported screenshot locales (App Store top 10)
 SCREENSHOT_LOCALES := en es zh-Hans zh-Hant ja ko fr de pt-BR ru
 
-.PHONY: dmg appstore publish icon-png \
+.PHONY: dmg appstore appstore-publish publish icon-png \
         synthetic-data run-synthetic marketing marketing-screenshots \
         marketing-screenshots-capture marketing-screenshots-localized \
         preview-video
@@ -101,6 +101,45 @@ PUBLISH_FLAGS ?=
 
 publish:
 	@$(DIST_DIR)/publish.py $(PUBLISH_FLAGS)
+
+# ============================================================================
+# Combined: Build + Publish to App Store Connect
+# ============================================================================
+# Usage (local):
+#   AGE_SECRET_KEY=... make -C distribution appstore-publish VERSION=1.2.3
+#
+# Usage (with explicit provisioning profile):
+#   AGE_SECRET_KEY=... make -C distribution appstore-publish \
+#     PROVISIONING_PROFILE=path/to/profile VERSION=1.2.3
+#
+# If PROVISIONING_PROFILE is not set but AGE_SECRET_KEY is available,
+# the provisioning profile is auto-decrypted from secrets/.
+# ============================================================================
+
+appstore-publish:
+	@if [ -z "$$AGE_SECRET_KEY" ]; then \
+		AGE_SECRET_KEY=$$(security find-generic-password -s clipkitty -a AGE_SECRET_KEY -w 2>/dev/null) || true; \
+	fi; \
+	export AGE_SECRET_KEY; \
+	$(DIST_DIR)/setup-signing.sh; \
+	PROV="$(PROVISIONING_PROFILE)"; \
+	if [ -z "$$PROV" ] && [ -n "$$AGE_SECRET_KEY" ]; then \
+		echo "Decrypting provisioning profile from secrets..."; \
+		printf '%s' "$$AGE_SECRET_KEY" > /tmp/_ck_age.txt; \
+		age -d -i /tmp/_ck_age.txt "$(PROJECT_ROOT)/secrets/PROVISION_PROFILE_BASE64.age" \
+			| base64 --decode > "$(PROJECT_ROOT)/ClipKitty.provisionprofile"; \
+		rm -f /tmp/_ck_age.txt; \
+		PROV="$(PROJECT_ROOT)/ClipKitty.provisionprofile"; \
+	fi; \
+	AGE_SECRET_KEY_SAVE=$$AGE_SECRET_KEY; unset AGE_SECRET_KEY; \
+	$(MAKE) appstore \
+		$${PROV:+PROVISIONING_PROFILE=$$PROV} \
+		$(if $(VERSION),VERSION=$(VERSION),) \
+		$(if $(BUILD_NUMBER),BUILD_NUMBER=$(BUILD_NUMBER),) && \
+	AGE_SECRET_KEY=$$AGE_SECRET_KEY_SAVE $(MAKE) publish $(if $(PUBLISH_FLAGS),PUBLISH_FLAGS=$(PUBLISH_FLAGS),); \
+	STATUS=$$?; \
+	$(DIST_DIR)/setup-signing.sh --cleanup; \
+	exit $$STATUS
 
 # ============================================================================
 # Marketing Assets (Screenshots & Preview Video)

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -5,6 +5,7 @@
 set -e
 
 DEPS=(
+    age           # For decrypting secrets (provisioning profile, API keys)
     create-dmg    # For building DMG installers
     ffmpeg        # For video recording and processing
     cliclick      # For UI automation in preview video recording

--- a/distribution/setup-signing.sh
+++ b/distribution/setup-signing.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Sets up App Store signing certificates in a temporary keychain.
+# This avoids interactive keychain password prompts for codesign/productbuild.
+#
+# Usage:
+#   ./distribution/setup-signing.sh           # Create keychain & import certs
+#   ./distribution/setup-signing.sh --cleanup  # Remove temporary keychain
+#
+# Requires AGE_SECRET_KEY environment variable (or reads from macOS Keychain).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+KEYCHAIN_NAME="clipkitty_signing.keychain-db"
+KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME"
+
+if [ "$1" = "--cleanup" ]; then
+    security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+    exit 0
+fi
+
+# Check if signing identities are already usable (CI case)
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "3rd Party Mac Developer Application" && \
+   security find-identity -v 2>/dev/null | grep -q "3rd Party Mac Developer Installer"; then
+    # Test that productbuild can actually access the key (non-interactive)
+    # by checking if the keychain is a temp one (not login)
+    if security list-keychains -d user 2>/dev/null | grep -q "signing_temp\|clipkitty_signing"; then
+        echo "Signing certificates already available"
+        exit 0
+    fi
+fi
+
+# Resolve AGE_SECRET_KEY
+if [ -z "$AGE_SECRET_KEY" ]; then
+    AGE_SECRET_KEY=$(security find-generic-password -s clipkitty -a AGE_SECRET_KEY -w 2>/dev/null) || true
+fi
+if [ -z "$AGE_SECRET_KEY" ]; then
+    echo "Error: AGE_SECRET_KEY not set and not found in Keychain" >&2
+    exit 1
+fi
+
+# Decrypt secrets
+printf '%s' "$AGE_SECRET_KEY" > /tmp/_ck_age.txt
+P12_PASS=$(age -d -i /tmp/_ck_age.txt "$PROJECT_ROOT/secrets/P12_PASSWORD.age")
+age -d -i /tmp/_ck_age.txt "$PROJECT_ROOT/secrets/APPSTORE_APP_CERT_BASE64.age" \
+    | base64 --decode > /tmp/_ck_app.p12
+age -d -i /tmp/_ck_age.txt "$PROJECT_ROOT/secrets/APPSTORE_CERT_BASE64.age" \
+    | base64 --decode > /tmp/_ck_inst.p12
+rm -f /tmp/_ck_age.txt
+
+# Create temporary keychain with known password
+KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
+security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security set-keychain-settings -t 3600 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+# Import certificates
+security import /tmp/_ck_app.p12 -k "$KEYCHAIN_PATH" -P "$P12_PASS" \
+    -T /usr/bin/codesign -T /usr/bin/productbuild
+security import /tmp/_ck_inst.p12 -k "$KEYCHAIN_PATH" -P "$P12_PASS" \
+    -T /usr/bin/codesign -T /usr/bin/productbuild
+rm -f /tmp/_ck_app.p12 /tmp/_ck_inst.p12
+
+# Remove duplicate Application cert (installer P12 bundles an extra one)
+HASHES=$(security find-certificate -a -c "3rd Party Mac Developer Application" -Z \
+    "$KEYCHAIN_PATH" 2>/dev/null | grep "SHA-1" | awk '{print $NF}')
+FIRST=$(echo "$HASHES" | head -1)
+echo "$HASHES" | tail -n +2 | while read -r HASH; do
+    security delete-certificate -Z "$HASH" "$KEYCHAIN_PATH" 2>/dev/null || true
+done
+
+# Allow codesign/productbuild to access keys without prompt
+security set-key-partition-list \
+    -S apple-tool:,apple:,codesign:,productbuild: \
+    -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+# Add to keychain search list (prepend so our certs are found first)
+EXISTING=$(security list-keychains -d user | tr -d '" ' | tr '\n' ' ')
+security list-keychains -d user -s "$KEYCHAIN_PATH" $EXISTING
+
+echo "Signing keychain ready: $KEYCHAIN_NAME"


### PR DESCRIPTION
## Summary
- Adds a single `make appstore-publish` target that orchestrates signing setup, provisioning profile decryption, App Store build, and publishing
- Adds `setup-signing.sh` to import signing certificates into a temporary keychain (works locally via macOS Keychain and in CI via `AGE_SECRET_KEY`)
- Adds `age` to `install-deps.sh` for secret decryption
- Simplifies the CI workflow from multiple steps to one `make appstore-publish` invocation

## Test plan
- [ ] Run `AGE_SECRET_KEY=... make -C distribution appstore-publish VERSION=x.y.z` locally
- [ ] Verify CI publish job succeeds with the simplified workflow