### PR TITLE
Add clipboard sync delay for remote desktop apps

### DIFF
--- a/Sources/App/FloatingPanelController.swift
+++ b/Sources/App/FloatingPanelController.swift
@@ -163,11 +163,52 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
         hide()
     }
 
+    // ⚠️ HACK: Remote desktop clipboard sync delay
+    //
+    // This is a UX hack, not a proper fix. RDP and similar protocols use lazy clipboard
+    // sync - when macOS clipboard changes, only a "format list" notification is sent over
+    // the network. The actual data isn't transferred until the remote side requests it.
+    //
+    // Problem: We send Cmd+V immediately after updating the clipboard. The keystroke can
+    // arrive at the remote machine before the format list notification, causing the remote
+    // app to paste stale clipboard content.
+    //
+    // Proper fix: Impossible from our side - would require the RDP client to synchronize
+    // keyboard events with clipboard channel updates.
+    //
+    // This hack: Delay 250ms before sending Cmd+V for known remote desktop apps. This
+    // usually gives enough time for the clipboard notification to propagate. It's a guess
+    // that works for most network conditions but may still fail on very slow connections.
+    //
+    // We do this because it makes the app feel magical for RDP users, even though it's
+    // technically papering over a protocol limitation.
+    private static let remoteDesktopBundleIDs: Set<String> = [
+        "com.microsoft.rdc.macos",        // Microsoft Remote Desktop
+        "com.microsoft.rdc.osx",          // Microsoft Remote Desktop (older)
+        "com.royalapps.royaltsx",         // Royal TSX
+        "net.parallels.desktop.console",  // Parallels Desktop
+        "com.vmware.fusion",              // VMware Fusion
+        "com.citrix.XenAppViewer",        // Citrix Workspace
+        "com.citrix.receiver.icaviewer",  // Citrix Receiver
+        "com.realvnc.vncviewer",          // RealVNC Viewer
+        "com.tigervnc.vncviewer",         // TigerVNC
+        "org.turbovnc.vncviewer",         // TurboVNC
+        "com.thinomenon.remotix",         // Remotix
+        "com.nulana.rxcontrolmac",        // Remote Desktop Manager
+        "com.devolutions.remotedesktopmanager", // Devolutions RDM
+        "com.teamviewer.TeamViewer",      // TeamViewer
+        "us.zoom.xos",                    // Zoom (remote control)
+        "com.anydesk.anydesk",            // AnyDesk
+    ]
+
     /// Simulate Cmd+V keystroke to paste into the target app
     private func simulatePaste(targetApp: NSRunningApplication?) {
         guard let targetApp = targetApp else {
             return
         }
+
+        let needsClipboardSyncDelay = targetApp.bundleIdentifier
+            .map { Self.remoteDesktopBundleIDs.contains($0) } ?? false
 
         // Wait for the target app to become active before sending keystroke
         Task {
@@ -177,6 +218,11 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
                     break
                 }
                 try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+            }
+
+            // Remote desktop apps need extra time for clipboard protocol sync
+            if needsClipboardSyncDelay {
+                try? await Task.sleep(nanoseconds: 250_000_000) // 250ms
             }
 
             await MainActor.run {


### PR DESCRIPTION
## Summary
- Add 250ms delay before auto-paste for remote desktop apps (RDP, VNC, etc.)
- Fixes race condition where Cmd+V arrives before clipboard sync notification

## Context
RDP and similar protocols use lazy clipboard sync. When macOS clipboard changes, only a "format list" notification is sent over the network - actual data isn't transferred until the remote side requests it. Our auto-paste Cmd+V keystroke can arrive before this notification, causing the remote app to paste stale content.

This adds a small delay for known remote desktop apps to let the clipboard notification propagate.

## Test plan
- [ ] Test with Royal TSX or Microsoft Remote Desktop
- [ ] Verify normal (non-RDP) apps still paste instantly

Fixes #133
