### PR TITLE
Re-enable App Sandbox with Sparkle XPC installer

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -87,7 +87,7 @@ let project = Project(
                 "SUPublicEDKey": "9VqfSPPY2Gr8QTYDLa99yJXAFWnHw5aybSbKaYDyCq0=",
                 "SUEnableAutomaticChecks": true,
                 "SUAutomaticallyUpdate": true,
-                "SUEnableInstallerLauncherService": false,
+                "SUEnableInstallerLauncherService": true,
             ]),
             sources: ["Sources/App/**"],
             resources: [

--- a/Sources/App/ClipKitty.oss.entitlements
+++ b/Sources/App/ClipKitty.oss.entitlements
@@ -6,11 +6,9 @@
     <key>com.apple.application-identifier</key>
     <string>ANBBV7LQ2P.com.eviljuliette.clipkitty</string>
 
-    <!-- macOS App Sandbox disabled for DMG distribution -->
-    <!-- Sparkle needs filesystem access to replace the app bundle during updates. -->
-    <!-- App Store builds use ClipKitty.appstore.entitlements which keeps sandbox enabled. -->
+    <!-- macOS App Sandbox — enabled; Sparkle uses XPC installer service to update outside sandbox -->
     <key>com.apple.security.app-sandbox</key>
-    <false/>
+    <true/>
 
     <!-- Network: outgoing connections for LPMetadataProvider link preview fetching -->
     <key>com.apple.security.network.client</key>
@@ -20,11 +18,13 @@
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
 
-    <!-- Sparkle: mach-lookup for XPC services (installer & status) -->
+    <!-- Sparkle: mach-lookup for XPC services (installer & status).
+         Hardcoded because $(PRODUCT_BUNDLE_IDENTIFIER) is not expanded when
+         codesign is invoked directly in CI (outside xcodebuild). -->
     <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
     <array>
-        <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
-        <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+        <string>com.eviljuliette.clipkitty-spks</string>
+        <string>com.eviljuliette.clipkitty-spki</string>
     </array>
 
     <!-- Hardware: camera/microphone/location are omitted; no sensor access. -->


### PR DESCRIPTION
## Summary
- Re-enables App Sandbox for DMG/non-App Store builds by using Sparkle's XPC Services-based installer (`InstallerLauncher`) instead of disabling the sandbox
- Enables `SUEnableInstallerLauncherService` so Sparkle spawns a privileged XPC process outside the sandbox to replace the app bundle
- Hardcodes mach-lookup entitlements (`com.eviljuliette.clipkitty-spks`/`-spki`) because `$(PRODUCT_BUNDLE_IDENTIFIER)` is not expanded when `codesign` is invoked directly in CI (outside xcodebuild)

## How it works
1. Sandboxed app checks appcast and downloads the update
2. `InstallerLauncher` XPC service spawns outside the sandbox
3. `Autoupdate` process verifies the EdDSA signature
4. App terminates, `Autoupdate` replaces the bundle, app relaunches

## Test plan
- [x] Verified end-to-end on test repo (`clipkitty-sparkle-test`): sandboxed app updated from v1.0.0 → v1.0.7 via XPC installer
- [x] Confirmed XPC services (`Installer.xpc`, `Downloader.xpc`) are embedded in `Sparkle.framework`
- [x] Confirmed mach-lookup entitlements are hardcoded (not using build variable)
- [x] Confirmed `SUEnableInstallerLauncherService: true` in built Info.plist
- [ ] CI builds and signs correctly on `release` branch
- [ ] Update installs successfully from CI-built DMG