### PR TITLE
Re-add smart search bar

### DIFF
--- a/Sources/App/AutocompleteDropdownView.swift
+++ b/Sources/App/AutocompleteDropdownView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct AutocompleteDropdownView: View {
+    let suggestions: [FilterSuggestion]
+    let highlightedIndex: Int
+    let searchText: String
+    let onSelect: (FilterSuggestion) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(suggestions.enumerated()), id: \.element.filter) { index, suggestion in
+                AutocompleteSuggestionRow(
+                    suggestion: suggestion,
+                    isHighlighted: index == highlightedIndex,
+                    searchText: searchText,
+                    onSelect: { onSelect(suggestion) }
+                )
+            }
+        }
+        .padding(6)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.regularMaterial)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+        .frame(width: 180)
+    }
+}

--- a/Sources/App/AutocompleteSuggestionRow.swift
+++ b/Sources/App/AutocompleteSuggestionRow.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct AutocompleteSuggestionRow: View {
+    let suggestion: FilterSuggestion
+    let isHighlighted: Bool
+    let searchText: String
+    let onSelect: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 8) {
+                Image(systemName: suggestion.icon)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(isHighlighted ? .white : .primary.opacity(0.6))
+                    .frame(width: 20)
+
+                prefixHighlightedText
+                    .foregroundColor(isHighlighted ? .white : .primary)
+
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Group {
+                    if isHighlighted {
+                        selectionBackground()
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                    } else if isHovered {
+                        Color.primary.opacity(0.1)
+                    } else {
+                        Color.primary.opacity(0.05)
+                    }
+                }
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .accessibilityIdentifier("Suggestion_\(suggestion.displayName)")
+    }
+
+    /// Renders the display name with the matching prefix in bold
+    private var prefixHighlightedText: Text {
+        let name = suggestion.displayName
+        let matchLen = min(searchText.count, name.count)
+
+        if matchLen > 0,
+           name.lowercased().hasPrefix(searchText.lowercased()) {
+            let matchEnd = name.index(name.startIndex, offsetBy: matchLen)
+            let matched = Text(name[name.startIndex..<matchEnd])
+                .font(.custom(FontManager.sansSerif, size: 14).bold())
+            let rest = Text(name[matchEnd...])
+                .font(.custom(FontManager.sansSerif, size: 14))
+            return matched + rest
+        } else {
+            return Text(name)
+                .font(.custom(FontManager.sansSerif, size: 14))
+        }
+    }
+}

--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -26,11 +26,6 @@ private enum SpinnerState: Equatable {
     }
 }
 
