### PR TITLE
Remove Phase 2 bucket re-ranking

### DIFF
--- a/purr/src/indexer.rs
+++ b/purr/src/indexer.rs
@@ -4,7 +4,6 @@
 //! For queries under 3 characters, returns empty (handled by search.rs streaming fallback).
 
 use crate::candidate::SearchCandidate;
-use crate::ranking::compute_bucket_score;
 use chrono::Utc;
 
 /// Large boost for proximity PhraseQuery, creating distinct score bands.
@@ -260,54 +259,14 @@ impl Indexer {
             return Ok(candidates);
         }
 
-        // Phase 2: Bucket re-ranking (parallelized — compute_bucket_score is a pure function)
-        let query_words_owned = crate::search::tokenize_words(query);
-        let query_words: Vec<&str> = query_words_owned.iter().map(|(_, _, w)| w.as_str()).collect();
-        let last_word_is_prefix = query.ends_with(|c: char| c.is_alphanumeric());
-        let now = Utc::now().timestamp();
-
-        use rayon::prelude::*;
-        let mut scored: Vec<(crate::ranking::BucketScore, usize)> = candidates
-            .par_iter()
-            .enumerate()
-            .map(|(i, c)| {
-                let content_lower = c.content().to_lowercase();
-                let doc_words = crate::search::tokenize_words(&content_lower);
-                let doc_word_strs: Vec<&str> = doc_words.iter().map(|(_, _, w)| w.as_str()).collect();
-                let bucket = compute_bucket_score(
-                    &content_lower,
-                    &doc_word_strs,
-                    &query_words,
-                    last_word_is_prefix,
-                    c.timestamp,
-                    c.tantivy_score,
-                    now,
-                );
-                (bucket, i)
-            })
-            .collect();
-
-        scored.sort_unstable_by(|a, b| b.0.cmp(&a.0));
-        scored.truncate(limit);
+        // Tantivy handles ranking directly via soft-lexicographic scoring in tweak_score.
+        // No Phase 2 re-ranking needed.
+        candidates.truncate(limit);
 
         #[cfg(feature = "perf-log")]
-        {
-            let t2 = std::time::Instant::now();
-            eprintln!(
-                "[perf] phase1={:.1}ms phase2={:.1}ms candidates={}",
-                (t1 - t0).as_secs_f64() * 1000.0,
-                (t2 - t1).as_secs_f64() * 1000.0,
-                scored.len(),
-            );
-        }
+        eprintln!("[perf] phase1={:.1}ms candidates={}", (t1 - t0).as_secs_f64() * 1000.0, candidates.len());
 
-        let mut candidate_slots: Vec<Option<SearchCandidate>> =
-            candidates.into_iter().map(Some).collect();
-
-        Ok(scored
-            .into_iter()
-            .filter_map(|(_, i)| candidate_slots[i].take())
-            .collect())
+        Ok(candidates)
     }
 
     /// Phase 1: Trigram recall using Tantivy BM25.
@@ -361,13 +320,9 @@ impl Indexer {
                     // Higher tiers dominate, but large lower-tier differences can
                     // overcome small upper-tier differences.
                     //
-                    // Weight ratio = 10x between tiers means:
-                    // - 2-point recency diff (200) beats 15-point proximity diff (150)
-                    // - 1-point recency diff (100) loses to 15-point proximity diff (150)
-                    //
                     // Tiers (high to low):
                     // 1. recency_score (0-255) * 10.0 = 0-2550
-                    // 2. proximity_tier (0-1) * 100.0 = 0-100  (proximity match = +100)
+                    // 2. proximity_tier (0-1) * 100.0 = 0-100 (proximity match = +100)
                     // 3. base_remainder (BM25) * 1.0 = typically 0-50
                     recency_score * 10.0 + proximity_tier * 100.0 + base_remainder
                 }


### PR DESCRIPTION
## Summary

Removes Phase 2 bucket re-ranking since Phase 1 (Tantivy) now handles ranking directly via soft-lexicographic scoring.

**Depends on:** #180 (word-field-index branch)

## Changes

- Remove Phase 2 re-ranking from `Indexer::search()`
- Tantivy's `tweak_score` now computes final ranking using soft-lexicographic formula

## Performance Benchmarks

Tested on 150 large documents (5KB-100KB each, ~34KB average):

| Query Type | Main (Phase 2) | This PR (Phase 1 only) | Speedup |
|------------|----------------|------------------------|---------|
| large_function | 197ms | 52ms | **3.8x** |
| large_error | 196ms | 53ms | **3.7x** |
| large_class | 165ms | 50ms | **3.3x** |
| large_fuzzy | 266ms | 46ms | **5.8x** |
| large_multi | 340ms | 66ms | **5.2x** |
| large_lorem | 330ms | 63ms | **5.2x** |

**Average speedup: 4.5x faster** by eliminating Phase 2 re-ranking.

## Tradeoffs

### Phase 1 Ranking (from previous PR)

**Pros:**
- Single-phase search eliminates re-ranking overhead
- Soft-lexicographic scoring allows large lower-tier differences to overcome small upper-tier differences (unlike Phase 2's strict lexicographic order)

**Cons:**
- Proximity detection is binary (slop=3 PhraseQuery match or not) vs Phase 2's granular proximity_score (0-255)
- No typo_score tier - fuzzy matches are handled at recall level but don't affect final ranking order
- No exactness_score tier - exact vs prefix vs fuzzy matches all rank the same within recency buckets
- Score band encoding for proximity is a bit hacky (uses 1000x boost to create distinguishable bands)

### Phase 2 Removal

**Pros:**
- **3-6x faster search** on large documents (no parallelized re-ranking pass)
- Simpler code path - ranking logic consolidated in one place

**Cons:**
- Loses granular multi-tier ranking (words_matched_weight, typo_score, proximity_score, exactness_score, bm25_quantized)
- Phase 2's bucket scoring was more principled and easier to tune
- If Tantivy ranking diverges from expected behavior, debugging is harder (inside tweak_score closure)

## Test plan

- [x] All 216 existing tests pass (including 10 ranking-specific tests)
- [ ] Manual testing with real clipboard history