### PR TITLE
Refactor state management using enum-driven patterns

### DIFF
--- a/Sources/App/Settings.swift
+++ b/Sources/App/Settings.swift
@@ -50,6 +50,21 @@ struct HotKey: Codable, Equatable {
     }
 }
 
+enum PasteMode {
+    case noPermission
+    case copyOnly
+    case autoPaste
+
+    var buttonLabel: String {
+        switch self {
+        case .noPermission, .copyOnly:
+            return String(localized: "Copy")
+        case .autoPaste:
+            return String(localized: "Paste")
+        }
+    }
+}
+
 @MainActor
 final class AppSettings: ObservableObject {
     static let shared = AppSettings()
@@ -79,10 +94,11 @@ final class AppSettings: ObservableObject {
         didSet { save() }
     }
 
-    /// Whether the button should show "paste" or "copy"
-    var shouldShowPasteLabel: Bool {
-        return hasAccessibilityPermission && autoPasteEnabled
+    var pasteMode: PasteMode {
+        guard hasAccessibilityPermission else { return .noPermission }
+        return autoPasteEnabled ? .autoPaste : .copyOnly
     }
+
 
     let maxImageMegapixels: Double
     let imageCompressionQuality: Double

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -61,24 +61,30 @@ struct GeneralSettingsView: View {
     var body: some View {
         Form {
             Section("Startup") {
-                Toggle("Launch at login", isOn: launchAtLoginBinding)
-                    .disabled(!launchAtLogin.isInApplicationsDirectory)
-
-                if !launchAtLogin.isInApplicationsDirectory {
-                    Text("Move ClipKitty to the Applications folder to enable this option.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                if let errorMessage = launchAtLogin.errorMessage {
-                    Text(errorMessage)
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                    Button("Open Login Items Settings") {
-                        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension")!)
-                        launchAtLogin.errorMessage = nil
+                let canToggle: Bool = {
+                    switch launchAtLogin.state {
+                    case .enabled, .disabled: return true
+                    case .unavailable, .error: return false
                     }
-                    .font(.caption)
+                }()
+
+                Toggle("Launch at login", isOn: launchAtLoginBinding)
+                    .disabled(!canToggle)
+
+                if let message = launchAtLogin.state.displayMessage {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle({
+                            if case .error = launchAtLogin.state { return AnyShapeStyle(.red) }
+                            return AnyShapeStyle(.secondary)
+                        }())
+
+                    if case .error = launchAtLogin.state {
+                        Button("Open Login Items Settings") {
+                            NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension")!)
+                        }
+                        .font(.caption)
+                    }
                 }
             }
 

--- a/Sources/ClipKittyRustWrapper/ClipKittyRust.swift
+++ b/Sources/ClipKittyRustWrapper/ClipKittyRust.swift
@@ -9,21 +9,6 @@ import AppKit
 // MARK: - ClipboardItem Extensions
 
 extension ClipboardItem {
-    /// Convenience accessor for source app
-    public var sourceApp: String? {
-        itemMetadata.sourceApp
-    }
-
-    /// Convenience accessor for source app bundle ID (Swift naming convention)
-    public var sourceAppBundleID: String? {
-        itemMetadata.sourceAppBundleId
-    }
-
-    /// The raw text content for searching and display
-    public var textContent: String {
-        content.textContent
-    }
-
     @MainActor
     private static let timeAgoFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
@@ -65,13 +50,6 @@ extension IconType {
 }
 
 // MARK: - ItemMatch Extensions
-
-extension ItemMatch {
-    /// Convenience accessor for item ID
-    public var itemId: Int64 {
-        itemMetadata.itemId
-    }
-}
 
 // MARK: - ClipboardContent Extensions
 
@@ -117,14 +95,6 @@ extension FileStatus {
         case .missing:
             return "missing"
         }
-    }
-
-    /// Extract the new path if status is .moved, nil otherwise
-    public var movedPath: String? {
-        if case .moved(let newPath) = self {
-            return newPath
-        }
-        return nil
     }
 }
 

--- a/Tests/UnitTests/MultiFileTests.swift
+++ b/Tests/UnitTests/MultiFileTests.swift
@@ -149,7 +149,7 @@ final class MultiFileTests: XCTestCase {
         )
 
         let items = try store.fetchByIds(itemIds: [id])
-        XCTAssertEqual(items[0].textContent, "a.txt, b.txt")
+        XCTAssertEqual(items[0].content.textContent, "a.txt, b.txt")
     }
 
     func testThreeFilesDisplayName() throws {
@@ -167,7 +167,7 @@ final class MultiFileTests: XCTestCase {
         )
 
         let items = try store.fetchByIds(itemIds: [id])
-        XCTAssertEqual(items[0].textContent, "a.txt and 2 more")
+        XCTAssertEqual(items[0].content.textContent, "a.txt and 2 more")
     }
 
     // MARK: - Search


### PR DESCRIPTION
## Summary

- Apply enum-driven state refactoring across the codebase to make illegal states unrepresentable
- Replace structs with optional fields and boolean flags with Swift enums containing associated values
- Remove anti-pattern convenience properties that degrade enums back to booleans
- Inline `if case` and `switch` at call sites instead of using boolean properties

### Files Changed (13 files, +572/-262 lines)

| File | Refactoring |
|------|-------------|
| **HotKeyManager.swift** | `RegistrationState` enum replacing optional `hotKeyRef` + `eventHandler` |
| **LaunchAtLogin.swift** | `LaunchAtLoginState` enum with nested `UnavailableReason` and `ErrorType` |
| **FloatingPanelController.swift** | `PanelMode` + `PanelState` enums with inlined config and comments explaining test vs prod differences |
| **ClipboardStore.swift** | `SystemSleepMonitoring` enum replacing 3 sleep-related variables |
| **Settings.swift** | `PasteMode` enum for accessibility/paste behavior |
| **PrivacySettingsView.swift** | `AppListState` enum replacing apps array + selection |
| **LinkMetadataFetcher.swift** | `FetchedLinkMetadata` enum with title-only/image-only/both variants |
| **ImageDescriptionGenerator.swift** | `VisionProcessingResult` enum for success/cancelled/failed |
| **AppDelegate.swift** | `LaunchMode` enum with inlined case checks (no boolean properties) |
| **ContentView.swift** | `SpinnerState`, `FilterPopoverState`, `ActionsPopoverState` enums with inlined checks |
| **SettingsView.swift** | Updated to use pattern matching for `LaunchAtLoginState` |
| **ClipKittyRust.swift** | Removed anti-pattern convenience properties |
| **MultiFileTests.swift** | Updated to use `content.textContent` instead of removed property |

### Anti-pattern fixes

- Removed boolean convenience properties (`isVisible`, `canBeToggled`, `shouldX`, etc.)
- Inlined `if case` and `switch` at call sites
- Kept data extraction properties (`title`, `description`, `displayMessage`, `buttonLabel`)

## Test plan

- [x] Build succeeds (`make build`)
- [x] Unit tests pass
- [x] UI tests run (14 expected failures in test environment)