### PR TITLE
Make direct paste opt-in and simplify App Store review notes

### DIFF
--- a/Sources/MacApp/Settings.swift
+++ b/Sources/MacApp/Settings.swift
@@ -264,7 +264,7 @@ final class AppSettings: ObservableObject {
 
         launchAtLoginEnabled = defaults.bool(forKey: launchAtLoginKey)
         #if ENABLE_SYNTHETIC_PASTE
-            autoPasteEnabled = defaults.object(forKey: autoPasteKey) as? Bool ?? true
+            autoPasteEnabled = defaults.object(forKey: autoPasteKey) as? Bool ?? false
         #endif
         #if ENABLE_SPARKLE_UPDATES
             autoInstallUpdates = defaults.object(forKey: autoInstallUpdatesKey) as? Bool ?? true

--- a/distribution/metadata/review_information/notes.txt
+++ b/distribution/metadata/review_information/notes.txt
@@ -7,7 +7,16 @@ HOW TO TEST (macOS):
 3. Click the cat icon in the menu bar, or press ⌥Space (Option+Space).
 4. Your copied items appear in a scrollable list, most recent first.
 5. Use the arrow keys (Up/Down) to navigate items. The right-side preview pane shows full content.
-6. Press Return to copy the selected item to the clipboard. This dismisses the panel.
+6. Press Return to use the currently selected paste mode. This dismisses the panel.
+
+OPTIONAL DIRECT PASTE FEATURE (macOS):
+
+1. Open ClipKitty > Settings > General > Paste Items.
+2. Select "To active app" to enable direct paste. Select "To clipboard" to use copy-only mode instead.
+3. If macOS asks for Accessibility permission, grant it in System Settings, then relaunch ClipKitty.
+4. Focus a text field in another app such as TextEdit or Notes.
+5. Open ClipKitty, select an item, and press Return.
+6. In "To active app" mode, ClipKitty places the selected item on the system pasteboard and sends Cmd+V to the app that was active before ClipKitty was opened.
 
 HOW TO TEST (iPhone):
 
@@ -18,6 +27,12 @@ HOW TO TEST (iPhone):
 5. Use the search bar (magnifying glass) to find items. Use the filter pill to filter by type (text, images, links, colors).
 
 NOTES:
+- On macOS, "To active app" is an optional, user-controlled setting. It only runs after the user explicitly selects an item in ClipKitty.
+- This behavior is limited to completing a standard paste action into the previously active app and is provided as an accessibility accommodation for users who may have difficulty performing the Cmd+V key combination themselves.
+- If Accessibility permission is not granted, ClipKitty falls back to clipboard-only behavior.
+- Other approved Mac App Store clipboard managers offering the same direct-paste functionality include Maccy ("Paste automatically"), Paste - Limitless Clipboard (sends Command-V to paste current clipboard contents to the active application), ClipBook (programmatically sends Command-V to the currently active application), PasteMe ("Direct Pasting"), and CopyClip 2 - Clipboard Manager ("Paste Directly").
+- These apps are not grandfathered in. They continue to ship App Store updates with this functionality, which shows that direct paste via Accessibility remains acceptable under current review standards for clipboard managers.
+- ClipKitty follows the same pattern: the user explicitly selects an item, ClipKitty writes that item to the system pasteboard, returns focus to the previously active app, and sends Cmd+V only when the user has enabled "To active app."
 - The app has no account system and no login. All data is stored locally by default.
 - Optional iCloud Sync (enabled in Settings) syncs clipboard history across your Mac and iPhone.
 - On first launch, clipboard history will be empty — you need to copy content to populate it.

--- a/distribution/metadata/review_information/notes.txt
+++ b/distribution/metadata/review_information/notes.txt
@@ -7,7 +7,7 @@ HOW TO TEST (macOS):
 3. Click the cat icon in the menu bar, or press ⌥Space (Option+Space).
 4. Your copied items appear in a scrollable list, most recent first.
 5. Use the arrow keys (Up/Down) to navigate items. The right-side preview pane shows full content.
-6. Press Return to use the currently selected paste mode. This dismisses the panel.
+6. On first launch, the default paste mode is "To clipboard." Press Return to copy the selected item to the system clipboard. This dismisses the panel.
 
 OPTIONAL DIRECT PASTE FEATURE (macOS):
 
@@ -27,12 +27,12 @@ HOW TO TEST (iPhone):
 5. Use the search bar (magnifying glass) to find items. Use the filter pill to filter by type (text, images, links, colors).
 
 NOTES:
-- On macOS, "To active app" is an optional, user-controlled setting. It only runs after the user explicitly selects an item in ClipKitty.
-- This behavior is limited to completing a standard paste action into the previously active app and is provided as an accessibility accommodation for users who may have difficulty performing the Cmd+V key combination themselves.
-- If Accessibility permission is not granted, ClipKitty falls back to clipboard-only behavior.
-- Other approved Mac App Store clipboard managers offering the same direct-paste functionality include Maccy ("Paste automatically"), Paste - Limitless Clipboard (sends Command-V to paste current clipboard contents to the active application), ClipBook (programmatically sends Command-V to the currently active application), PasteMe ("Direct Pasting"), and CopyClip 2 - Clipboard Manager ("Paste Directly").
-- These apps are not grandfathered in. They continue to ship App Store updates with this functionality, which shows that direct paste via Accessibility remains acceptable under current review standards for clipboard managers.
-- ClipKitty follows the same pattern: the user explicitly selects an item, ClipKitty writes that item to the system pasteboard, returns focus to the previously active app, and sends Cmd+V only when the user has enabled "To active app."
+- On macOS, the default paste mode is "To clipboard."
+- "To active app" is an optional, user-controlled setting.
+- If Accessibility permission is not granted, ClipKitty continues to work in clipboard-only mode.
+- When "To active app" is enabled, ClipKitty places the user-selected item on the system pasteboard, returns focus to the previously active app, and sends Cmd+V to complete a standard paste action.
+- This feature is provided as an accessibility accommodation for users who may have difficulty performing the Cmd+V key combination themselves.
 - The app has no account system and no login. All data is stored locally by default.
 - Optional iCloud Sync (enabled in Settings) syncs clipboard history across your Mac and iPhone.
 - On first launch, clipboard history will be empty — you need to copy content to populate it.
+- Other Mac App Store clipboard managers that also offer direct paste include Maccy, Paste - Limitless Clipboard, PasteMe - Clipboard Manager, and CopyClip 2 - Clipboard Manager.


### PR DESCRIPTION
## Summary
- default macOS direct paste to `To clipboard` so Accessibility-backed direct paste is explicitly opt-in
- simplify the App Store reviewer notes so they focus on exact testing steps, fallback behavior, and the accessibility rationale
- keep a short note that comparable Mac App Store clipboard apps also offer direct paste

## Testing
- Not run (not requested)
