### PR TITLE
Fix stuck Cmd key in RDP apps with explicit modifier release

### DIFF
--- a/Sources/App/FloatingPanelController.swift
+++ b/Sources/App/FloatingPanelController.swift
@@ -169,11 +169,36 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
         ToastWindow.shared.show(message: String(localized: "Copied"))
     }
 
+    // Remote desktop apps that need special handling for keyboard simulation.
+    // These apps forward keyboard events over the network, and synthetic macOS
+    // events can cause modifier keys to get "stuck" on the remote side.
+    private static let remoteDesktopBundleIDs: Set<String> = [
+        "com.microsoft.rdc.macos",        // Microsoft Remote Desktop
+        "com.microsoft.rdc.osx",          // Microsoft Remote Desktop (older)
+        "com.royalapps.royaltsx",         // Royal TSX
+        "net.parallels.desktop.console",  // Parallels Desktop
+        "com.vmware.fusion",              // VMware Fusion
+        "com.citrix.XenAppViewer",        // Citrix Workspace
+        "com.citrix.receiver.icaviewer",  // Citrix Receiver
+        "com.realvnc.vncviewer",          // RealVNC Viewer
+        "com.tigervnc.vncviewer",         // TigerVNC
+        "org.turbovnc.vncviewer",         // TurboVNC
+        "com.thinomenon.remotix",         // Remotix
+        "com.nulana.rxcontrolmac",        // Remote Desktop Manager
+        "com.devolutions.remotedesktopmanager", // Devolutions RDM
+        "com.teamviewer.TeamViewer",      // TeamViewer
+        "us.zoom.xos",                    // Zoom (remote control)
+        "com.anydesk.anydesk",            // AnyDesk
+    ]
+
     /// Simulate Cmd+V keystroke to paste into the target app
     private func simulatePaste(targetApp: NSRunningApplication?) {
         guard let targetApp = targetApp else {
             return
         }
+
+        let isRemoteDesktop = targetApp.bundleIdentifier
+            .map { Self.remoteDesktopBundleIDs.contains($0) } ?? false
 
         // Wait for the target app to become active before sending keystroke
         Task {
@@ -185,25 +210,82 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
                 try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
             }
 
+            // Remote desktop apps need extra time for clipboard protocol sync.
+            // RDP uses lazy clipboard sync - only a "format list" notification is sent
+            // initially, and actual data is fetched on demand. This delay helps ensure
+            // the clipboard notification propagates before we send the paste keystroke.
+            if isRemoteDesktop {
+                try? await Task.sleep(nanoseconds: 500_000_000) // 500ms
+            }
+
             await MainActor.run {
                 guard let source = CGEventSource(stateID: .hidSystemState) else {
                     return
                 }
 
-                // Key down: Cmd+V
-                guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true) else {
-                    return
+                if isRemoteDesktop {
+                    // For remote desktop apps, explicitly post modifier key events.
+                    // This helps prevent the Cmd key from getting "stuck" on the remote
+                    // side, which can happen when synthetic events are forwarded over RDP.
+                    simulatePasteWithExplicitModifiers(source: source)
+                } else {
+                    // Standard paste simulation for local apps
+                    simulatePasteStandard(source: source)
                 }
-                keyDown.flags = .maskCommand
-                keyDown.post(tap: .cgSessionEventTap)
-
-                // Key up: Cmd+V
-                guard let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false) else {
-                    return
-                }
-                keyUp.flags = .maskCommand
-                keyUp.post(tap: .cgSessionEventTap)
             }
         }
+    }
+
+    /// Standard Cmd+V simulation - works well for local apps
+    private func simulatePasteStandard(source: CGEventSource) {
+        // Key down: Cmd+V
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true) else {
+            return
+        }
+        keyDown.flags = .maskCommand
+        keyDown.post(tap: .cgSessionEventTap)
+
+        // Key up: Cmd+V
+        guard let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false) else {
+            return
+        }
+        keyUp.flags = .maskCommand
+        keyUp.post(tap: .cgSessionEventTap)
+    }
+
+    /// Explicit modifier key simulation for remote desktop apps.
+    /// Posts separate events for Cmd key down/up to ensure the modifier is properly
+    /// released on the remote side.
+    private func simulatePasteWithExplicitModifiers(source: CGEventSource) {
+        let kVK_Command: CGKeyCode = 0x37
+        let kVK_V: CGKeyCode = 0x09
+
+        // 1. Command key down
+        guard let cmdDown = CGEvent(keyboardEventSource: source, virtualKey: kVK_Command, keyDown: true) else {
+            return
+        }
+        cmdDown.flags = .maskCommand
+        cmdDown.post(tap: .cgSessionEventTap)
+
+        // 2. V key down (with Cmd modifier)
+        guard let vDown = CGEvent(keyboardEventSource: source, virtualKey: kVK_V, keyDown: true) else {
+            return
+        }
+        vDown.flags = .maskCommand
+        vDown.post(tap: .cgSessionEventTap)
+
+        // 3. V key up (with Cmd modifier)
+        guard let vUp = CGEvent(keyboardEventSource: source, virtualKey: kVK_V, keyDown: false) else {
+            return
+        }
+        vUp.flags = .maskCommand
+        vUp.post(tap: .cgSessionEventTap)
+
+        // 4. Command key up (explicitly release modifier with no flags)
+        guard let cmdUp = CGEvent(keyboardEventSource: source, virtualKey: kVK_Command, keyDown: false) else {
+            return
+        }
+        cmdUp.flags = []  // No modifiers - explicitly release
+        cmdUp.post(tap: .cgSessionEventTap)
     }
 }


### PR DESCRIPTION
## Summary
- Explicitly post separate key events for Command modifier to prevent stuck keys in RDP
- Increase clipboard sync delay from 250ms to 500ms for better reliability

## Context
The previous approach (PR #140) just delayed the paste keystroke, but users reported the Cmd key still getting stuck on the remote side. This fix explicitly posts:

1. Command key down
2. V key down (with Cmd flag)
3. V key up (with Cmd flag)
4. Command key up (with **empty flags**) ← ensures proper release

## Test plan
- [ ] Test with Royal TSX or Microsoft Remote Desktop
- [ ] Verify Cmd key doesn't get stuck after pasting
- [ ] Verify clipboard content is correct (not stale)

Fixes #133