### PR TITLE
Refactor: UpdateCheckState enum replaces parallel booleans

### DIFF
--- a/Sources/App/Settings.swift
+++ b/Sources/App/Settings.swift
@@ -110,11 +110,13 @@ final class AppSettings: ObservableObject {
 
 
     #if !APP_STORE
-    /// Set when a genuine update is available but not yet installed (e.g. auto-install is off).
-    @Published var updateAvailable = false
+    enum UpdateCheckState: Equatable {
+        case idle
+        case available
+        case checkFailed
+    }
 
-    /// Set to true when update checks have been failing for more than 14 days.
-    @Published var updateCheckFailed = false
+    @Published var updateCheckState: UpdateCheckState = .idle
 
     /// Records when consecutive update-check failures started. Persisted to UserDefaults.
     var updateCheckFailingSince: Date? {

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -82,7 +82,8 @@ struct GeneralSettingsView: View {
         Form {
             #if !APP_STORE
             Section(String(localized: "Updates")) {
-                if settings.updateCheckFailed {
+                switch settings.updateCheckState {
+                case .checkFailed:
                     HStack {
                         Label(String(localized: "Unable to check for updates."), systemImage: "exclamationmark.triangle")
                         Spacer()
@@ -90,7 +91,7 @@ struct GeneralSettingsView: View {
                             NSWorkspace.shared.open(URL(string: "https://github.com/jul-sh/clipkitty/releases/latest")!)
                         }
                     }
-                } else if settings.updateAvailable {
+                case .available:
                     HStack {
                         Label(String(localized: "A new version of ClipKitty is available."), systemImage: "arrow.down.circle")
                         Spacer()
@@ -98,6 +99,8 @@ struct GeneralSettingsView: View {
                             onInstallUpdate?()
                         }
                     }
+                case .idle:
+                    EmptyView()
                 }
 
                 Toggle(String(localized: "Automatically install updates"), isOn: $settings.autoInstallUpdates)


### PR DESCRIPTION
## Summary
- Replace `updateAvailable` (Bool) + `updateCheckFailed` (Bool) in `AppSettings` with a single `UpdateCheckState` enum (`.idle`, `.available`, `.checkFailed`)
- Eliminates the structurally invalid `(true, true)` combination — illegal state is now unrepresentable
- `SettingsView` uses exhaustive `switch` instead of chained `if/else`
- `updateCheckFailingSince` (UserDefaults) kept as-is — it's a persistence detail for the 14-day threshold logic

## Test plan
- [ ] Verify settings view shows nothing in `.idle` state
- [ ] Verify "update available" banner appears when an update is found but not auto-installed
- [ ] Verify "unable to check" banner appears after 14+ days of check failures
- [ ] Verify state resets to `.idle` after successful update install