### PR TITLE
Disable direct paste for RDP apps

### DIFF
--- a/Sources/MacApp/FloatingPanelController.swift
+++ b/Sources/MacApp/FloatingPanelController.swift
@@ -219,6 +219,7 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
         }
         return size
     }
+
     private static let animationScale: CGFloat = 1.05
     private static var animationMargin: CGFloat {
         ceil(max(panelSize.width, panelSize.height) * (animationScale - 1) / 2) + 2

--- a/Sources/MacApp/FloatingPanelController.swift
+++ b/Sources/MacApp/FloatingPanelController.swift
@@ -219,7 +219,6 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
         }
         return size
     }
-
     private static let animationScale: CGFloat = 1.05
     private static var animationMargin: CGFloat {
         ceil(max(panelSize.width, panelSize.height) * (animationScale - 1) / 2) + 2
@@ -359,9 +358,15 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
         store.paste(itemId: itemId, content: content)
         #if ENABLE_SYNTHETIC_PASTE
             let targetApp = hide()
-            if case .autoPaste = AppSettings.shared.pasteMode {
-                activationService.simulatePaste(to: targetApp)
-            } else {
+            switch AppSettings.shared.pasteMode {
+            case .autoPaste:
+                switch activationService.syntheticPasteBehavior(for: targetApp) {
+                case let .paste(targetApp):
+                    activationService.simulatePaste(to: targetApp)
+                case .copyOnly:
+                    snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+                }
+            case .copyOnly, .noPermission:
                 snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
             }
         #else

--- a/Sources/MacPlatform/AppActivationService.swift
+++ b/Sources/MacPlatform/AppActivationService.swift
@@ -1,5 +1,57 @@
 import AppKit
 
+public enum SyntheticPasteBehavior {
+    case copyOnly
+    case paste(targetApp: NSRunningApplication)
+}
+
+enum RemoteDesktopApp: CaseIterable, Equatable {
+    case microsoftRemoteDesktop
+    case royalTSX
+
+    static func detect(bundleIdentifier: String?, localizedName: String?) -> RemoteDesktopApp? {
+        for candidate in allCases {
+            if candidate.matches(bundleIdentifier: bundleIdentifier, localizedName: localizedName) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private func matches(bundleIdentifier: String?, localizedName: String?) -> Bool {
+        switch self {
+        case .microsoftRemoteDesktop:
+            if let bundleIdentifier,
+               bundleIdentifier.hasPrefix("com.microsoft.rdc")
+            {
+                return true
+            }
+            if let localizedName {
+                switch true {
+                case localizedName.localizedCaseInsensitiveContains("Microsoft Remote Desktop"),
+                     localizedName.localizedCaseInsensitiveContains("Windows App"):
+                    return true
+                default:
+                    break
+                }
+            }
+            return false
+        case .royalTSX:
+            if let bundleIdentifier,
+               bundleIdentifier.localizedCaseInsensitiveContains("RoyalTSX")
+            {
+                return true
+            }
+            if let localizedName,
+               localizedName.localizedCaseInsensitiveContains("Royal TSX")
+            {
+                return true
+            }
+            return false
+        }
+    }
+}
+
 @MainActor
 public final class AppActivationService {
     private let workspace: WorkspaceProtocol
@@ -18,10 +70,25 @@ public final class AppActivationService {
     }
 
     #if ENABLE_SYNTHETIC_PASTE
-        public func simulatePaste(to targetApp: NSRunningApplication?) {
+        public func syntheticPasteBehavior(for targetApp: NSRunningApplication?) -> SyntheticPasteBehavior {
             guard let targetApp, !targetApp.isTerminated else {
-                return
+                return .copyOnly
             }
+
+            // RDP clients lazily sync clipboard contents and can leave modifiers stuck
+            // if we immediately synthesize Cmd+V, so fall back to manual paste.
+            if RemoteDesktopApp.detect(
+                bundleIdentifier: targetApp.bundleIdentifier,
+                localizedName: targetApp.localizedName
+            ) != nil {
+                return .copyOnly
+            }
+
+            return .paste(targetApp: targetApp)
+        }
+
+        public func simulatePaste(to targetApp: NSRunningApplication) {
+            guard !targetApp.isTerminated else { return }
 
             Task {
                 for _ in 0 ..< 50 {

--- a/Tests/UnitTests/AppActivationServiceTests.swift
+++ b/Tests/UnitTests/AppActivationServiceTests.swift
@@ -1,0 +1,50 @@
+@testable import ClipKittyMacPlatform
+import XCTest
+
+@MainActor
+final class AppActivationServiceTests: XCTestCase {
+    func testSyntheticPasteFallsBackToCopyOnlyWithoutTargetApp() {
+        let service = AppActivationService(workspace: MockWorkspace())
+
+        switch service.syntheticPasteBehavior(for: nil) {
+        case .copyOnly:
+            break
+        case .paste:
+            XCTFail("Expected nil target app to disable synthetic paste")
+        }
+    }
+
+    func testDetectsRoyalTSXBundleIdentifier() {
+        XCTAssertEqual(
+            RemoteDesktopApp.detect(bundleIdentifier: "com.lemonmojo.RoyalTSX.App", localizedName: nil),
+            .royalTSX
+        )
+    }
+
+    func testDetectsRoyalTSXByLocalizedName() {
+        XCTAssertEqual(
+            RemoteDesktopApp.detect(bundleIdentifier: "com.example.remote", localizedName: "Royal TSX"),
+            .royalTSX
+        )
+    }
+
+    func testDetectsMicrosoftRemoteDesktopBundleIdentifier() {
+        XCTAssertEqual(
+            RemoteDesktopApp.detect(bundleIdentifier: "com.microsoft.rdc.macos", localizedName: nil),
+            .microsoftRemoteDesktop
+        )
+    }
+
+    func testDetectsWindowsAppByLocalizedName() {
+        XCTAssertEqual(
+            RemoteDesktopApp.detect(bundleIdentifier: "com.example.remote", localizedName: "Windows App"),
+            .microsoftRemoteDesktop
+        )
+    }
+
+    func testLeavesRegularAppsEligibleForSyntheticPaste() {
+        XCTAssertNil(
+            RemoteDesktopApp.detect(bundleIdentifier: "com.microsoft.VSCode", localizedName: "Visual Studio Code")
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- disable synthetic direct paste for known RDP clients and fall back to clipboard-only behavior
- detect Royal TSX and Microsoft remote desktop app targets before posting Cmd+V
- add unit coverage for the RDP target detection rules

## Why
Fixes #133.

RDP apps lazily synchronize clipboard updates and can also leave the synthetic Command modifier stuck. For those app targets, copying to the clipboard without sending the direct paste keystroke is the safer behavior.

## Validation
- Local verification was intentionally deferred; CI will verify this branch per request.
