### PR TITLE
Fix settings window activation after Cmd+,

### DIFF
--- a/Sources/MacApp/AppDelegate.swift
+++ b/Sources/MacApp/AppDelegate.swift
@@ -286,6 +286,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
 
         NSApp.setActivationPolicy(.regular)
+        panelController.hideForAppWindow()
         settingsWindow?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }

--- a/Sources/MacApp/FloatingPanelController.swift
+++ b/Sources/MacApp/FloatingPanelController.swift
@@ -23,6 +23,11 @@ private enum PanelState: Equatable {
     }
 }
 
+private enum PanelDismissalDestination {
+    case previousApplication
+    case appWindow
+}
+
 @MainActor
 final class FloatingPanelController: NSObject, NSWindowDelegate {
     private var panel: NSPanel!
@@ -299,6 +304,15 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
 
     @discardableResult
     func hide() -> NSRunningApplication? {
+        hide(destination: .previousApplication)
+    }
+
+    func hideForAppWindow() {
+        hide(destination: .appWindow)
+    }
+
+    @discardableResult
+    private func hide(destination: PanelDismissalDestination) -> NSRunningApplication? {
         snackbarObservationTask?.cancel()
         snackbarObservationTask = nil
         snackbarWindow.panelDidHide()
@@ -338,7 +352,12 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
         CATransaction.commit()
 
         panelState = .hidden
-        activationService.activate(previousApp)
+        switch destination {
+        case .previousApplication:
+            activationService.activate(previousApp)
+        case .appWindow:
+            break
+        }
         return previousApp
     }
 

--- a/Tests/UITests/ClipKittyUITests.swift
+++ b/Tests/UITests/ClipKittyUITests.swift
@@ -1563,19 +1563,18 @@ final class ClipKittyUITests: XCTestCase {
 
     /// Tests that the Settings window opens without crashing and all tabs are accessible.
     func testSettingsWindowOpensAllTabs() {
-        let baselineVisibleWindowCount = app.windows.allElementsBoundByIndex
-            .filter { $0.exists && $0.isHittable }
-            .count
-
         // Open settings via Cmd+, even if the ClipKitty panel is already showing.
         app.typeKey(",", modifierFlags: .command)
         let settingsWindow = app.windows["ClipKitty Settings"]
         XCTAssertTrue(settingsWindow.waitForExistence(timeout: 5), "Settings window should appear")
-        let expectedVisibleWindowCount = baselineVisibleWindowCount + 1
-        let expectedWindowCountShown = waitForCondition(timeout: 3) {
-            self.app.windows.allElementsBoundByIndex.filter { $0.exists && $0.isHittable }.count == expectedVisibleWindowCount
+        let settingsWindowIsTopmost = waitForCondition(timeout: 3) {
+            settingsWindow.isHittable
         }
-        XCTAssertTrue(expectedWindowCountShown, "Cmd+, should add only the real settings window")
+        XCTAssertTrue(settingsWindowIsTopmost, "Settings window should be topmost and interactable")
+        let singleVisibleWindowShown = waitForCondition(timeout: 3) {
+            self.app.windows.allElementsBoundByIndex.filter { $0.exists && $0.isHittable }.count == 1
+        }
+        XCTAssertTrue(singleVisibleWindowShown, "Cmd+, should leave only the real settings window visible")
 
         // General tab should be visible by default
         let generalTab = settingsWindow.buttons["SettingsTab_General"]
@@ -1612,10 +1611,10 @@ final class ClipKittyUITests: XCTestCase {
 
         // Trigger Cmd+, again to ensure it refocuses the same window instead of spawning another one.
         app.typeKey(",", modifierFlags: .command)
-        let stillExpectedWindowCountShown = waitForCondition(timeout: 3) {
-            self.app.windows.allElementsBoundByIndex.filter { $0.exists && $0.isHittable }.count == expectedVisibleWindowCount
+        let stillSingleVisibleWindowShown = waitForCondition(timeout: 3) {
+            self.app.windows.allElementsBoundByIndex.filter { $0.exists && $0.isHittable }.count == 1
         }
-        XCTAssertTrue(stillExpectedWindowCountShown, "Cmd+, should keep reusing the same settings window")
+        XCTAssertTrue(stillSingleVisibleWindowShown, "Cmd+, should keep reusing the same settings window")
 
         // Verify the settings window is still alive (didn't crash)
         XCTAssertTrue(settingsWindow.exists, "Settings window should still exist after tab navigation")


### PR DESCRIPTION
## Summary
- Route `Cmd+,` through the SwiftUI commands menu instead of the placeholder Settings scene.
- Add a dedicated panel dismissal path for app-window transitions so opening Settings does not reactivate the previously frontmost app.
- Update the macOS UI test to open Settings while the panel is still visible and verify the settings window is topmost and reused.

## Testing
- Not run (not requested)