### PR TITLE
Fix launch at login on non-App Store new installs

### DIFF
--- a/Sources/App/LaunchAtLogin.swift
+++ b/Sources/App/LaunchAtLogin.swift
@@ -9,7 +9,6 @@ enum LaunchAtLoginState: Equatable {
 
     enum UnavailableReason: Equatable {
         case notInApplicationsDirectory
-        case serviceNotFound
     }
 
     enum ErrorType: Equatable {
@@ -24,8 +23,6 @@ enum LaunchAtLoginState: Equatable {
             return nil
         case .unavailable(.notInApplicationsDirectory):
             return String(localized: "Move ClipKitty to the Applications folder to enable this option.")
-        case .unavailable(.serviceNotFound):
-            return String(localized: "Launch at login service not found.")
         case .error(.registrationFailed):
             return String(localized: "Could not enable launch at login. Please add ClipKitty manually in System Settings.")
         case .error(.unregistrationFailed):
@@ -100,7 +97,7 @@ final class LaunchAtLogin: ObservableObject {
         case .notRegistered, .requiresApproval:
             state = .disabled
         case .notFound:
-            state = .unavailable(reason: .serviceNotFound)
+            state = .disabled
         @unknown default:
             state = .disabled
         }


### PR DESCRIPTION
## Summary
- `SMAppService.mainApp.status` returns `.notFound` on non-App Store builds before the service has ever been registered
- This was mapped to `.unavailable(.serviceNotFound)`, which disabled the toggle and blocked `syncLaunchAtLogin` from auto-enabling on first launch
- Now treats `.notFound` as `.disabled` so registration is actually attempted — if it genuinely fails, the existing error handling shows "Could not enable launch at login"

## Test plan
- [ ] Fresh install of non-App Store build in /Applications — should auto-enable launch at login
- [ ] Settings toggle should be interactive (not grayed out) on new installs
- [ ] App Store build still defaults to launch at login off