### PR TITLE
Fix settings shortcut to open only the real settings window

### DIFF
--- a/Sources/MacApp/AppDelegate.swift
+++ b/Sources/MacApp/AppDelegate.swift
@@ -104,7 +104,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(openSettings),
+            selector: #selector(handleOpenSettingsNotification(_:)),
             name: .clipKittyOpenSettings,
             object: nil
         )
@@ -239,6 +239,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc private func showPanel() {
         panelController.show()
+    }
+
+    @objc private func handleOpenSettingsNotification(_: Notification) {
+        openSettings()
     }
 
     @objc private func openSettings() {

--- a/Sources/MacApp/ClipKittyApp.swift
+++ b/Sources/MacApp/ClipKittyApp.swift
@@ -5,28 +5,21 @@ extension Notification.Name {
     static let clipKittyOpenSettings = Notification.Name("ClipKittyOpenSettings")
 }
 
-// The real settings window is managed by AppDelegate; this placeholder forwards
-// the ⌘, shortcut that macOS routes to the SwiftUI Settings scene.
-private struct SettingsShortcutForwarder: NSViewRepresentable {
-    func makeNSView(context _: Context) -> NSView {
-        let view = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
-        DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .clipKittyOpenSettings, object: nil)
-            view.window?.close()
-        }
-        return view
-    }
-
-    func updateNSView(_: NSView, context _: Context) {}
-}
-
 @main
 struct ClipKittyApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
         Settings {
-            SettingsShortcutForwarder()
+            EmptyView()
+        }
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button(NSLocalizedString("Settings...", comment: "Command menu item to open settings window")) {
+                    NotificationCenter.default.post(name: .clipKittyOpenSettings, object: nil)
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
         }
     }
 }

--- a/Tests/UITests/ClipKittyUITests.swift
+++ b/Tests/UITests/ClipKittyUITests.swift
@@ -1563,14 +1563,19 @@ final class ClipKittyUITests: XCTestCase {
 
     /// Tests that the Settings window opens without crashing and all tabs are accessible.
     func testSettingsWindowOpensAllTabs() {
-        // Hide the panel first so settings isn't overlaid
-        app.typeKey(.escape, modifierFlags: [])
-        Thread.sleep(forTimeInterval: 0.5)
+        let baselineVisibleWindowCount = app.windows.allElementsBoundByIndex
+            .filter { $0.exists && $0.isHittable }
+            .count
 
-        // Open settings via Cmd+,
+        // Open settings via Cmd+, even if the ClipKitty panel is already showing.
         app.typeKey(",", modifierFlags: .command)
         let settingsWindow = app.windows["ClipKitty Settings"]
         XCTAssertTrue(settingsWindow.waitForExistence(timeout: 5), "Settings window should appear")
+        let expectedVisibleWindowCount = baselineVisibleWindowCount + 1
+        let expectedWindowCountShown = waitForCondition(timeout: 3) {
+            self.app.windows.allElementsBoundByIndex.filter { $0.exists && $0.isHittable }.count == expectedVisibleWindowCount
+        }
+        XCTAssertTrue(expectedWindowCountShown, "Cmd+, should add only the real settings window")
 
         // General tab should be visible by default
         let generalTab = settingsWindow.buttons["SettingsTab_General"]
@@ -1604,6 +1609,13 @@ final class ClipKittyUITests: XCTestCase {
             generalTabNav.click()
             Thread.sleep(forTimeInterval: 0.5)
         }
+
+        // Trigger Cmd+, again to ensure it refocuses the same window instead of spawning another one.
+        app.typeKey(",", modifierFlags: .command)
+        let stillExpectedWindowCountShown = waitForCondition(timeout: 3) {
+            self.app.windows.allElementsBoundByIndex.filter { $0.exists && $0.isHittable }.count == expectedVisibleWindowCount
+        }
+        XCTAssertTrue(stillExpectedWindowCountShown, "Cmd+, should keep reusing the same settings window")
 
         // Verify the settings window is still alive (didn't crash)
         XCTAssertTrue(settingsWindow.exists, "Settings window should still exist after tab navigation")


### PR DESCRIPTION
## Summary
- replace the placeholder SwiftUI settings forwarder with a real `appSettings` command bound to `Cmd+,`
- route the settings notification through a dedicated AppDelegate handler that opens the existing AppKit settings window
- update the macOS UI test to verify `Cmd+,` works while the ClipKitty window is visible and reuses the same settings window

## Testing
- Not run (not requested)