### PR TITLE
Polish settings UI layout and styling

### DIFF
--- a/Sources/App/PrivacySettingsView.swift
+++ b/Sources/App/PrivacySettingsView.swift
@@ -33,7 +33,7 @@ struct PrivacySettingsView: View {
 
     var body: some View {
         Form {
-            Section {
+            Section(String(localized: "Networking")) {
                 Toggle(isOn: $settings.generateLinkPreviews) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(String(localized: "Generate link previews"))
@@ -44,7 +44,7 @@ struct PrivacySettingsView: View {
                 }
             }
 
-            Section {
+            Section(String(localized: "Storage")) {
                 Toggle(isOn: $settings.ignoreConfidentialContent) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(String(localized: "Ignore confidential content"))
@@ -62,12 +62,9 @@ struct PrivacySettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
-            }
 
-            Section {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(String(localized: "Ignore Applications"))
-                        .font(.headline)
                     Text(String(localized: "Do not save content copied from the applications below."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -75,18 +72,6 @@ struct PrivacySettingsView: View {
                 .padding(.bottom, 4)
 
                 IgnoredAppsListView()
-            }
-
-            Section(String(localized: "Security")) {
-                HStack {
-                    Image(systemName: "lock.shield")
-                        .foregroundStyle(.secondary)
-                    Text(String(localized: "Sandboxed"))
-                        .font(.headline)
-                }
-                Text(String(localized: "ClipKitty runs in an isolated environment, protecting your privacy and keeping your data secure."))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/Sources/App/SettingsView.swift
+++ b/Sources/App/SettingsView.swift
@@ -80,33 +80,6 @@ struct GeneralSettingsView: View {
 
     var body: some View {
         Form {
-            #if !APP_STORE
-            Section(String(localized: "Updates")) {
-                switch settings.updateCheckState {
-                case .checkFailed:
-                    HStack {
-                        Label(String(localized: "Unable to check for updates."), systemImage: "exclamationmark.triangle")
-                        Spacer()
-                        Button(String(localized: "Download")) {
-                            NSWorkspace.shared.open(URL(string: "https://github.com/jul-sh/clipkitty/releases/latest")!)
-                        }
-                    }
-                case .available:
-                    HStack {
-                        Label(String(localized: "A new version of ClipKitty is available."), systemImage: "arrow.down.circle")
-                        Spacer()
-                        Button(String(localized: "Install")) {
-                            onInstallUpdate?()
-                        }
-                    }
-                case .idle:
-                    EmptyView()
-                }
-
-                Toggle(String(localized: "Automatically install updates"), isOn: $settings.autoInstallUpdates)
-            }
-            #endif
-
             Section(String(localized: "Startup")) {
                 let canToggle: Bool = {
                     switch launchAtLogin.state {
@@ -145,6 +118,33 @@ struct GeneralSettingsView: View {
                     }
                 }
             }
+
+            #if !APP_STORE
+            Section(String(localized: "Updates")) {
+                switch settings.updateCheckState {
+                case .checkFailed:
+                    HStack {
+                        Label(String(localized: "Unable to check for updates."), systemImage: "exclamationmark.triangle")
+                        Spacer()
+                        Button(String(localized: "Download")) {
+                            NSWorkspace.shared.open(URL(string: "https://github.com/jul-sh/clipkitty/releases/latest")!)
+                        }
+                    }
+                case .available:
+                    HStack {
+                        Label(String(localized: "A new version of ClipKitty is available."), systemImage: "arrow.down.circle")
+                        Spacer()
+                        Button(String(localized: "Install")) {
+                            onInstallUpdate?()
+                        }
+                    }
+                case .idle:
+                    EmptyView()
+                }
+
+                Toggle(String(localized: "Automatically install updates"), isOn: $settings.autoInstallUpdates)
+            }
+            #endif
 
             Section(String(localized: "Storage")) {
                 LabeledContent(String(localized: "Current Size")) {


### PR DESCRIPTION
## Summary
- Move Updates section to appear right above Storage in General settings
- Reorganize Privacy settings into Networking and Storage sections
- Remove Security/Sandboxed section from Privacy settings
- Remove bold styling from "Ignore Applications" text

## Test plan
- [ ] Open Settings > General and verify Updates section appears above Storage
- [ ] Open Settings > Privacy and verify Networking section contains link previews
- [ ] Verify Storage section contains all ignore options
- [ ] Confirm Security/Sandboxed section is removed