-private enum FilterPopoverState: Equatable {
-    case hidden
-    case visible(highlightedIndex: Int)
-}
-
 private enum ActionsPopoverState: Equatable {
     case hidden
     case showingActions(highlightedIndex: Int)
@@ -47,27 +42,19 @@ struct ContentView: View {
     @State private var selectedItemId: Int64?
     @State private var selectedItem: ClipboardItem?
     @State private var searchText: String = ""
+    @State private var filterState: SearchFilterState = .idle
     @State private var didApplyInitialSearch = false
     @State private var lastItemsSignature: [Int64] = []  // Track when items change to suppress animation
     @State private var searchSpinner: SpinnerState = .idle
     @State private var previewSpinner: SpinnerState = .idle
     @State private var hasUserNavigated = false
-    @State private var filterPopover: FilterPopoverState = .hidden
     @State private var actionsPopover: ActionsPopoverState = .hidden
     @State private var commandNumberEventMonitor: Any?
     enum FocusTarget: Hashable {
         case search
-        case filterDropdown
         case actionsDropdown
     }
     @FocusState private var focusTarget: FocusTarget?
-
-    private var filterPopoverBinding: Binding<Bool> {
-        Binding(
-            get: { if case .visible = filterPopover { return true } else { return false } },
-            set: { if !$0 { filterPopover = .hidden } }
-        )
-    }
 
     private var actionsPopoverBinding: Binding<Bool> {
         Binding(
@@ -125,10 +112,27 @@ struct ContentView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            searchBar
-            Divider()
-            content
+        ZStack(alignment: .topLeading) {
+            VStack(spacing: 0) {
+                searchBar
+                Divider()
+                content
+            }
+
+            // Autocomplete dropdown — rendered above all content to receive clicks
+            if case .suggesting(let suggestions, let highlightedIndex) = filterState {
+                AutocompleteDropdownView(
+                    suggestions: suggestions,
+                    highlightedIndex: highlightedIndex,
+                    searchText: searchText,
+                    onSelect: { suggestion in
+                        filterState = .filtered(suggestion.filter)
+                        searchText = ""
+                    }
+                )
+                .padding(.top, 50) // Below the search bar
+                .padding(.leading, 57) // Align with text field (17 padding + 40 icon area)
+            }
         }
         // Hidden element for UI testing - exposes selected index
         .accessibilityElement(children: .contain)
@@ -158,6 +162,7 @@ struct ContentView: View {
             } else {
                 searchText = ""
             }
+            filterState = .idle
             // Select first item if nothing selected
             if selectedItemId == nil, let firstId = firstItemId {
                 loadItem(id: firstId)
@@ -178,7 +183,7 @@ struct ContentView: View {
             } else {
                 searchText = ""
             }
-            filterPopover = .hidden
+            filterState = .idle
             actionsPopover = .hidden
             // Select first item whenever display resets (re-open)
             if let firstId = firstItemId {
@@ -218,6 +223,18 @@ struct ContentView: View {
         .onChange(of: searchText) { _, newValue in
             hasUserNavigated = false
             store.setSearchQuery(newValue)
+        }
+        .onChange(of: filterState) { oldState, newState in
+            // Extract the filter from each state, defaulting to .all
+            let oldFilter: ContentTypeFilter
+            if case .filtered(let f) = oldState { oldFilter = f } else { oldFilter = .all }
+            let newFilter: ContentTypeFilter
+            if case .filtered(let f) = newState { newFilter = f } else { newFilter = .all }
+
+            if oldFilter != newFilter {
+                hasUserNavigated = false
+                store.setContentTypeFilter(newFilter)
+            }
         }
         .onChange(of: store.contentTypeFilter) { _, _ in
             // Reset selection when filter changes
@@ -296,13 +313,6 @@ struct ContentView: View {
         }
     }
 
-    private func focusFilterDropdown() {
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(50))
-            focusTarget = .filterDropdown
-        }
-    }
-
     private func focusActionsDropdown() {
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(50))
@@ -356,197 +366,42 @@ struct ContentView: View {
                 .foregroundStyle(.secondary)
                 .font(.custom(FontManager.sansSerif, size: 17).weight(.medium))
 
-            TextField("Clipboard History Search", text: $searchText)
-                .textFieldStyle(.plain)
-                .font(.custom(FontManager.sansSerif, size: 17))
-                .tint(.primary)
-                .focused($focusTarget, equals: .search)
-                .accessibilityIdentifier("SearchField")
-                .onKeyPress(.upArrow) {
-                    moveSelection(by: -1)
-                    return .handled
-                }
-                .onKeyPress(.downArrow) {
-                    moveSelection(by: 1)
-                    return .handled
-                }
-                .onKeyPress(.return, phases: .down) { _ in
-                    confirmSelection()
-                    return .handled
-                }
-                .onKeyPress("k", phases: .down) { keyPress in
-                    if keyPress.modifiers.contains(.command) {
-                        guard selectedItem != nil else { return .handled }
-                        if case .hidden = actionsPopover {
-                            let actions = actionItems
-                            actionsPopover = .showingActions(highlightedIndex: actions.count - 1)
-                            focusActionsDropdown()
-                        } else {
-                            actionsPopover = .hidden
-                        }
-                        return .handled
+<<<<<<< HEAD
+            SmartSearchField(
+                textQuery: $searchText,
+                filterState: $filterState,
+                onMoveSelection: { moveSelection(by: $0) },
+                onConfirmSelection: { confirmSelection() },
+                onDismiss: { onDismiss() },
+                onShowActions: {
+                    guard selectedItem != nil else { return }
+                    if case .hidden = actionsPopover {
+                        let actions = actionItems
+                        actionsPopover = .showingActions(highlightedIndex: actions.count - 1)
+                        focusActionsDropdown()
+                    } else {
+                        actionsPopover = .hidden
                     }
-                    return .ignored
-                }
-                .onKeyPress(.escape) {
-                    onDismiss()
-                    return .handled
-                }
-                .onKeyPress(.tab) {
-                    let allOptions = Self.filterOptions
-                    let index = allOptions.firstIndex(where: { $0.0 == store.contentTypeFilter }) ?? 0
-                    filterPopover = .visible(highlightedIndex: index)
-                    focusFilterDropdown()
-                    return .handled
-                }
-                .onKeyPress(characters: .decimalDigits, phases: .down) { keyPress in
-                    handleNumberKey(keyPress)
-                }
-                .onKeyPress(.delete) {
-                    guard selectedItemId != nil else { return .ignored }
+                },
+                onShowDelete: {
+                    guard selectedItemId != nil else { return }
                     actionsPopover = .showingDeleteConfirm(highlightedIndex: 0)
                     focusActionsDropdown()
-                    return .handled
                 }
-                .onKeyPress(.deleteForward) {
-                    guard selectedItemId != nil else { return .ignored }
-                    actionsPopover = .showingDeleteConfirm(highlightedIndex: 0)
-                    focusActionsDropdown()
-                    return .handled
-                }
+            )
+            .focused($focusTarget, equals: .search)
+            .onKeyPress(characters: .decimalDigits, phases: .down) { keyPress in
+                handleNumberKey(keyPress)
+            }
 
             if case .visible = searchSpinner {
                 ProgressView()
                     .scaleEffect(0.5)
                     .frame(width: 16, height: 16)
             }
-
-            filterDropdown
         }
         .padding(.horizontal, 17)
-        .padding(.vertical, 13)
-    }
-
-    // MARK: - Filter Dropdown
-
-    private var filterLabel: String {
-        switch store.contentTypeFilter {
-        case .all: return String(localized: "All Types")
-        case .text: return String(localized: "Text")
-        case .images: return String(localized: "Images")
-        case .links: return String(localized: "Links")
-        case .colors: return String(localized: "Colors")
-        case .files: return String(localized: "Files")
-        }
-    }
-
-    private var filterDropdown: some View {
-        Button {
-            let allOptions = Self.filterOptions
-            let index = allOptions.firstIndex(where: { $0.0 == store.contentTypeFilter }) ?? 0
-            if case .visible = filterPopover {
-                filterPopover = .hidden
-            } else {
-                filterPopover = .visible(highlightedIndex: index)
-                focusFilterDropdown()
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Text(filterLabel)
-                    .font(.system(size: 13))
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 9, weight: .semibold))
-            }
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .overlay(Capsule().strokeBorder(Color.primary.opacity(0.15)))
-        }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("FilterDropdown")
-        .popover(isPresented: filterPopoverBinding, arrowEdge: .bottom) {
-            filterPopoverContent
-        }
-    }
-
-    private static let filterOptions: [(ContentTypeFilter, String)] = {
-        var options: [(ContentTypeFilter, String)] = [
-            (.all, String(localized: "All Types")),
-            (.text, String(localized: "Text")),
-            (.images, String(localized: "Images")),
-            (.links, String(localized: "Links")),
-            (.colors, String(localized: "Colors")),
-        ]
-        options.append((.files, String(localized: "Files")))
-        return options
-    }()
-
-    private var filterPopoverContent: some View {
-        let options = Self.filterOptions
-        let highlightedIndex: Int
-        if case .visible(let idx) = filterPopover {
-            highlightedIndex = idx
-        } else {
-            highlightedIndex = 0
-        }
-        return VStack(spacing: 2) {
-            ForEach(Array(options.enumerated()), id: \.offset) { index, entry in
-                let (option, label) = entry
-                if index == 1 {
-                    Divider().padding(.horizontal, 4).padding(.vertical, 3)
-                }
-                FilterOptionRow(
-                    label: label,
-                    isSelected: store.contentTypeFilter == option,
-                    isHighlighted: highlightedIndex == index,
-                    action: {
-                        store.setContentTypeFilter(option)
-                        filterPopover = .hidden
-                        focusSearchField()
-                    }
-                )
-            }
-        }
-        .padding(10)
-        .frame(width: 160)
-        .focusable()
-        .focused($focusTarget, equals: .filterDropdown)
-        .focusEffectDisabled()
-        .onKeyPress(.upArrow) {
-            if case .visible(let idx) = filterPopover {
-                filterPopover = .visible(highlightedIndex: max(idx - 1, 0))
-            }
-            return .handled
-        }
-        .onKeyPress(.downArrow) {
-            if case .visible(let idx) = filterPopover {
-                filterPopover = .visible(highlightedIndex: min(idx + 1, options.count - 1))
-            }
-            return .handled
-        }
-        .onKeyPress(.return, phases: .down) { _ in
-            let selected = options[highlightedIndex]
-            store.setContentTypeFilter(selected.0)
-            filterPopover = .hidden
-            focusSearchField()
-            return .handled
-        }
-        .onKeyPress(.escape) {
-            filterPopover = .hidden
-            focusSearchField()
-            return .handled
-        }
-        .onKeyPress(.tab) {
-            filterPopover = .hidden
-            focusSearchField()
-            return .handled
-        }
-        .onAppear {
-            let allOptions = Self.filterOptions
-            let index = allOptions.firstIndex(where: { $0.0 == store.contentTypeFilter }) ?? 0
-            filterPopover = .visible(highlightedIndex: index)
-            focusFilterDropdown()
-        }
+        .frame(height: 46)
     }
 
     private func handleNumberKey(_ keyPress: KeyPress) -> KeyPress.Result {
@@ -563,6 +418,17 @@ struct ContentView: View {
     private func installCommandNumberEventMonitor() {
         guard commandNumberEventMonitor == nil else { return }
         commandNumberEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            // Backspace on empty search field removes the active filter.
+            // Handled here because SwiftUI's .onKeyPress(.delete) does not fire
+            // on an empty TextField.
+            if event.keyCode == 51, // 51 = backspace key
+               searchText.isEmpty,
+               case .filtered = filterState,
+               focusTarget == .search {
+                filterState = .idle
+                return nil
+            }
+
             guard let number = commandNumber(from: event) else {
                 return event
             }
@@ -1748,38 +1614,6 @@ struct HighlightedTextView: View, Equatable {
     }
 }
 
-// MARK: - Filter Option Row
-
-private struct FilterOptionRow: View {
-    let label: String
-    let isSelected: Bool
-    var isHighlighted: Bool = false
-    let action: () -> Void
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            Text(label)
-                .font(.system(size: 13))
-                .foregroundStyle(isHighlighted ? .white : .secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 5)
-                .background {
-                    if isHighlighted {
-                        selectionBackground()
-                            .clipShape(RoundedRectangle(cornerRadius: 9))
-                    } else {
-                        RoundedRectangle(cornerRadius: 9)
-                            .fill(isSelected ? Color.primary.opacity(0.1) : isHovered ? Color.primary.opacity(0.05) : Color.clear)
-                    }
-                }
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-    }
-}
-
 // MARK: - Action Option Row
 
 private struct ActionOptionRow: View {
@@ -1829,7 +1663,7 @@ private struct ActionOptionRow: View {
 
 /// Shared selection highlight matching Spotlight's style (H220 S68 B71)
 @ViewBuilder
-private func selectionBackground() -> some View {
+func selectionBackground() -> some View {
     Color.accentColor
         .opacity(0.9)
         .saturation(0.78)

--- a/Sources/App/FilterTagView.swift
+++ b/Sources/App/FilterTagView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// A pill-shaped view that displays an active filter tag inside the search field
+struct FilterTagView: View {
+    let suggestion: FilterSuggestion
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 4) {
+            // Filter icon
+            Image(systemName: suggestion.icon)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.primary)
+
+            // Filter display name
+            Text(suggestion.displayName)
+                .font(.custom(FontManager.sansSerif, size: 16))
+                .foregroundColor(.primary)
+
+        }
+        .accessibilityIdentifier("FilterTag_\(suggestion.displayName)")
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            Capsule()
+                .fill(Color.primary.opacity(0.1))
+        )
+        .contentShape(Capsule())
+        .onTapGesture(perform: onDelete)
+    }
+}

--- a/Sources/App/SmartSearchField.swift
+++ b/Sources/App/SmartSearchField.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import ClipKittyRust
+
+/// Custom search field with inline filter tag support and autocomplete suggestions
+struct SmartSearchField: View {
+    @Binding var textQuery: String
+    @Binding var filterState: SearchFilterState
+
+    let onMoveSelection: (Int) -> Void
+    let onConfirmSelection: () -> Void
+    let onDismiss: () -> Void
+    let onShowActions: () -> Void
+    let onShowDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // Filter tag (if active)
+            if case .filtered(let filter) = filterState,
+               let suggestion = FilterSuggestion.suggestion(for: filter) {
+                FilterTagView(
+                    suggestion: suggestion,
+                    onDelete: {
+                        filterState = .idle
+                    }
+                )
+            }
+
+            // Text input
+            TextField("Clipboard History Search", text: $textQuery)
+                .textFieldStyle(.plain)
+                .font(.custom(FontManager.sansSerif, size: 17))
+                .tint(.primary)
+                .accessibilityIdentifier("SearchField")
+                .onChange(of: textQuery) { _, newValue in
+                    processInput(newValue)
+                }
+                .onKeyPress(.upArrow) {
+                    handleUpArrow()
+                }
+                .onKeyPress(.downArrow) {
+                    handleDownArrow()
+                }
+                .onKeyPress(.return, phases: .down) { keyPress in
+                    handleReturn(modifiers: keyPress.modifiers)
+                }
+                .onKeyPress(.escape) {
+                    handleEscape()
+                }
+                .onKeyPress(.tab) {
+                    handleTab()
+                }
+                .onKeyPress(.deleteForward) {
+                    onShowDelete()
+                    return .handled
+                }
+        }
+    }
+
+    // MARK: - Input Processing
+
+    private func processInput(_ input: String) {
+        if case .filtered = filterState {
+            // Filter already active, don't show autocomplete for filter names
+            return
+        }
+        // Check for filter suggestions
+        let suggestions = FilterSuggestion.suggestions(for: input)
+        if input.isEmpty || suggestions.isEmpty {
+            filterState = .idle
+        } else {
+            filterState = .suggesting(suggestions: suggestions, highlightedIndex: 0)
+        }
+    }
+
+    // MARK: - Keyboard Handlers
+
+    private func handleUpArrow() -> KeyPress.Result {
+        if case .suggesting(let suggestions, let index) = filterState {
+            let newIndex = index > 0 ? index - 1 : suggestions.count - 1
+            filterState = .suggesting(suggestions: suggestions, highlightedIndex: newIndex)
+            return .handled
+        }
+        onMoveSelection(-1)
+        return .handled
+    }
+
+    private func handleDownArrow() -> KeyPress.Result {
+        if case .suggesting(let suggestions, let index) = filterState {
+            let newIndex = index < suggestions.count - 1 ? index + 1 : 0
+            filterState = .suggesting(suggestions: suggestions, highlightedIndex: newIndex)
+            return .handled
+        }
+        onMoveSelection(1)
+        return .handled
+    }
+
+    private func handleReturn(modifiers: EventModifiers) -> KeyPress.Result {
+        // Check for Option+Return to show actions
+        if modifiers.contains(.option) {
+            onShowActions()
+            return .handled
+        }
+
+        // If autocomplete is visible, select the highlighted suggestion
+        if case .suggesting(let suggestions, let index) = filterState {
+            let suggestion = suggestions[index]
+            selectFilterSuggestion(suggestion)
+            return .handled
+        }
+
+        // No autocomplete visible - confirm selection in results list
+        onConfirmSelection()
+        return .handled
+    }
+
+    private func handleEscape() -> KeyPress.Result {
+        if case .suggesting = filterState {
+            filterState = .idle
+            return .handled
+        }
+        onDismiss()
+        return .handled
+    }
+
+    private func handleTab() -> KeyPress.Result {
+        if case .suggesting(let suggestions, let index) = filterState {
+            // Tab acts like Return for autocomplete selection
+            let suggestion = suggestions[index]
+            selectFilterSuggestion(suggestion)
+            return .handled
+        }
+        // Tab with no autocomplete does nothing special
+        return .ignored
+    }
+
+    // MARK: - Selection
+
+    private func selectFilterSuggestion(_ suggestion: FilterSuggestion) {
+        filterState = .filtered(suggestion.filter)
+        textQuery = "" // Clear the text that matched the filter name
+    }
+}

--- a/Sources/App/SmartSearchTypes.swift
+++ b/Sources/App/SmartSearchTypes.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import ClipKittyRust
+
+/// Represents a filter suggestion in the autocomplete dropdown
+struct FilterSuggestion: Identifiable, Equatable {
+    let filter: ContentTypeFilter
+    let displayName: String
+    let icon: String // SF Symbol name
+    let iconColor: Color
+
+    var id: ContentTypeFilter { filter }
+
+    /// Checks if this suggestion matches the given input (case-insensitive prefix matching only)
+    func matches(_ input: String) -> Bool {
+        displayName.lowercased().hasPrefix(input.lowercased())
+    }
+
+    /// All available filter suggestions (excluding .all)
+    static let allSuggestions: [FilterSuggestion] = [
+        FilterSuggestion(
+            filter: .text,
+            displayName: String(localized: "Text"),
+            icon: "doc.text",
+            iconColor: .blue
+        ),
+        FilterSuggestion(
+            filter: .images,
+            displayName: String(localized: "Images"),
+            icon: "photo",
+            iconColor: Color(hue: 0.93, saturation: 0.7, brightness: 0.9)
+        ),
+        FilterSuggestion(
+            filter: .links,
+            displayName: String(localized: "Links"),
+            icon: "link",
+            iconColor: .green
+        ),
+        FilterSuggestion(
+            filter: .colors,
+            displayName: String(localized: "Colors"),
+            icon: "paintpalette",
+            iconColor: .purple
+        ),
+        FilterSuggestion(
+            filter: .files,
+            displayName: String(localized: "Files"),
+            icon: "doc",
+            iconColor: .orange
+        )
+    ]
+
+    /// Returns suggestions that match the given input
+    static func suggestions(for input: String) -> [FilterSuggestion] {
+        guard !input.isEmpty else {
+            return allSuggestions
+        }
+        return allSuggestions.filter { $0.matches(input) }
+    }
+
+    /// Returns the suggestion for a specific filter type
+    static func suggestion(for filter: ContentTypeFilter) -> FilterSuggestion? {
+        allSuggestions.first { $0.filter == filter }
+    }
+}
+
+/// Combined state for filter tag and autocomplete suggestions.
+/// Exactly 3 valid states — the illegal combination of an active filter
+/// with visible autocomplete suggestions is structurally impossible.
+enum SearchFilterState: Equatable {
+    case idle
+    case suggesting(suggestions: [FilterSuggestion], highlightedIndex: Int)
+    case filtered(ContentTypeFilter)
+}


### PR DESCRIPTION
## Summary

- Re-adds the smart search bar feature (reverts the revert from #141)
- Replaces the filter dropdown with an inline smart search field with autocomplete

## ⚠️ UX improvements needed before merge

**DO NOT MERGE** until the following issues are resolved:

1. **Suggestions are distracting** - The autocomplete suggestions appear as you type, which can be distracting during normal search
2. **Suggestions cover the first item** - The dropdown overlay obscures the first result in the list, making it hard to see what you're searching for

### Possible solutions to explore:
- Delay showing suggestions until user pauses typing
- Only show suggestions when triggered (e.g., pressing Tab or a specific key)
- Position suggestions differently so they don't cover results
- Make suggestions less prominent/smaller
- Add a setting to disable autocomplete suggestions

## Test plan

- [ ] Fix UX issues listed above
- [ ] Verify smart search works correctly
- [ ] Verify filter suggestions appear appropriately
- [ ] Verify selected filters display correctly