### PR TITLE
Fix Sparkle auto-updates not installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ NIX_SHELL := ./Scripts/run-in-nix.sh -c
 APP_NAME := ClipKitty
 SCRIPT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
-# Version: override via `make all VERSION=1.2.3 BUILD_NUMBER=42`
+# Version: override via `make all VERSION=1.2.3`
+# BUILD_NUMBER defaults to VERSION so CFBundleVersion matches sparkle:version in the appcast.
+# App Store CI overrides BUILD_NUMBER explicitly with an integer commit count.
 VERSION ?= 1.0.0
-BUILD_NUMBER ?= $(shell git rev-list --count HEAD 2>/dev/null || echo 1)
+BUILD_NUMBER ?= $(VERSION)
 
 # Build configuration: Debug, Release (DMG), or AppStore (sandboxed)
 CONFIGURATION ?= Release

--- a/Project.swift
+++ b/Project.swift
@@ -87,7 +87,7 @@ let project = Project(
                 "SUPublicEDKey": "9VqfSPPY2Gr8QTYDLa99yJXAFWnHw5aybSbKaYDyCq0=",
                 "SUEnableAutomaticChecks": true,
                 "SUAutomaticallyUpdate": true,
-                "SUEnableInstallerLauncherService": true,
+                "SUEnableInstallerLauncherService": false,
             ]),
             sources: ["Sources/App/**"],
             resources: [
@@ -132,7 +132,6 @@ let project = Project(
                     ]),
                     .release(name: "Release", settings: [
                         "CODE_SIGN_ENTITLEMENTS": "Sources/App/ClipKitty.oss.entitlements",
-                        "CURRENT_PROJECT_VERSION": "$(MARKETING_VERSION)",
                     ]),
                     .release(name: .configuration("AppStore"), settings: [
                         "CODE_SIGN_ENTITLEMENTS": "Sources/App/ClipKitty.appstore.entitlements",

--- a/Sources/App/ClipKitty.oss.entitlements
+++ b/Sources/App/ClipKitty.oss.entitlements
@@ -6,10 +6,11 @@
     <key>com.apple.application-identifier</key>
     <string>ANBBV7LQ2P.com.eviljuliette.clipkitty</string>
 
-    <!-- macOS App Sandbox enabled -->
-    <!-- Note: Direct paste (Cmd+V keystroke) requires user to grant permission at runtime via System Settings -->
+    <!-- macOS App Sandbox disabled for DMG distribution -->
+    <!-- Sparkle needs filesystem access to replace the app bundle during updates. -->
+    <!-- App Store builds use ClipKitty.appstore.entitlements which keeps sandbox enabled. -->
     <key>com.apple.security.app-sandbox</key>
-    <true/>
+    <false/>
 
     <!-- Network: outgoing connections for LPMetadataProvider link preview fetching -->
     <key>com.apple.security.network.client</key>

--- a/Sources/App/UpdateController.swift
+++ b/Sources/App/UpdateController.swift
@@ -25,6 +25,7 @@ final class SilentUpdateDriver: NSObject, SPUUserDriver {
     func showUserInitiatedUpdateCheck(cancellation: @escaping () -> Void) {}
 
     func showUpdateFound(with appcastItem: SUAppcastItem, state: SPUUserUpdateState, reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        log.info("Update found: \(appcastItem.displayVersionString) (build \(appcastItem.versionString))")
         let settings = AppSettings.shared
         settings.updateCheckState = .idle
         settings.updateCheckFailingSince = nil
@@ -120,8 +121,19 @@ final class UpdateController {
         updater.automaticallyDownloadsUpdates = AppSettings.shared.autoInstallUpdates
         updater.updateCheckInterval = 14400 // 4 hours
 
+        log.info("Feed URL: \(bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String ?? "not set")")
+        log.info("Version: \(bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"), build: \(bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown")")
+
         do {
             try updater.start()
+            log.info("Sparkle updater started")
+            // Trigger a check shortly after launch to ensure updates are found promptly,
+            // rather than waiting for the full scheduled interval on first launch.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+                guard let self, self.updater.canCheckForUpdates else { return }
+                log.info("Running startup update check")
+                self.updater.checkForUpdates()
+            }
         } catch {
             log.error("Failed to start updater: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary

- **CFBundleVersion mismatch**: Makefile defaulted `BUILD_NUMBER` to git commit count, but appcast uses marketing version for `sparkle:version`. Sparkle compares `CFBundleVersion` against `sparkle:version`, so the mismatch broke version comparison. Fixed by defaulting `BUILD_NUMBER` to `$(VERSION)`.
- **No startup update check**: Sparkle's automatic scheduler delays first check on fresh launch. Added explicit `checkForUpdates()` 5 seconds after launch.
- **App Sandbox blocking updates**: Sparkle can't replace the app bundle inside sandbox. Disabled sandbox for DMG builds (App Store builds unaffected — they use separate entitlements).
- Disabled `SUEnableInstallerLauncherService` (XPC privileged installer not needed without sandbox).

## Verification

Tested end-to-end in [clipkitty-sparkle-test](https://github.com/jul-sh/clipkitty-sparkle-test):

1. Built and released v1.0.6 with fixes
2. Pushed v1.0.7 via CI (with matching `CFBundleVersion = "1.0.7"` and `sparkle:version = "1.0.7"`)
3. Installed v1.0.6 from DMG to ~/Applications/
4. Ran the app → Sparkle detected v1.0.7, downloaded DMG, extracted, replaced app bundle, relaunched
5. Confirmed app was now v1.0.7 with valid Developer ID code signing

## Test plan

- [ ] Build Release configuration and verify `CFBundleVersion` matches `MARKETING_VERSION`
- [ ] Run app and confirm Sparkle startup check fires ~5s after launch (visible in Console.app under ClipKitty/Update category)
- [ ] Verify App Store build is unaffected (uses separate entitlements, CI overrides `BUILD_NUMBER`)