### PR TITLE
Fix eager list decoration for initial short trigram results

### DIFF
--- a/purr/src/search_result_builder.rs
+++ b/purr/src/search_result_builder.rs
@@ -13,8 +13,8 @@ use tokio_util::sync::CancellationToken;
 const EAGER_MATCH_DATA_COUNT: usize = 1;
 /// Content length threshold for "short" items that get eager row decoration.
 const SHORT_CONTENT_THRESHOLD: usize = 1024;
-/// Skip eager short-item decoration when results exceed this count.
-const EAGER_SHORT_RESULT_LIMIT: usize = 0;
+/// Number of early short-content results to eagerly decorate.
+const EAGER_SHORT_MATCH_WINDOW: usize = 24;
 const SHORT_QUERY_MAX_RESULTS: usize = 50;
 const SHORT_QUERY_RECENT_WINDOW: usize = 5000;
 const SHORT_QUERY_CONTENT_CAP: usize = 512;
@@ -212,7 +212,6 @@ impl<'a> SearchResultAssembler<'a> {
             .map(|metadata| (metadata.item_metadata.item_id.clone(), metadata))
             .collect();
 
-        let few_results = metadata_map.len() <= EAGER_SHORT_RESULT_LIMIT;
         let presentation = self.presentation();
         #[cfg(test)]
         crate::match_presentation::test_support::before_eager_matches();
@@ -242,7 +241,9 @@ impl<'a> SearchResultAssembler<'a> {
                 self.presentation,
             );
             let is_short = candidate.content().len() <= SHORT_CONTENT_THRESHOLD;
-            let item_match = if eager_index < EAGER_MATCH_DATA_COUNT || (is_short && few_results) {
+            let item_match = if eager_index < EAGER_MATCH_DATA_COUNT
+                || (is_short && eager_index < EAGER_SHORT_MATCH_WINDOW)
+            {
                 #[cfg(test)]
                 crate::match_presentation::test_support::on_eager_match(eager_index);
                 if self.token.is_cancelled() {

--- a/purr/tests/snippet_tests.rs
+++ b/purr/tests/snippet_tests.rs
@@ -73,6 +73,33 @@ async fn list_decoration_short_text_returns_full_content() {
 }
 
 #[tokio::test]
+async fn trigram_search_eagerly_decorates_initial_short_results() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let store = ClipboardStore::new(db_path.to_str().unwrap().to_string()).unwrap();
+
+    for index in 0..3 {
+        store
+            .save_text(format!("needle result {index}"), None, None)
+            .unwrap();
+    }
+
+    let result = store
+        .search("needle".to_string(), ListPresentationProfile::CompactRow)
+        .await
+        .unwrap();
+
+    assert_eq!(result.matches.len(), 3);
+    assert!(
+        result
+            .matches
+            .iter()
+            .all(|item| item.list_decoration.is_some()),
+        "expected every short initial trigram match to be eagerly decorated"
+    );
+}
+
+#[tokio::test]
 async fn list_decoration_normalizes_whitespace() {
     let row = list_decoration_for("Hello\n\n\nWorld", "Hello").await;
     assert_eq!(row.text, "Hello World");


### PR DESCRIPTION
## Summary
- Eagerly decorate the first window of short trigram matches instead of gating on a disabled zero-result limit
- Keep the first result eagerly decorated and bound the rest with a small short-match window
- Add a regression test covering multiple short trigram matches

## Testing
- `cargo fmt -p purr`
- `cargo test -p purr --test snippet_tests -- --nocapture`