### PR TITLE
Change actions shortcut from ⌥⏎ to ⌘K

### DIFF
--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -370,8 +370,12 @@ struct ContentView: View {
                     moveSelection(by: 1)
                     return .handled
                 }
-                .onKeyPress(.return, phases: .down) { keyPress in
-                    if keyPress.modifiers.contains(.option) {
+                .onKeyPress(.return, phases: .down) { _ in
+                    confirmSelection()
+                    return .handled
+                }
+                .onKeyPress("k", phases: .down) { keyPress in
+                    if keyPress.modifiers.contains(.command) {
                         guard selectedItem != nil else { return .handled }
                         if case .hidden = actionsPopover {
                             let actions = actionItems
@@ -382,8 +386,7 @@ struct ContentView: View {
                         }
                         return .handled
                     }
-                    confirmSelection()
-                    return .handled
+                    return .ignored
                 }
                 .onKeyPress(.escape) {
                     onDismiss()
@@ -882,7 +885,7 @@ struct ContentView: View {
                 actionsPopover = .hidden
             }
         } label: {
-            Text("⌥⏎ Actions")
+            Text("⌘K Actions")
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 6)

--- a/Sources/App/Resources/Localizable.xcstrings
+++ b/Sources/App/Resources/Localizable.xcstrings
@@ -1473,66 +1473,66 @@
         }
       }
     },
-    "⌥⏎ Actions": {
+    "⌘K Actions": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ Actions"
+            "value": "⌘K Actions"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ Acciones"
+            "value": "⌘K Acciones"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ 操作"
+            "value": "⌘K 操作"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ 動作"
+            "value": "⌘K 動作"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ アクション"
+            "value": "⌘K アクション"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ 동작"
+            "value": "⌘K 동작"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ Actions"
+            "value": "⌘K Actions"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ Aktionen"
+            "value": "⌘K Aktionen"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ Ações"
+            "value": "⌘K Ações"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "⌥⏎ Действия"
+            "value": "⌘K Действия"
           }
         }
       }

--- a/Tests/UITests/ClipKittyUITests.swift
+++ b/Tests/UITests/ClipKittyUITests.swift
@@ -386,17 +386,17 @@ final class ClipKittyUITests: XCTestCase {
         XCTAssertTrue(copyAction.waitForExistence(timeout: 3), "Copy action should appear in popover")
     }
 
-    /// Tests that Option+Return opens the actions popover.
-    func testOptionReturnOpensActionsPopover() throws {
+    /// Tests that Cmd+K opens the actions popover.
+    func testCmdKOpensActionsPopover() throws {
         let searchField = app.textFields["SearchField"]
         XCTAssertTrue(searchField.waitForExistence(timeout: 5), "Search field not found")
 
-        // Option+Return should open the actions menu
-        searchField.typeKey(.return, modifierFlags: .option)
+        // Cmd+K should open the actions menu
+        searchField.typeKey("k", modifierFlags: .command)
         Thread.sleep(forTimeInterval: 0.5)
 
         let deleteAction = app.buttons["Action_Delete"]
-        XCTAssertTrue(deleteAction.waitForExistence(timeout: 3), "Actions popover should open with Option+Return")
+        XCTAssertTrue(deleteAction.waitForExistence(timeout: 3), "Actions popover should open with Cmd+K")
     }
 
     /// Tests that Escape closes the actions popover.
@@ -447,8 +447,8 @@ final class ClipKittyUITests: XCTestCase {
         let initialCount = app.outlines.firstMatch.buttons.allElementsBoundByIndex.count
         XCTAssertGreaterThan(initialCount, 0, "Should have items to delete")
 
-        // Press Option+Return to open actions popover
-        searchField.typeKey(.return, modifierFlags: .option)
+        // Press Cmd+K to open actions popover
+        searchField.typeKey("k", modifierFlags: .command)
         Thread.sleep(forTimeInterval: 0.5)
 
         let deleteAction = app.buttons["Action_Delete"]


### PR DESCRIPTION
## Summary
- Changes the actions popover keyboard shortcut from Option+Return to Cmd+K
- Updates the button label and all localizations to show ⌘K
- Updates UI tests to use the new shortcut

## Test plan
- [ ] Verify Cmd+K opens the actions popover
- [ ] Verify Return still confirms selection without opening actions
- [ ] Verify button shows "⌘K Actions"
- [ ] Run UI tests