### PR TITLE
Rename Shortcuts tab to Advanced and move Direct Paste

### DIFF
--- a/Sources/App/Resources/Localizable.xcstrings
+++ b/Sources/App/Resources/Localizable.xcstrings
@@ -129,66 +129,66 @@
         }
       }
     },
-    "Behavior": {
+    "Advanced": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Behavior"
+            "value": "Advanced"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comportamiento"
+            "value": "Avanzado"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "行为"
+            "value": "高级"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "行為"
+            "value": "進階"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "動作"
+            "value": "詳細"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "동작"
+            "value": "고급"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comportement"
+            "value": "Avancé"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Comportamento"
+            "value": "Avançado"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Поведение"
+            "value": "Дополнительно"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Verhalten"
+            "value": "Erweitert"
           }
         }
       }
@@ -4033,70 +4033,7 @@
         }
       }
     },
-    "Shortcuts": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shortcuts"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atajos"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "快捷键"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "快速鍵"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ショートカット"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "단축키"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Raccourcis"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kurzbefehle"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Atalhos"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сочетания клавиш"
-          }
-        }
-      }
-    },
+
     "Show Clipboard History": {
       "localizations": {
         "en": {

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -9,7 +9,7 @@ enum HotKeyEditState: Equatable {
 enum SettingsTab: String, CaseIterable {
     case general = "General"
     case privacy = "Privacy"
-    case shortcuts = "Shortcuts"
+    case advanced = "Advanced"
 }
 
 struct SettingsView: View {
@@ -37,11 +37,11 @@ struct SettingsView: View {
                 }
                 .tag(SettingsTab.privacy)
 
-            ShortcutsSettingsView(onHotKeyChanged: onHotKeyChanged)
+            AdvancedSettingsView(onHotKeyChanged: onHotKeyChanged)
                 .tabItem {
-                    Label(String(localized: "Shortcuts"), systemImage: "keyboard")
+                    Label(String(localized: "Advanced"), systemImage: "gearshape.2")
                 }
-                .tag(SettingsTab.shortcuts)
+                .tag(SettingsTab.advanced)
         }
         .frame(width: 480, height: 420)
     }
@@ -122,30 +122,7 @@ struct GeneralSettingsView: View {
 
             }
 
-            Section(String(localized: "Behavior")) {
-                if settings.hasPostEventPermission {
-                    Toggle(String(localized: "Direct Paste"), isOn: $settings.autoPasteEnabled)
-                    if settings.autoPasteEnabled {
-                        Text(String(localized: "ClipKitty will paste items directly into the previous app when you press Enter."))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Text(String(localized: "Items will be copied to the clipboard without pasting."))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    Toggle(String(localized: "Direct Paste"), isOn: .constant(false))
-                        .disabled(true)
-                    Text(String(localized: "Paste items directly into the previous app. Requires permission in System Settings."))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Button(String(localized: "Open System Settings")) {
-                        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
-                    }
-                    .font(.caption)
-                }
-            }
+
 
             Section(String(localized: "Data")) {
                 Button(role: .destructive) {
@@ -306,7 +283,7 @@ class HotKeyRecorderView: NSView {
     }
 }
 
-struct ShortcutsSettingsView: View {
+struct AdvancedSettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
     @State private var hotKeyState: HotKeyEditState = .idle
 
@@ -351,6 +328,31 @@ struct ShortcutsSettingsView: View {
                     Button(String(localized: "Reset to Default (⌥Space)")) {
                         settings.hotKey = .default
                         onHotKeyChanged(.default)
+                    }
+                    .font(.caption)
+                }
+            }
+
+            Section(String(localized: "Direct Paste")) {
+                if settings.hasPostEventPermission {
+                    Toggle(String(localized: "Direct Paste"), isOn: $settings.autoPasteEnabled)
+                    if settings.autoPasteEnabled {
+                        Text(String(localized: "ClipKitty will paste items directly into the previous app when you press Enter."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(String(localized: "Items will be copied to the clipboard without pasting."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Toggle(String(localized: "Direct Paste"), isOn: .constant(false))
+                        .disabled(true)
+                    Text(String(localized: "Paste items directly into the previous app. Requires permission in System Settings."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button(String(localized: "Open System Settings")) {
+                        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!)
                     }
                     .font(.caption)
                 }


### PR DESCRIPTION
- Rename the **Shortcuts** settings tab to **Advanced**
- Move the **Direct Paste** toggle from General settings into the Advanced tab
- Rename section header from "Behavior" to "Direct Paste"
- Update localizations: add "Advanced" translations for all 10 languages, remove stale "Behavior" and "Shortcuts" entries