### PR TITLE
Fix Makefile to use renamed appstore entitlements

### DIFF
--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -73,7 +73,7 @@ appstore:
 	@echo "Re-signing for App Store distribution..."
 	@codesign --force --options runtime \
 		--sign "$(APPSTORE_SIGNING_IDENTITY)" \
-		--entitlements $(PROJECT_ROOT)/Sources/App/ClipKitty.entitlements \
+		--entitlements $(PROJECT_ROOT)/Sources/App/ClipKitty.appstore.entitlements \
 		"$(DERIVED_DATA)/Build/Products/AppStore/$(APP_NAME).app"
 	@echo "Creating installer package..."
 	@rm -f "$(PROJECT_ROOT)/$(APP_NAME).pkg"
@@ -182,7 +182,7 @@ marketing-screenshots-capture:
 	@$(MAKE) -C $(PROJECT_ROOT) all CONFIGURATION=AppStore
 	@codesign --force --options runtime \
 		--sign "$(SIGNING_IDENTITY)" \
-		--entitlements $(PROJECT_ROOT)/Sources/App/ClipKitty.entitlements \
+		--entitlements $(PROJECT_ROOT)/Sources/App/ClipKitty.appstore.entitlements \
 		"$(DERIVED_DATA)/Build/Products/AppStore/$(APP_NAME).app"
 	@echo "Capturing marketing screenshots..."
 	@$(DIST_DIR)/prepare-screenshot-environment.sh 'cd $(PROJECT_ROOT) && xcodebuild test -scheme ClipKittyUITests -destination "platform=macOS" -derivedDataPath DerivedData -only-testing:ClipKittyUITests/ClipKittyUITests/testTakeMarketingScreenshots 2>&1 | grep -E "(Test Case|passed|failed)" || true'
@@ -209,7 +209,7 @@ marketing-screenshots-localized:
 	@$(MAKE) -C $(PROJECT_ROOT) all CONFIGURATION=AppStore
 	@codesign --force --options runtime \
 		--sign "$(SIGNING_IDENTITY)" \
-		--entitlements $(PROJECT_ROOT)/Sources/App/ClipKitty.entitlements \
+		--entitlements $(PROJECT_ROOT)/Sources/App/ClipKitty.appstore.entitlements \
 		"$(DERIVED_DATA)/Build/Products/AppStore/$(APP_NAME).app"
 	@rm -f /tmp/clipkitty_screenshot_locale.txt
 	@rm -f /tmp/clipkitty_screenshot_db.txt
@@ -250,7 +250,7 @@ preview-video:
 	@$(MAKE) -C $(PROJECT_ROOT) all CONFIGURATION=AppStore
 	@codesign --force --options runtime \
 		--sign "$(SIGNING_IDENTITY)" \
-		--entitlements $(PROJECT_ROOT)/Sources/App/ClipKitty.entitlements \
+		--entitlements $(PROJECT_ROOT)/Sources/App/ClipKitty.appstore.entitlements \
 		"$(DERIVED_DATA)/Build/Products/AppStore/$(APP_NAME).app"
 	@echo "Recording preview video..."
 	@$(DIST_DIR)/record-preview-video.sh


### PR DESCRIPTION
## Summary
- Update all entitlements references in Makefile from `ClipKitty.entitlements` to `ClipKitty.appstore.entitlements`
- Fixes marketing screenshot capture and other AppStore config targets after #168

## Test plan
- [x] `make -C distribution marketing-screenshots` succeeds