### PR TITLE
Disable perf CI on pull requests

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -1,9 +1,10 @@
 name: Performance Tests
 
 on:
-  # Run on PRs to catch regressions before merge
-  pull_request:
-    branches: [main, release]
+  # Disabled: frequently times out at 30m and produces incorrect output.
+  # Can still be triggered manually via workflow_dispatch.
+  # pull_request:
+  #   branches: [main, release]
   # Manual trigger for on-demand testing
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- Disables the automatic performance test workflow on PRs
- The workflow frequently times out at 30 minutes and produces incorrect output (all metrics show `?` instead of values)
- Keeps `workflow_dispatch` so it can still be triggered manually when needed