### PR TITLE
Fix auto-scroll race: settle container size before deferred scroll

### DIFF
--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -1304,6 +1304,16 @@ struct TextPreviewView: NSViewRepresentable {
         let font = NSFont(name: fontName, size: scaledSize)
             ?? NSFont.monospacedSystemFont(ofSize: scaledSize, weight: .regular)
 
+        // Settle container dimensions FIRST so that any deferred scroll
+        // computes geometry against the correct width.  Previously this ran
+        // *after* the text update and the async scroll was already scheduled,
+        // causing intermittent stale-layout scrolls to the document bottom.
+        textView.textContainer?.containerSize = NSSize(
+            width: nsView.contentSize.width,
+            height: .greatestFiniteMagnitude
+        )
+        textView.frame = NSRect(x: 0, y: 0, width: nsView.contentSize.width, height: textView.frame.height)
+
         // Only update if text or highlights changed
         let currentText = textView.string
         let shouldUpdate = currentText != text || context.coordinator.lastHighlights != highlights
@@ -1380,12 +1390,6 @@ struct TextPreviewView: NSViewRepresentable {
                 }
             }
         }
-
-        textView.textContainer?.containerSize = NSSize(
-            width: nsView.contentSize.width,
-            height: .greatestFiniteMagnitude
-        )
-        textView.frame = NSRect(x: 0, y: 0, width: nsView.contentSize.width, height: textView.frame.height)
     }
 
 


### PR DESCRIPTION
## Problem

When selecting an item during search, the preview pane sometimes scrolls to the bottom of the document instead of the highlighted match. The issue is intermittent — the same item may scroll correctly or incorrectly depending on timing.

## Root Cause

In `TextPreviewView.updateNSView`, the container size update (`textContainer.containerSize` and `textView.frame`) ran **after** the highlight scroll was scheduled via `DispatchQueue.main.async`. When the deferred scroll block fired on the next run loop, `ensureLayout` sometimes computed geometry against stale container dimensions.

This caused `boundingRect` to return incorrect coordinates, making `isNearEnd` evaluate to `true` spuriously — triggering `scrollToEndOfDocument` instead of scrolling to the actual match.

## Fix

Move the container size + frame update **before** the text content block so layout geometry is settled when the async scroll fires.