### PR TITLE
Update privacy policy to cover iCloud Sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -590,6 +590,7 @@ jobs:
           fi
 
           cp "$GITHUB_WORKSPACE/icon.png" .
+          cp "$GITHUB_WORKSPACE/privacy.html" .
           cp "$GITHUB_WORKSPACE/marketing/en/screenshot_1.png" marketing_1.png
           cp "$GITHUB_WORKSPACE/marketing/en/screenshot_2.png" marketing_2.png
           cp "$GITHUB_WORKSPACE/marketing/en/screenshot_3.png" marketing_3.png
@@ -615,7 +616,7 @@ jobs:
           # Generate landing page from README.md (cmark-gfm installed via Nix)
           make -C "$GITHUB_WORKSPACE" site-landing-page > index.html
 
-          git add icon.png marketing_1.png marketing_2.png marketing_3.png index.html
+          git add icon.png privacy.html marketing_1.png marketing_2.png marketing_3.png index.html
           git add appcast.xml appcast-state.json 2>/dev/null || true
           git commit -m "Update site, screenshots and icon [skip ci]" || echo "No changes to commit"
           git push origin gh-pages

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Privacy Policy — ClipKitty</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.7;
+    max-width: 680px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+    color: #1d1d1f;
+    background: #fff;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { color: #f5f5f7; background: #1d1d1f; }
+    a { color: #6cb4ee; }
+  }
+  h1 { font-size: 2rem; margin-bottom: 0.25rem; }
+  h2 { font-size: 1.25rem; margin-top: 2rem; margin-bottom: 0.5rem; }
+  p, ul { margin-bottom: 1rem; }
+  ul { padding-left: 1.5rem; }
+  .updated { color: #86868b; font-size: 0.875rem; margin-bottom: 2rem; }
+  a { color: #0071e3; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid #d2d2d7; font-size: 0.875rem; color: #86868b; }
+</style>
+</head>
+<body>
+
+<h1>Privacy Policy</h1>
+<p class="updated">Last updated: April 20, 2026</p>
+
+<p>ClipKitty is a clipboard history manager for macOS built by Juliette Pluto. This policy explains how ClipKitty handles your data.</p>
+
+<h2>The short version</h2>
+<p>ClipKitty does not collect, transmit, or share your data with the developer or any third party. Everything stays on your Mac &mdash; unless you choose to turn on the optional iCloud Sync feature, which stores a copy of your clipboard history in your own private iCloud account so it can be shared across your Apple devices.</p>
+
+<h2>Data storage</h2>
+<p>ClipKitty stores your clipboard history (text, images, links, files, and colors) in a local database on your Mac at:</p>
+<p><code>~/Library/Application Support/ClipKitty/</code></p>
+<p>This data never leaves your device unless you enable iCloud Sync (see below). ClipKitty does not operate any server-side component.</p>
+
+<h2>iCloud Sync (optional)</h2>
+<p>iCloud Sync is <strong>off by default</strong> and must be enabled manually in ClipKitty's settings. When enabled, ClipKitty uses Apple's CloudKit framework to synchronize your clipboard history between devices signed in to the same Apple Account.</p>
+<ul>
+  <li>Your synced clipboard data is stored in the <strong>private CloudKit database</strong> of your own iCloud account. It is only accessible to you and your signed-in devices.</li>
+  <li>Sync traffic goes directly between your devices and Apple's servers. It does <strong>not</strong> pass through any server operated by ClipKitty or its developer, and the developer has no access to your synced data.</li>
+  <li>Your use of iCloud Sync is additionally governed by <a href="https://www.apple.com/legal/privacy/">Apple's Privacy Policy</a> and your iCloud terms.</li>
+  <li>Content filtering rules (excluded apps, "Don't save passwords", and "Don't save temporary data") apply before sync, so filtered items are never uploaded.</li>
+  <li>You can turn off iCloud Sync at any time from ClipKitty's settings. To remove data already stored in iCloud, delete the items in ClipKitty (deletions propagate to your other devices), remove ClipKitty's data from your iCloud storage in System Settings, or sign out of iCloud.</li>
+</ul>
+
+<h2>Data collection</h2>
+<p>ClipKitty collects <strong>no data whatsoever</strong>:</p>
+<ul>
+  <li>No analytics or usage tracking</li>
+  <li>No crash reports sent externally</li>
+  <li>No telemetry</li>
+  <li>No advertising identifiers</li>
+  <li>No personal information</li>
+</ul>
+
+<h2>Network access</h2>
+<p>ClipKitty makes outbound network requests only for:</p>
+<ul>
+  <li><strong>Link previews</strong>: fetching metadata (titles and icons) for URLs in your clipboard history via Apple's LinkPresentation framework.</li>
+  <li><strong>iCloud Sync</strong> (when you enable it): communicating with Apple's CloudKit service to sync your clipboard history between your own devices.</li>
+</ul>
+<p>No clipboard content is sent to any server controlled by ClipKitty.</p>
+
+<h2>Clipboard access</h2>
+<p>ClipKitty monitors the macOS system clipboard to record items you copy. It respects concealed clipboard items (e.g. passwords from password managers) and skips them automatically.</p>
+
+<h2>Third-party services</h2>
+<p>ClipKitty does not integrate with any third-party analytics, advertising, or tracking services. When you enable iCloud Sync, ClipKitty relies on Apple's iCloud and CloudKit services to move data between your own devices.</p>
+
+<h2>Data deletion</h2>
+<p>You can delete your entire clipboard history at any time from the Settings screen, by removing the ClipKitty data directory, or by uninstalling the app. If iCloud Sync is enabled, deletions made in ClipKitty propagate to your other signed-in devices. To remove clipboard data stored in iCloud independently, you can disable iCloud Sync, manage ClipKitty's data in your Apple Account's iCloud storage, or sign out of iCloud.</p>
+
+<h2>Children's privacy</h2>
+<p>ClipKitty does not knowingly collect any information from anyone, including children under 13.</p>
+
+<h2>Changes to this policy</h2>
+<p>If this policy changes, the updated version will be published at this URL with a new "Last updated" date.</p>
+
+<h2>Contact</h2>
+<p>Questions about this privacy policy can be directed to <a href="mailto:apple@jul.sh">apple@jul.sh</a>.</p>
+
+<footer>
+  <p>&copy; 2025&ndash;2026 Juliette Pluto &middot; <a href="https://github.com/jul-sh/clipkitty">GitHub</a></p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
Adds a new "iCloud Sync (optional)" section explaining that sync is
off by default, uses the user's private CloudKit database, does not
pass through any developer-operated server, and honors local content
filtering rules. Also updates the short version, data storage,
network access, third-party services, and data deletion sections so
the document reflects what iCloud Sync implies.

Moves privacy.html into version control at the repo root (previously
only present on gh-pages) and copies it into the gh-pages deploy so
future updates ship via the normal build workflow.

