### PR TITLE
Refactor row excerpts into explicit presentation states

### DIFF
--- a/Sources/MacApp/Browser/BrowserRenderingSupport.swift
+++ b/Sources/MacApp/Browser/BrowserRenderingSupport.swift
@@ -1219,7 +1219,7 @@ private enum RowIconCache {
 
 struct ItemRow: View {
     let metadata: ItemMetadata
-    let listDecoration: ListDecoration?
+    let presentation: RowPresentation
     let isSelected: Bool
     let isContextMenuTargeted: Bool
     let hasUserNavigated: Bool
@@ -1240,18 +1240,25 @@ struct ItemRow: View {
 
     // MARK: - Display Text (Simplified - SwiftUI handles truncation)
 
-    /// Text to display - uses matchData.text if in search mode, otherwise metadata.snippet
-    /// SwiftUI's Three-Part HStack handles truncation with proper ellipsis via layout priorities
-    private var displayText: String {
-        if let rowText = listDecoration?.text, !rowText.isEmpty {
-            return rowText
+    private var displayExcerpt: (text: String, highlights: [Utf16HighlightRange], lineNumber: UInt64?) {
+        switch presentation {
+        case let .baseline(excerpt):
+            return (excerpt.text, [], nil)
+        case let .search(searchPresentation):
+            switch searchPresentation {
+            case let .ready(excerpt):
+                return (excerpt.text, excerpt.highlights, excerpt.lineNumber)
+            case let .deferred(_, placeholder):
+                switch placeholder {
+                case let .baseline(excerpt), let .provisional(excerpt):
+                    return (excerpt.text, [], nil)
+                case let .compatibleCached(_, excerpt):
+                    return (excerpt.text, excerpt.highlights, excerpt.lineNumber)
+                }
+            case let .unavailable(fallback, _):
+                return (fallback.text, [], nil)
+            }
         }
-        return metadata.snippet
-    }
-
-    /// Highlights for display - passed directly from Rust (already adjusted for normalization)
-    private var displayHighlights: [Utf16HighlightRange] {
-        listDecoration?.highlights ?? []
     }
 
     private var showsSourceAppBadge: Bool {
@@ -1334,7 +1341,7 @@ struct ItemRow: View {
                 .allowsHitTesting(false)
 
                 // Line number (shown in search mode when line > 1)
-                if let lineNumber = listDecoration?.lineNumber, lineNumber > 1 {
+                if let lineNumber = displayExcerpt.lineNumber, lineNumber > 1 {
                     Text("L\(lineNumber):")
                         .font(.custom(FontManager.mono, size: 13))
                         .foregroundColor(accentSelected ? .white.opacity(0.7) : .secondary)
@@ -1346,8 +1353,8 @@ struct ItemRow: View {
                 // Text content - SwiftUI Three-Part HStack with layout priorities
                 HStack(spacing: 6) {
                     HighlightedTextView(
-                        text: displayText,
-                        highlights: displayHighlights,
+                        text: displayExcerpt.text,
+                        highlights: displayExcerpt.highlights,
                         accentSelected: accentSelected,
                         textScale: AppSettings.shared.textScale
                     )
@@ -1395,7 +1402,7 @@ struct ItemRow: View {
             )
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(displayText)
+        .accessibilityLabel(displayExcerpt.text)
         .accessibilityHint(AppSettings.shared.pasteMode == .autoPaste ? String(localized: "Double tap to paste") : String(localized: "Double tap to copy"))
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(isSelected ? .isSelected : [])

--- a/Sources/MacApp/Browser/BrowserRenderingSupport.swift
+++ b/Sources/MacApp/Browser/BrowserRenderingSupport.swift
@@ -1244,20 +1244,17 @@ struct ItemRow: View {
         switch presentation {
         case let .baseline(excerpt):
             return (excerpt.text, [], nil)
-        case let .search(searchPresentation):
-            switch searchPresentation {
-            case let .ready(excerpt):
+        case let .matched(excerpt):
+            return (excerpt.text, excerpt.highlights, excerpt.lineNumber)
+        case let .deferred(_, placeholder):
+            switch placeholder {
+            case let .baseline(excerpt), let .provisional(excerpt):
+                return (excerpt.text, [], nil)
+            case let .compatibleCached(_, excerpt):
                 return (excerpt.text, excerpt.highlights, excerpt.lineNumber)
-            case let .deferred(_, placeholder):
-                switch placeholder {
-                case let .baseline(excerpt), let .provisional(excerpt):
-                    return (excerpt.text, [], nil)
-                case let .compatibleCached(_, excerpt):
-                    return (excerpt.text, excerpt.highlights, excerpt.lineNumber)
-                }
-            case let .unavailable(fallback, _):
-                return (fallback.text, [], nil)
             }
+        case let .unavailable(fallback, _):
+            return (fallback.text, [], nil)
         }
     }
 

--- a/Sources/MacApp/Browser/BrowserResultsList.swift
+++ b/Sources/MacApp/Browser/BrowserResultsList.swift
@@ -17,7 +17,7 @@ struct BrowserResultsList: View {
                 ForEach(Array(viewModel.displayRows.enumerated()), id: \.element.metadata.itemId) { index, row in
                     ItemRow(
                         metadata: row.metadata,
-                        listDecoration: row.listDecoration,
+                        presentation: row.presentation,
                         isSelected: row.metadata.itemId == viewModel.selectedItemId,
                         isContextMenuTargeted: row.metadata.itemId == contextMenuItemId,
                         hasUserNavigated: viewModel.hasUserNavigated,
@@ -116,6 +116,6 @@ struct BrowserResultsList: View {
         let idsToLoad = (startIndex ... endIndex).compactMap { idx in
             viewModel.itemIds.indices.contains(idx) ? viewModel.itemIds[idx] : nil
         }
-        viewModel.loadListDecorationsForItems(idsToLoad)
+        viewModel.loadMatchedExcerptsForItems(idsToLoad)
     }
 }

--- a/Sources/MacApp/Browser/BrowserStoreClient.swift
+++ b/Sources/MacApp/Browser/BrowserStoreClient.swift
@@ -53,8 +53,8 @@ final class ClipboardStoreBrowserClient: BrowserStoreClient {
         await store.fetchItem(id: id)
     }
 
-    func loadListDecorations(itemIds: [String], query: String, presentation: ListPresentationProfile) async -> [ListDecorationResult] {
-        await store.loadListDecorations(itemIds: itemIds, query: query, presentation: presentation)
+    func resolveMatchedExcerpts(requests: [MatchedExcerptRequest]) async -> [MatchedExcerptResolution] {
+        await store.resolveMatchedExcerpts(requests: requests)
     }
 
     func loadPreviewPayload(itemId: String, query: String) async -> PreviewPayload? {

--- a/Sources/MacApp/ClipboardStore.swift
+++ b/Sources/MacApp/ClipboardStore.swift
@@ -397,9 +397,9 @@ final class ClipboardStore {
         return await previewLoader.fetchItem(id: id)
     }
 
-    func loadListDecorations(itemIds: [String], query: String, presentation: ListPresentationProfile) async -> [ListDecorationResult] {
+    func resolveMatchedExcerpts(requests: [MatchedExcerptRequest]) async -> [MatchedExcerptResolution] {
         guard let repository else { return [] }
-        return await repository.computeListDecorations(itemIds: itemIds, query: query, presentation: presentation)
+        return await repository.resolveMatchedExcerpts(requests: requests)
     }
 
     func loadPreviewPayload(itemId: String, query: String) async -> PreviewPayload? {

--- a/Sources/Shared/BrowserSession.swift
+++ b/Sources/Shared/BrowserSession.swift
@@ -102,15 +102,15 @@ public struct LoadedBrowserContent {
 
 public struct DisplayRow: Equatable, Identifiable {
     public let metadata: ItemMetadata
-    public let listDecoration: ListDecoration?
+    public let presentation: RowPresentation
 
     public var id: String {
         metadata.itemId
     }
 
-    public init(metadata: ItemMetadata, listDecoration: ListDecoration?) {
+    public init(metadata: ItemMetadata, presentation: RowPresentation) {
         self.metadata = metadata
-        self.listDecoration = listDecoration
+        self.presentation = presentation
     }
 }
 

--- a/Sources/Shared/BrowserStoreClient.swift
+++ b/Sources/Shared/BrowserStoreClient.swift
@@ -18,7 +18,7 @@ public protocol BrowserStoreClient: AnyObject {
     var listPresentationProfile: ListPresentationProfile { get }
     func startSearch(request: SearchRequest) -> BrowserSearchOperation
     func fetchItem(id: String) async -> ClipboardItem?
-    func loadListDecorations(itemIds: [String], query: String, presentation: ListPresentationProfile) async -> [ListDecorationResult]
+    func resolveMatchedExcerpts(requests: [MatchedExcerptRequest]) async -> [MatchedExcerptResolution]
     func loadPreviewPayload(itemId: String, query: String) async -> PreviewPayload?
     #if ENABLE_LINK_PREVIEWS
     func fetchLinkMetadata(url: String, itemId: String) async -> ClipboardItem?

--- a/Sources/Shared/BrowserViewModel.swift
+++ b/Sources/Shared/BrowserViewModel.swift
@@ -1541,14 +1541,9 @@ public final class BrowserViewModel {
         }
         guard resolvedMatchedExcerptsByItemId[itemId] == nil else { return nil }
         switch displayRows[index].presentation {
-        case let .search(searchPresentation):
-            switch searchPresentation {
-            case let .deferred(request, _):
-                return request
-            case .ready, .unavailable:
-                return nil
-            }
-        case .baseline:
+        case let .deferred(request, _):
+            return request
+        case .baseline, .matched, .unavailable:
             return nil
         }
     }
@@ -1823,14 +1818,9 @@ public final class BrowserViewModel {
     private func presentationApplyingResolvedExcerpt(_ presentation: RowPresentation, itemId: String) -> RowPresentation {
         guard let excerpt = resolvedMatchedExcerptsByItemId[itemId] else { return presentation }
         switch presentation {
-        case let .search(searchPresentation):
-            switch searchPresentation {
-            case .deferred:
-                return .search(presentation: .ready(excerpt: excerpt))
-            case .ready, .unavailable:
-                return presentation
-            }
-        case .baseline:
+        case .deferred:
+            return .matched(excerpt: excerpt)
+        case .baseline, .matched, .unavailable:
             return presentation
         }
     }

--- a/Sources/Shared/BrowserViewModel.swift
+++ b/Sources/Shared/BrowserViewModel.swift
@@ -71,7 +71,7 @@ public final class BrowserViewModel {
     #if ENABLE_LINK_PREVIEWS
         private var metadataTask: Task<Void, Never>?
     #endif
-    private var listDecorationTasks: [String: Task<Void, Never>] = [:]
+    private var matchedExcerptTasks: [String: Task<Void, Never>] = [:]
     private var pendingDeleteTask: Task<Void, Never>?
     private var pendingTagSettleTask: Task<Void, Never>?
     private var queryGeneration = 0
@@ -88,7 +88,7 @@ public final class BrowserViewModel {
     public private(set) var overlayState: OverlayState = .none
     public private(set) var mutationState: MutationState = .idle
     public private(set) var editSession: PreviewEditSession = .inactive
-    public private(set) var listDecorationsByItemId: [String: ListDecoration] = [:]
+    public private(set) var resolvedMatchedExcerptsByItemId: [String: MatchedExcerpt] = [:]
     private var previewPayloadsByItemId: [String: PreviewPayload] = [:]
     public private(set) var hasUserNavigated = false
     public private(set) var prefetchCache: [String: ClipboardItem] = [:]
@@ -207,8 +207,8 @@ public final class BrowserViewModel {
             metadataTask?.cancel()
             metadataTask = nil
         #endif
-        listDecorationTasks.values.forEach { $0.cancel() }
-        listDecorationTasks.removeAll()
+        matchedExcerptTasks.values.forEach { $0.cancel() }
+        matchedExcerptTasks.removeAll()
         pendingDeleteTask?.cancel()
         pendingDeleteTask = nil
         pendingTagSettleTask?.cancel()
@@ -224,7 +224,7 @@ public final class BrowserViewModel {
         hasUserNavigated = false
         prefetchCache.removeAll()
         previewPayloadsByItemId.removeAll()
-        listDecorationsByItemId.removeAll()
+        resolvedMatchedExcerptsByItemId.removeAll()
         overlayState = .none
         mutationState = .idle
         editSession = .inactive
@@ -355,42 +355,48 @@ public final class BrowserViewModel {
         performItemAction(itemId: itemId, handler: onCopyOnly)
     }
 
-    public func loadListDecorationsForItems(_ ids: [String]) {
+    public func loadMatchedExcerptsForItems(_ ids: [String]) {
         guard displayedContent != nil else { return }
         let request = contentState.request
-        guard !request.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
         let uniqueIds = Array(Set(ids)).sorted()
         guard !uniqueIds.isEmpty else { return }
 
-        let itemIdsNeedingDecoration = uniqueIds.filter { listDecoration(for: $0) == nil }
-        guard !itemIdsNeedingDecoration.isEmpty else { return }
+        let excerptRequests = uniqueIds.compactMap { deferredMatchedExcerptRequest(for: $0) }
+        guard !excerptRequests.isEmpty else { return }
 
         let generation = queryGeneration
-        let key = "\(generation)|\(request.text)|\(itemIdsNeedingDecoration.joined(separator: ","))"
-        guard listDecorationTasks[key] == nil else { return }
+        let requestSignature = excerptRequests
+            .map { "\($0.itemId)|\($0.query)|\($0.contentHash)|\($0.presentationProfile)" }
+            .joined(separator: ",")
+        let key = "\(generation)|\(requestSignature)"
+        guard matchedExcerptTasks[key] == nil else { return }
 
-        listDecorationTasks[key] = Task { [weak self] in
+        matchedExcerptTasks[key] = Task { [weak self] in
             guard let self else { return }
-            let results = await self.client.loadListDecorations(itemIds: itemIdsNeedingDecoration, query: request.text, presentation: self.client.listPresentationProfile)
+            let results = await self.client.resolveMatchedExcerpts(requests: excerptRequests)
             await MainActor.run {
-                defer { self.listDecorationTasks[key] = nil }
+                defer { self.matchedExcerptTasks[key] = nil }
                 guard self.queryGeneration == generation,
                       self.contentState.request == request
                 else {
                     return
                 }
 
-                var updates: [String: ListDecoration] = [:]
+                var updates: [String: MatchedExcerpt] = [:]
                 for result in results {
-                    guard let decoration = result.decoration else { continue }
-                    guard self.indexOfItem(result.itemId) != nil else { continue }
-                    guard self.listDecoration(for: result.itemId) == nil else { continue }
-                    updates[result.itemId] = decoration
+                    switch result {
+                    case let .ready(itemId, excerpt):
+                        guard self.indexOfItem(itemId) != nil else { continue }
+                        guard self.deferredMatchedExcerptRequest(for: itemId) != nil else { continue }
+                        updates[itemId] = excerpt
+                    case .unavailable:
+                        continue
+                    }
                 }
 
                 guard !updates.isEmpty else { return }
-                self.listDecorationsByItemId.merge(updates) { existing, _ in existing }
+                self.resolvedMatchedExcerptsByItemId.merge(updates) { existing, _ in existing }
                 self.rebuildDisplayedRows()
             }
         }
@@ -468,7 +474,7 @@ public final class BrowserViewModel {
                 totalCount: 0
             )
         ))
-        listDecorationsByItemId.removeAll()
+        resolvedMatchedExcerptsByItemId.removeAll()
         rebuildDisplayedRows()
         previewPayloadsByItemId.removeAll()
         prefetchCache.removeAll()
@@ -558,11 +564,10 @@ public final class BrowserViewModel {
 
         let currentItem = selectedItemState.item
         let updatedContent = ClipboardContent.text(value: editedText)
-        let updatedSnippet = client.formatExcerpt(content: editedText)
+        let updatedExcerpt = BaselineExcerpt(text: client.formatExcerpt(content: editedText))
         let updatedMetadata = ItemMetadata(
             itemId: currentItem.itemMetadata.itemId,
             icon: currentItem.itemMetadata.icon,
-            snippet: updatedSnippet,
             sourceApp: currentItem.itemMetadata.sourceApp,
             sourceAppBundleId: currentItem.itemMetadata.sourceAppBundleId,
             timestampUnix: currentItem.itemMetadata.timestampUnix,
@@ -580,11 +585,12 @@ public final class BrowserViewModel {
         updateDisplayedResponseForItem(
             itemId: id,
             updatedMetadata: updatedMetadata,
-            updatedFirstItem: updatedItem
+            updatedFirstItem: updatedItem,
+            updatedPresentation: .baseline(excerpt: updatedExcerpt)
         )
 
         // Invalidate stale decoration caches for this item
-        listDecorationsByItemId.removeValue(forKey: id)
+        resolvedMatchedExcerptsByItemId.removeValue(forKey: id)
         previewPayloadsByItemId[id] = PreviewPayload(item: updatedItem, decoration: nil)
 
         showSnackbarNotification(.passive(message: String(localized: "Saved"), iconSystemName: "checkmark.circle.fill"), nil)
@@ -667,10 +673,10 @@ public final class BrowserViewModel {
         hasUserNavigated = false
         prefetchCache.removeAll()
         previewPayloadsByItemId.removeAll()
-        listDecorationsByItemId.removeAll()
+        resolvedMatchedExcerptsByItemId.removeAll()
         searchExecution.cancel()
-        listDecorationTasks.values.forEach { $0.cancel() }
-        listDecorationTasks.removeAll()
+        matchedExcerptTasks.values.forEach { $0.cancel() }
+        matchedExcerptTasks.removeAll()
 
         if displayedContent?.response.request != request {
             setDisplayedSelection(selectionDuringSearchTransition(to: request))
@@ -1117,7 +1123,6 @@ public final class BrowserViewModel {
                     let mergedPreviewMetadata = ItemMetadata(
                         itemId: updatedItem.itemMetadata.itemId,
                         icon: updatedItem.itemMetadata.icon,
-                        snippet: updatedItem.itemMetadata.snippet,
                         sourceApp: updatedItem.itemMetadata.sourceApp,
                         sourceAppBundleId: updatedItem.itemMetadata.sourceAppBundleId,
                         timestampUnix: updatedItem.itemMetadata.timestampUnix,
@@ -1138,7 +1143,10 @@ public final class BrowserViewModel {
                     self.updateDisplayedResponseForItem(
                         itemId: updatedItem.itemMetadata.itemId,
                         updatedMetadata: mergedPreviewMetadata,
-                        updatedFirstItem: mergedPreviewItem
+                        updatedFirstItem: mergedPreviewItem,
+                        updatedPresentation: self.currentResponse?.items.first {
+                            $0.itemMetadata.itemId == updatedItem.itemMetadata.itemId
+                        }?.presentation ?? .baseline(excerpt: BaselineExcerpt(text: ""))
                     )
                 }
             }
@@ -1201,7 +1209,7 @@ public final class BrowserViewModel {
     private func applyOptimisticDelete(itemId: String) {
         guard let response = currentResponse else { return }
         let filteredItems = response.items.filter { $0.itemMetadata.itemId != itemId }
-        listDecorationsByItemId.removeValue(forKey: itemId)
+        resolvedMatchedExcerptsByItemId.removeValue(forKey: itemId)
         previewPayloadsByItemId.removeValue(forKey: itemId)
         prefetchCache.removeValue(forKey: itemId)
         let deletedSelectedItem = selectedItemId == itemId
@@ -1469,13 +1477,13 @@ public final class BrowserViewModel {
                activeTag == tag,
                !updatedMetadata.tags.contains(tag)
             {
-                listDecorationsByItemId.removeValue(forKey: itemMatch.itemMetadata.itemId)
+                resolvedMatchedExcerptsByItemId.removeValue(forKey: itemMatch.itemMetadata.itemId)
                 previewPayloadsByItemId.removeValue(forKey: itemMatch.itemMetadata.itemId)
                 prefetchCache.removeValue(forKey: itemMatch.itemMetadata.itemId)
                 return nil
             }
 
-            return ItemMatch(itemMetadata: updatedMetadata, listDecoration: itemMatch.listDecoration)
+            return ItemMatch(itemMetadata: updatedMetadata, presentation: itemMatch.presentation)
         }
 
         let updatedFirstPreviewPayload = response.firstPreviewPayload.flatMap { payload -> PreviewPayload? in
@@ -1520,7 +1528,6 @@ public final class BrowserViewModel {
         return ItemMetadata(
             itemId: metadata.itemId,
             icon: metadata.icon,
-            snippet: metadata.snippet,
             sourceApp: metadata.sourceApp,
             sourceAppBundleId: metadata.sourceAppBundleId,
             timestampUnix: metadata.timestampUnix,
@@ -1528,11 +1535,22 @@ public final class BrowserViewModel {
         )
     }
 
-    public func listDecoration(for itemId: String) -> ListDecoration? {
+    private func deferredMatchedExcerptRequest(for itemId: String) -> MatchedExcerptRequest? {
         guard let index = itemIndexById[itemId], displayRows.indices.contains(index) else {
             return nil
         }
-        return displayRows[index].listDecoration
+        guard resolvedMatchedExcerptsByItemId[itemId] == nil else { return nil }
+        switch displayRows[index].presentation {
+        case let .search(searchPresentation):
+            switch searchPresentation {
+            case let .deferred(request, _):
+                return request
+            case .ready, .unavailable:
+                return nil
+            }
+        case .baseline:
+            return nil
+        }
     }
 
     private func makeSelectedItemState(
@@ -1728,7 +1746,8 @@ public final class BrowserViewModel {
     private func updateDisplayedResponseForItem(
         itemId: String,
         updatedMetadata: ItemMetadata,
-        updatedFirstItem: ClipboardItem
+        updatedFirstItem: ClipboardItem,
+        updatedPresentation: RowPresentation
     ) {
         guard let response = currentResponse else { return }
         let updatedItems = response.items.map { itemMatch in
@@ -1736,7 +1755,7 @@ public final class BrowserViewModel {
             // Clear stale list decoration — Rust will recompute on next search
             return ItemMatch(
                 itemMetadata: updatedMetadata,
-                listDecoration: nil
+                presentation: updatedPresentation
             )
         }
         let firstPreviewPayload: PreviewPayload? = {
@@ -1792,13 +1811,28 @@ public final class BrowserViewModel {
             nextIndexById[itemId] = index
             nextDisplayRows.append(DisplayRow(
                 metadata: itemMatch.itemMetadata,
-                listDecoration: listDecorationsByItemId[itemId] ?? itemMatch.listDecoration
+                presentation: presentationApplyingResolvedExcerpt(itemMatch.presentation, itemId: itemId)
             ))
         }
 
         itemIds = nextItemIds
         itemIndexById = nextIndexById
         displayRows = nextDisplayRows
+    }
+
+    private func presentationApplyingResolvedExcerpt(_ presentation: RowPresentation, itemId: String) -> RowPresentation {
+        guard let excerpt = resolvedMatchedExcerptsByItemId[itemId] else { return presentation }
+        switch presentation {
+        case let .search(searchPresentation):
+            switch searchPresentation {
+            case .deferred:
+                return .search(presentation: .ready(excerpt: excerpt))
+            case .ready, .unavailable:
+                return presentation
+            }
+        case .baseline:
+            return presentation
+        }
     }
 
     private func clearInactiveEdits() {

--- a/Sources/Shared/ClipboardRepository.swift
+++ b/Sources/Shared/ClipboardRepository.swift
@@ -83,12 +83,12 @@ public final class ClipboardRepository {
         return nil
     }
 
-    public func computeListDecorations(itemIds: [String], query: String, presentation: ListPresentationProfile) async -> [ListDecorationResult] {
-        let result = await runRepositoryOperation("computeListDecorations", on: store) { store in
-            try store.computeListDecorations(itemIds: itemIds, query: query, presentation: presentation)
+    public func resolveMatchedExcerpts(requests: [MatchedExcerptRequest]) async -> [MatchedExcerptResolution] {
+        let result = await runRepositoryOperation("resolveMatchedExcerpts", on: store) { store in
+            try store.resolveMatchedExcerpts(requests: requests)
         }
-        if case let .success(decorations) = result {
-            return decorations
+        if case let .success(resolutions) = result {
+            return resolutions
         }
         return []
     }

--- a/Sources/Shared/HighlightHelpers.swift
+++ b/Sources/Shared/HighlightHelpers.swift
@@ -76,7 +76,7 @@ public enum HighlightAttributedStringBuilder {
         return attributed
     }
 
-    /// Build an `AttributedString` for a card snippet with highlight styling.
+    /// Build an `AttributedString` for a card excerpt with highlight styling.
     public static func attributedSnippet(
         _ text: String,
         highlights: [Utf16HighlightRange]

--- a/Sources/iOSApp/Services/iOSBrowserStoreClient.swift
+++ b/Sources/iOSApp/Services/iOSBrowserStoreClient.swift
@@ -56,8 +56,8 @@ final class iOSBrowserStoreClient: BrowserStoreClient {
         await previewLoader.fetchItem(id: id)
     }
 
-    func loadListDecorations(itemIds: [String], query: String, presentation: ListPresentationProfile) async -> [ListDecorationResult] {
-        await repository.computeListDecorations(itemIds: itemIds, query: query, presentation: presentation)
+    func resolveMatchedExcerpts(requests: [MatchedExcerptRequest]) async -> [MatchedExcerptResolution] {
+        await repository.resolveMatchedExcerpts(requests: requests)
     }
 
     func loadPreviewPayload(itemId: String, query: String) async -> PreviewPayload? {

--- a/Sources/iOSApp/Views/CardView.swift
+++ b/Sources/iOSApp/Views/CardView.swift
@@ -23,20 +23,17 @@ struct CardView: View {
         switch row.presentation {
         case let .baseline(excerpt):
             return (excerpt.text, [])
-        case let .search(searchPresentation):
-            switch searchPresentation {
-            case let .ready(excerpt):
+        case let .matched(excerpt):
+            return (excerpt.text, excerpt.highlights)
+        case let .deferred(_, placeholder):
+            switch placeholder {
+            case let .baseline(excerpt), let .provisional(excerpt):
+                return (excerpt.text, [])
+            case let .compatibleCached(_, excerpt):
                 return (excerpt.text, excerpt.highlights)
-            case let .deferred(_, placeholder):
-                switch placeholder {
-                case let .baseline(excerpt), let .provisional(excerpt):
-                    return (excerpt.text, [])
-                case let .compatibleCached(_, excerpt):
-                    return (excerpt.text, excerpt.highlights)
-                }
-            case let .unavailable(fallback, _):
-                return (fallback.text, [])
             }
+        case let .unavailable(fallback, _):
+            return (fallback.text, [])
         }
     }
 

--- a/Sources/iOSApp/Views/CardView.swift
+++ b/Sources/iOSApp/Views/CardView.swift
@@ -19,14 +19,25 @@ struct CardView: View {
         row.metadata
     }
 
-    /// Display text from Rust list decoration when available, falling back to metadata snippet.
-    private var displayText: String {
-        row.listDecoration?.text ?? metadata.snippet
-    }
-
-    /// Highlights from Rust list decoration, empty when no decoration is available.
-    private var displayHighlights: [Utf16HighlightRange] {
-        row.listDecoration?.highlights ?? []
+    private var displayExcerpt: (text: String, highlights: [Utf16HighlightRange]) {
+        switch row.presentation {
+        case let .baseline(excerpt):
+            return (excerpt.text, [])
+        case let .search(searchPresentation):
+            switch searchPresentation {
+            case let .ready(excerpt):
+                return (excerpt.text, excerpt.highlights)
+            case let .deferred(_, placeholder):
+                switch placeholder {
+                case let .baseline(excerpt), let .provisional(excerpt):
+                    return (excerpt.text, [])
+                case let .compatibleCached(_, excerpt):
+                    return (excerpt.text, excerpt.highlights)
+                }
+            case let .unavailable(fallback, _):
+                return (fallback.text, [])
+            }
+        }
     }
 
     private var isBookmarked: Bool {
@@ -118,7 +129,7 @@ struct CardView: View {
     private func symbolContentPreview(iconType: IconType) -> some View {
         switch iconType {
         case .text:
-            highlightedText(displayText, highlights: displayHighlights, font: .custom(FontManager.mono, size: 15))
+            highlightedText(displayExcerpt.text, highlights: displayExcerpt.highlights, font: .custom(FontManager.mono, size: 15))
                 .lineLimit(8)
 
         case .link:
@@ -126,7 +137,7 @@ struct CardView: View {
                 Image(systemName: "globe")
                     .font(.title3)
                     .foregroundStyle(.secondary)
-                highlightedText(displayText, highlights: displayHighlights, font: .custom(FontManager.sansSerif, size: 15))
+                highlightedText(displayExcerpt.text, highlights: displayExcerpt.highlights, font: .custom(FontManager.sansSerif, size: 15))
                     .lineLimit(2)
             }
 
@@ -135,7 +146,7 @@ struct CardView: View {
                 Image(systemName: "photo")
                     .font(.title3)
                     .foregroundStyle(.secondary)
-                highlightedText(displayText, highlights: displayHighlights, font: .custom(FontManager.sansSerif, size: 15))
+                highlightedText(displayExcerpt.text, highlights: displayExcerpt.highlights, font: .custom(FontManager.sansSerif, size: 15))
                     .lineLimit(2)
             }
 
@@ -145,7 +156,7 @@ struct CardView: View {
 
         case .color:
             // Fallback for symbol-based color (shouldn't normally hit this path)
-            highlightedText(displayText, highlights: displayHighlights, font: .custom(FontManager.mono, size: 15))
+            highlightedText(displayExcerpt.text, highlights: displayExcerpt.highlights, font: .custom(FontManager.mono, size: 15))
         }
     }
 
@@ -160,8 +171,8 @@ struct CardView: View {
                 )
 
             highlightedText(
-                displayHighlights.isEmpty ? hexStringFromRGBA(rgba) : displayText,
-                highlights: displayHighlights,
+                displayExcerpt.highlights.isEmpty ? hexStringFromRGBA(rgba) : displayExcerpt.text,
+                highlights: displayExcerpt.highlights,
                 font: .custom(FontManager.mono, size: 15)
             )
         }
@@ -188,8 +199,8 @@ struct CardView: View {
                         )
                 }
             }
-            if !displayText.isEmpty {
-                highlightedText(displayText, highlights: displayHighlights, font: .custom(FontManager.sansSerif, size: 15))
+            if !displayExcerpt.text.isEmpty {
+                highlightedText(displayExcerpt.text, highlights: displayExcerpt.highlights, font: .custom(FontManager.sansSerif, size: 15))
                     .lineLimit(2)
             }
         }
@@ -274,7 +285,7 @@ struct CardView: View {
     private var accessibilityCardLabel: String {
         var parts = [typeLabel]
         if isBookmarked { parts.append("bookmarked") }
-        let preview = metadata.snippet.prefix(100)
+        let preview = displayExcerpt.text.prefix(100)
         if !preview.isEmpty { parts.append(String(preview)) }
         parts.append(relativeTime)
         return parts.joined(separator: ", ")

--- a/Sources/iOSApp/Views/HomeFeedView.swift
+++ b/Sources/iOSApp/Views/HomeFeedView.swift
@@ -93,7 +93,7 @@ struct HomeFeedView: View {
                     previewItemId: $previewItemId
                 )
                 .onAppear {
-                    loadDecorationsIfNeeded(for: row)
+                    loadMatchedExcerptIfNeeded(for: row)
                 }
                 .listRowSeparator(.hidden)
                 .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
@@ -174,10 +174,8 @@ struct HomeFeedView: View {
             || viewModel.selectedTagFilter != nil
     }
 
-    private func loadDecorationsIfNeeded(for row: DisplayRow) {
-        if row.listDecoration == nil {
-            viewModel.loadListDecorationsForItems([row.id])
-        }
+    private func loadMatchedExcerptIfNeeded(for row: DisplayRow) {
+        viewModel.loadMatchedExcerptsForItems([row.id])
     }
 }
 

--- a/Tests/UnitTests/BrowserViewModelTests.swift
+++ b/Tests/UnitTests/BrowserViewModelTests.swift
@@ -1461,7 +1461,7 @@ final class BrowserViewModelTests: XCTestCase {
                 timestampUnix: 0,
                 tags: tags
             ),
-            presentation: .search(presentation: .deferred(
+            presentation: .deferred(
                 request: MatchedExcerptRequest(
                     itemId: id,
                     query: query,
@@ -1469,7 +1469,7 @@ final class BrowserViewModelTests: XCTestCase {
                     contentHash: "hash-\(id)-\(query)"
                 ),
                 placeholder: .baseline(excerpt: BaselineExcerpt(text: text))
-            ))
+            )
         )
     }
 

--- a/Tests/UnitTests/BrowserViewModelTests.swift
+++ b/Tests/UnitTests/BrowserViewModelTests.swift
@@ -19,13 +19,13 @@ final class BrowserViewModelTests: XCTestCase {
 
         let staleResponse = BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "stale")],
+            items: [makeMatch(id: "1", excerpt: "stale")],
             firstPreviewPayload: nil,
             totalCount: 1
         )
         let freshResponse = BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "2", snippet: "fresh")],
+            items: [makeMatch(id: "2", excerpt: "fresh")],
             firstPreviewPayload: nil,
             totalCount: 1
         )
@@ -48,7 +48,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one"), makeMatch(id: "2", snippet: "two")],
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
             firstPreviewPayload: nil,
             totalCount: 2
         ))
@@ -84,7 +84,7 @@ final class BrowserViewModelTests: XCTestCase {
         let secondItem = makeItem(id: "2", text: "second")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "first")],
+            items: [makeMatch(id: "1", excerpt: "first")],
             firstItem: firstItem,
             totalCount: 1
         ))
@@ -117,7 +117,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "first"), makeMatch(id: "2", snippet: "second")],
+            items: [makeMatch(id: "1", excerpt: "first"), makeMatch(id: "2", excerpt: "second")],
             firstItem: firstItem,
             totalCount: 2
         ))
@@ -133,7 +133,7 @@ final class BrowserViewModelTests: XCTestCase {
         let secondItem = makeItem(id: "2", text: "second")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "first")],
+            items: [makeMatch(id: "1", excerpt: "first")],
             firstItem: firstItem,
             totalCount: 1
         ))
@@ -167,7 +167,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "2", snippet: "second"), makeMatch(id: "1", snippet: "first")],
+            items: [makeMatch(id: "2", excerpt: "second"), makeMatch(id: "1", excerpt: "first")],
             firstItem: secondItem,
             totalCount: 2
         ))
@@ -183,7 +183,7 @@ final class BrowserViewModelTests: XCTestCase {
         let secondItem = makeItem(id: "2", text: "second")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "first")],
+            items: [makeMatch(id: "1", excerpt: "first")],
             firstItem: firstItem,
             totalCount: 1
         ))
@@ -217,7 +217,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "2", snippet: "second")],
+            items: [makeMatch(id: "2", excerpt: "second")],
             firstItem: secondItem,
             totalCount: 1
         ))
@@ -232,7 +232,7 @@ final class BrowserViewModelTests: XCTestCase {
         let firstItem = makeItem(id: "1", text: "first")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "first")],
+            items: [makeMatch(id: "1", excerpt: "first")],
             firstItem: firstItem,
             totalCount: 1
         ))
@@ -279,7 +279,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "a", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeDeferredMatch(id: "1", text: "alpha beta", query: "a")],
             firstItem: item,
             totalCount: 1
         ))
@@ -295,7 +295,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "al", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeDeferredMatch(id: "1", text: "alpha beta", query: "al")],
             firstItem: item,
             totalCount: 1
         ))
@@ -343,7 +343,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "a", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeDeferredMatch(id: "1", text: "alpha beta", query: "a")],
             firstItem: item,
             totalCount: 1
         ))
@@ -389,7 +389,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "al", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeMatch(id: "1", excerpt: "alpha beta")],
             firstPreviewPayload: makePreviewPayload(item: item, decoration: decoration),
             totalCount: 1
         ))
@@ -407,7 +407,7 @@ final class BrowserViewModelTests: XCTestCase {
         let decoration = makePreviewDecoration(highlightStart: 0, highlightEnd: 2)
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeMatch(id: "1", excerpt: "alpha beta")],
             firstItem: item,
             totalCount: 1
         ))
@@ -443,7 +443,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "al", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeMatch(id: "1", excerpt: "alpha beta")],
             firstItem: item,
             totalCount: 1
         ))
@@ -490,7 +490,7 @@ final class BrowserViewModelTests: XCTestCase {
         await flushMainActor()
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "a", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeMatch(id: "1", excerpt: "alpha beta")],
             firstItem: item,
             totalCount: 1
         ))
@@ -501,7 +501,7 @@ final class BrowserViewModelTests: XCTestCase {
         await flushMainActor()
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "be", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeMatch(id: "1", excerpt: "alpha beta")],
             firstItem: item,
             totalCount: 1
         ))
@@ -543,7 +543,7 @@ final class BrowserViewModelTests: XCTestCase {
         await flushMainActor()
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "hello", filter: .all),
-            items: [makeMatch(id: "1", snippet: "hello_arrr")],
+            items: [makeMatch(id: "1", excerpt: "hello_arrr")],
             firstItem: item,
             totalCount: 1
         ))
@@ -571,7 +571,7 @@ final class BrowserViewModelTests: XCTestCase {
         await flushMainActor()
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "hello_arr", filter: .all),
-            items: [makeMatch(id: "1", snippet: "hello_arrr")],
+            items: [makeMatch(id: "1", excerpt: "hello_arrr")],
             firstItem: item,
             totalCount: 1
         ))
@@ -617,13 +617,13 @@ final class BrowserViewModelTests: XCTestCase {
         await flushMainActor()
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "a", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeDeferredMatch(id: "1", text: "alpha beta", query: "a")],
             firstItem: item,
             totalCount: 1
         ))
         await flushMainActor()
 
-        viewModel.loadListDecorationsForItems(["1"])
+        viewModel.loadMatchedExcerptsForItems(["1"])
         await flushMainActor()
 
         viewModel.updateSearchText("al")
@@ -631,26 +631,26 @@ final class BrowserViewModelTests: XCTestCase {
         await flushMainActor()
         client.resumeSearch(with: BrowserSearchResponse(
             request: SearchRequest(text: "al", filter: .all),
-            items: [makeMatch(id: "1", snippet: "alpha beta")],
+            items: [makeDeferredMatch(id: "1", text: "alpha beta", query: "al")],
             firstItem: item,
             totalCount: 1
         ))
         await flushMainActor()
         await flushMainActor()
 
-        let staleListDecoration = ListDecoration(
+        let staleMatchedExcerpt = MatchedExcerpt(
             text: "alpha beta",
             highlights: [Utf16HighlightRange(utf16Start: 0, utf16End: 1, kind: .exact)],
             lineNumber: 1
         )
-        client.resumeListDecorations(
+        client.resumeMatchedExcerpts(
             itemIds: ["1"],
             query: "a",
-            with: [ListDecorationResult(itemId: "1", decoration: staleListDecoration)]
+            with: [.ready(itemId: "1", excerpt: staleMatchedExcerpt)]
         )
         await flushMainActor()
 
-        XCTAssertNil(viewModel.listDecorationsByItemId["1"])
+        XCTAssertNil(viewModel.resolvedMatchedExcerptsByItemId["1"])
         XCTAssertEqual(viewModel.previewDecoration?.highlights.first?.utf16End, 2)
     }
 
@@ -658,7 +658,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one"), makeMatch(id: "2", snippet: "two")],
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
             firstPreviewPayload: nil,
             totalCount: 2
         ))
@@ -697,7 +697,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one"), makeMatch(id: "2", snippet: "two")],
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
             firstPreviewPayload: nil,
             totalCount: 2
         ))
@@ -772,7 +772,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one")],
+            items: [makeMatch(id: "1", excerpt: "one")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -803,7 +803,7 @@ final class BrowserViewModelTests: XCTestCase {
         ))
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one")],
+            items: [makeMatch(id: "1", excerpt: "one")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -836,8 +836,8 @@ final class BrowserViewModelTests: XCTestCase {
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .tagged(tag: .bookmark)),
             items: [
-                makeMatch(id: "1", snippet: "one", tags: [.bookmark]),
-                makeMatch(id: "2", snippet: "two", tags: [.bookmark]),
+                makeMatch(id: "1", excerpt: "one", tags: [.bookmark]),
+                makeMatch(id: "2", excerpt: "two", tags: [.bookmark]),
             ],
             firstPreviewPayload: nil,
             totalCount: 2
@@ -868,9 +868,9 @@ final class BrowserViewModelTests: XCTestCase {
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
             items: [
-                makeMatch(id: "1", snippet: "one"),
-                makeMatch(id: "2", snippet: "two"),
-                makeMatch(id: "3", snippet: "three"),
+                makeMatch(id: "1", excerpt: "one"),
+                makeMatch(id: "2", excerpt: "two"),
+                makeMatch(id: "3", excerpt: "three"),
             ],
             firstPreviewPayload: nil,
             totalCount: 3
@@ -903,7 +903,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one"), makeMatch(id: "2", snippet: "two")],
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
             firstPreviewPayload: nil,
             totalCount: 2
         ))
@@ -939,7 +939,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one")],
+            items: [makeMatch(id: "1", excerpt: "one")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -971,7 +971,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "original text")],
+            items: [makeMatch(id: "1", excerpt: "original text")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -996,7 +996,10 @@ final class BrowserViewModelTests: XCTestCase {
             return XCTFail("Expected selected item text content")
         }
         XCTAssertEqual(value, "edited text")
-        XCTAssertTrue(viewModel.contentState.items.first?.itemMetadata.snippet.contains("edited") == true)
+        guard case let .baseline(excerpt)? = viewModel.contentState.items.first?.presentation else {
+            return XCTFail("Expected optimistic baseline excerpt")
+        }
+        XCTAssertTrue(excerpt.text.contains("edited"))
         XCTAssertEqual(client.updatedTexts.count, 1)
         XCTAssertEqual(client.updatedTexts.first?.itemId, "1")
         XCTAssertEqual(client.updatedTexts.first?.text, "edited text")
@@ -1007,7 +1010,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "original text")],
+            items: [makeMatch(id: "1", excerpt: "original text")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -1056,7 +1059,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "hello")],
+            items: [makeMatch(id: "1", excerpt: "hello")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -1080,7 +1083,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "hello")],
+            items: [makeMatch(id: "1", excerpt: "hello")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -1106,7 +1109,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "hello")],
+            items: [makeMatch(id: "1", excerpt: "hello")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -1133,7 +1136,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "hello")],
+            items: [makeMatch(id: "1", excerpt: "hello")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -1164,9 +1167,9 @@ final class BrowserViewModelTests: XCTestCase {
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
             items: [
-                makeMatch(id: "1", snippet: "one"),
-                makeMatch(id: "2", snippet: "two"),
-                makeMatch(id: "3", snippet: "three"),
+                makeMatch(id: "1", excerpt: "one"),
+                makeMatch(id: "2", excerpt: "two"),
+                makeMatch(id: "3", excerpt: "three"),
             ],
             firstPreviewPayload: nil,
             totalCount: 3
@@ -1199,7 +1202,7 @@ final class BrowserViewModelTests: XCTestCase {
         client.clearResult = .success(())
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one"), makeMatch(id: "2", snippet: "two")],
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
             firstPreviewPayload: nil,
             totalCount: 2
         ))
@@ -1236,7 +1239,7 @@ final class BrowserViewModelTests: XCTestCase {
         let item = makeItem(id: "1", text: "selected text")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "selected text")],
+            items: [makeMatch(id: "1", excerpt: "selected text")],
             firstItem: item,
             totalCount: 1
         ))
@@ -1259,7 +1262,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one"), makeMatch(id: "2", snippet: "two")],
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
             firstPreviewPayload: nil,
             totalCount: 2
         ))
@@ -1289,7 +1292,7 @@ final class BrowserViewModelTests: XCTestCase {
         let item = makeItem(id: "1", text: "selected text")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "selected text")],
+            items: [makeMatch(id: "1", excerpt: "selected text")],
             firstItem: item,
             totalCount: 1
         ))
@@ -1323,7 +1326,7 @@ final class BrowserViewModelTests: XCTestCase {
         let item = makeItem(id: "1", text: "selected text")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "selected text")],
+            items: [makeMatch(id: "1", excerpt: "selected text")],
             firstItem: item,
             totalCount: 1
         ))
@@ -1356,7 +1359,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one"), makeMatch(id: "2", snippet: "two")],
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
             firstPreviewPayload: nil,
             totalCount: 2
         ))
@@ -1393,7 +1396,7 @@ final class BrowserViewModelTests: XCTestCase {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "one"), makeMatch(id: "2", snippet: "two")],
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
             firstPreviewPayload: nil,
             totalCount: 2
         ))
@@ -1434,18 +1437,39 @@ final class BrowserViewModelTests: XCTestCase {
         }
     }
 
-    private func makeMatch(id: String, snippet: String, tags: [ItemTag] = []) -> ItemMatch {
+    private func makeMatch(id: String, excerpt: String, tags: [ItemTag] = []) -> ItemMatch {
         ItemMatch(
             itemMetadata: ItemMetadata(
                 itemId: id,
                 icon: .symbol(iconType: .text),
-                snippet: snippet,
                 sourceApp: nil,
                 sourceAppBundleId: nil,
                 timestampUnix: 0,
                 tags: tags
             ),
-            listDecoration: nil
+            presentation: .baseline(excerpt: BaselineExcerpt(text: excerpt))
+        )
+    }
+
+    private func makeDeferredMatch(id: String, text: String, query: String, tags: [ItemTag] = []) -> ItemMatch {
+        ItemMatch(
+            itemMetadata: ItemMetadata(
+                itemId: id,
+                icon: .symbol(iconType: .text),
+                sourceApp: nil,
+                sourceAppBundleId: nil,
+                timestampUnix: 0,
+                tags: tags
+            ),
+            presentation: .search(presentation: .deferred(
+                request: MatchedExcerptRequest(
+                    itemId: id,
+                    query: query,
+                    presentationProfile: .compactRow,
+                    contentHash: "hash-\(id)-\(query)"
+                ),
+                placeholder: .baseline(excerpt: BaselineExcerpt(text: text))
+            ))
         )
     }
 
@@ -1454,7 +1478,6 @@ final class BrowserViewModelTests: XCTestCase {
             itemMetadata: ItemMetadata(
                 itemId: id,
                 icon: .symbol(iconType: .text),
-                snippet: text,
                 sourceApp: nil,
                 sourceAppBundleId: nil,
                 timestampUnix: 0,
@@ -1505,7 +1528,7 @@ private extension BrowserSearchResponse {
 
 @MainActor
 private final class MockBrowserStoreClient: BrowserStoreClient {
-    struct ListDecorationRequest: Hashable {
+    struct MatchedExcerptRequestKey: Hashable {
         let itemIds: [String]
         let query: String
     }
@@ -1526,12 +1549,12 @@ private final class MockBrowserStoreClient: BrowserStoreClient {
     var updateTextResult: Result<Void, ClipboardError> = .success(())
     var updatedTexts: [(itemId: String, text: String)] = []
     var startedSearchRequests: [SearchRequest] = []
-    var loadListDecorationRequests: [ListDecorationRequest] = []
+    var resolveMatchedExcerptRequests: [MatchedExcerptRequestKey] = []
     var loadPreviewDecorationRequests: [PreviewDecorationRequest] = []
-    var listDecorationsByQuery: [String: [String: ListDecoration]] = [:]
+    var matchedExcerptsByQuery: [String: [String: MatchedExcerpt]] = [:]
     var previewPayloadsByQuery: [String: [String: PreviewPayload]] = [:]
     private var fetchContinuations: [String: [CheckedContinuation<ClipboardItem?, Never>]] = [:]
-    private var listDecorationContinuations: [ListDecorationRequest: [CheckedContinuation<[ListDecorationResult], Never>]] = [:]
+    private var matchedExcerptContinuations: [MatchedExcerptRequestKey: [CheckedContinuation<[MatchedExcerptResolution], Never>]] = [:]
     private var previewPayloadContinuations: [PreviewDecorationRequest: [CheckedContinuation<PreviewPayload?, Never>]] = [:]
 
     func startSearch(request: SearchRequest) -> BrowserSearchOperation {
@@ -1564,18 +1587,23 @@ private final class MockBrowserStoreClient: BrowserStoreClient {
         }
     }
 
-    func loadListDecorations(itemIds: [String], query: String, presentation _: ListPresentationProfile) async -> [ListDecorationResult] {
-        let request = ListDecorationRequest(itemIds: itemIds, query: query)
-        loadListDecorationRequests.append(request)
+    func resolveMatchedExcerpts(requests: [MatchedExcerptRequest]) async -> [MatchedExcerptResolution] {
+        let itemIds = requests.map { $0.itemId }
+        let query = requests.first?.query ?? ""
+        let request = MatchedExcerptRequestKey(itemIds: itemIds, query: query)
+        resolveMatchedExcerptRequests.append(request)
 
-        if let decorationsByItemId = listDecorationsByQuery[query] {
+        if let excerptsByItemId = matchedExcerptsByQuery[query] {
             return itemIds.map { itemId in
-                ListDecorationResult(itemId: itemId, decoration: decorationsByItemId[itemId])
+                if let excerpt = excerptsByItemId[itemId] {
+                    return .ready(itemId: itemId, excerpt: excerpt)
+                }
+                return .unavailable(itemId: itemId, reason: .itemMissing)
             }
         }
 
         return await withCheckedContinuation { continuation in
-            listDecorationContinuations[request, default: []].append(continuation)
+            matchedExcerptContinuations[request, default: []].append(continuation)
         }
     }
 
@@ -1631,9 +1659,9 @@ private final class MockBrowserStoreClient: BrowserStoreClient {
         fetchContinuations.removeValue(forKey: id)?.forEach { $0.resume(returning: item) }
     }
 
-    func resumeListDecorations(itemIds: [String], query: String, with results: [ListDecorationResult]) {
-        let request = ListDecorationRequest(itemIds: itemIds, query: query)
-        listDecorationContinuations.removeValue(forKey: request)?.forEach { $0.resume(returning: results) }
+    func resumeMatchedExcerpts(itemIds: [String], query: String, with results: [MatchedExcerptResolution]) {
+        let request = MatchedExcerptRequestKey(itemIds: itemIds, query: query)
+        matchedExcerptContinuations.removeValue(forKey: request)?.forEach { $0.resume(returning: results) }
     }
 
     func resumePreviewPayload(itemId: String, query: String, with payload: PreviewPayload?) {

--- a/Tests/iOSTests/MockiOSBrowserStoreClient.swift
+++ b/Tests/iOSTests/MockiOSBrowserStoreClient.swift
@@ -72,8 +72,8 @@ final class MockiOSBrowserStoreClient: BrowserStoreClient {
         }
     }
 
-    func loadListDecorations(itemIds: [String], query _: String, presentation _: ListPresentationProfile) async -> [ListDecorationResult] {
-        itemIds.map { ListDecorationResult(itemId: $0, decoration: nil) }
+    func resolveMatchedExcerpts(requests: [MatchedExcerptRequest]) async -> [MatchedExcerptResolution] {
+        requests.map { .unavailable(itemId: $0.itemId, reason: .itemMissing) }
     }
 
     func loadPreviewPayload(itemId _: String, query _: String) async -> PreviewPayload? {

--- a/Tests/iOSTests/iOSBrowserIntegrationTests.swift
+++ b/Tests/iOSTests/iOSBrowserIntegrationTests.swift
@@ -14,7 +14,7 @@ final class iOSBrowserIntegrationTests: XCTestCase {
 
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Hello world")],
+            items: [makeMatch(id: "1", excerpt: "Hello world")],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -28,8 +28,8 @@ final class iOSBrowserIntegrationTests: XCTestCase {
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
             items: [
-                makeMatch(id: "2", snippet: "New item"),
-                makeMatch(id: "1", snippet: "Hello world"),
+                makeMatch(id: "2", excerpt: "New item"),
+                makeMatch(id: "1", excerpt: "Hello world"),
             ],
             firstPreviewPayload: nil,
             totalCount: 2
@@ -51,7 +51,7 @@ final class iOSBrowserIntegrationTests: XCTestCase {
         let item = makeItem(id: "1", text: "Copy me")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Copy me")],
+            items: [makeMatch(id: "1", excerpt: "Copy me")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -84,7 +84,7 @@ final class iOSBrowserIntegrationTests: XCTestCase {
         }
     }
 
-    // MARK: - Edit long text → snippet uses formatExcerpt
+    // MARK: - Edit long text → excerpt uses formatExcerpt
 
     func testEditLongTextUsesFormatExcerpt() async {
         let client = MockiOSBrowserStoreClient()
@@ -93,7 +93,7 @@ final class iOSBrowserIntegrationTests: XCTestCase {
 
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Short original")],
+            items: [makeMatch(id: "1", excerpt: "Short original")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -115,11 +115,13 @@ final class iOSBrowserIntegrationTests: XCTestCase {
         XCTAssertEqual(client.updatedTexts.count, 1)
         XCTAssertEqual(client.updatedTexts.first?.text, longText)
 
-        // The optimistic snippet should have been formatted through formatExcerpt
+        // The optimistic baseline excerpt should have been formatted through formatExcerpt
         let displayRow = viewModel.displayRows.first { $0.id == "1" }
         XCTAssertNotNil(displayRow)
-        // formatExcerpt in mock returns prefix(300), so snippet should be truncated
-        XCTAssertEqual(displayRow?.metadata.snippet.count, 300)
+        guard case let .baseline(excerpt)? = displayRow?.presentation else {
+            return XCTFail("Expected baseline excerpt")
+        }
+        XCTAssertEqual(excerpt.text.count, 300)
     }
 
     // MARK: - Bookmark filter
@@ -130,8 +132,8 @@ final class iOSBrowserIntegrationTests: XCTestCase {
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
             items: [
-                makeMatch(id: "1", snippet: "Bookmarked", tags: [.bookmark]),
-                makeMatch(id: "2", snippet: "Not bookmarked"),
+                makeMatch(id: "1", excerpt: "Bookmarked", tags: [.bookmark]),
+                makeMatch(id: "2", excerpt: "Not bookmarked"),
             ],
             firstPreviewPayload: nil,
             totalCount: 2
@@ -146,7 +148,7 @@ final class iOSBrowserIntegrationTests: XCTestCase {
         // Apply bookmark filter — triggers new search
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .tagged(tag: .bookmark)),
-            items: [makeMatch(id: "1", snippet: "Bookmarked", tags: [.bookmark])],
+            items: [makeMatch(id: "1", excerpt: "Bookmarked", tags: [.bookmark])],
             firstPreviewPayload: nil,
             totalCount: 1
         ))
@@ -161,8 +163,8 @@ final class iOSBrowserIntegrationTests: XCTestCase {
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
             items: [
-                makeMatch(id: "1", snippet: "Bookmarked", tags: [.bookmark]),
-                makeMatch(id: "2", snippet: "Not bookmarked"),
+                makeMatch(id: "1", excerpt: "Bookmarked", tags: [.bookmark]),
+                makeMatch(id: "2", excerpt: "Not bookmarked"),
             ],
             firstPreviewPayload: nil,
             totalCount: 2
@@ -182,9 +184,9 @@ final class iOSBrowserIntegrationTests: XCTestCase {
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
             items: [
-                makeMatch(id: "1", snippet: "Text item", icon: .symbol(iconType: .text)),
-                makeMatch(id: "2", snippet: "file.pdf", icon: .symbol(iconType: .file)),
-                makeMatch(id: "3", snippet: "https://example.com", icon: .symbol(iconType: .link)),
+                makeMatch(id: "1", excerpt: "Text item", icon: .symbol(iconType: .text)),
+                makeMatch(id: "2", excerpt: "file.pdf", icon: .symbol(iconType: .file)),
+                makeMatch(id: "3", excerpt: "https://example.com", icon: .symbol(iconType: .link)),
             ],
             firstPreviewPayload: nil,
             totalCount: 3
@@ -221,7 +223,7 @@ final class iOSBrowserIntegrationTests: XCTestCase {
 
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Delete me")],
+            items: [makeMatch(id: "1", excerpt: "Delete me")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -250,7 +252,7 @@ final class iOSBrowserIntegrationTests: XCTestCase {
 
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Tag me")],
+            items: [makeMatch(id: "1", excerpt: "Tag me")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -298,7 +300,7 @@ final class iOSBrowserIntegrationTests: XCTestCase {
 
     private func makeMatch(
         id: String,
-        snippet: String,
+        excerpt: String,
         tags: [ItemTag] = [],
         icon: ItemIcon = .symbol(iconType: .text)
     ) -> ItemMatch {
@@ -306,13 +308,12 @@ final class iOSBrowserIntegrationTests: XCTestCase {
             itemMetadata: ItemMetadata(
                 itemId: id,
                 icon: icon,
-                snippet: snippet,
                 sourceApp: nil,
                 sourceAppBundleId: nil,
                 timestampUnix: 0,
                 tags: tags
             ),
-            listDecoration: nil
+            presentation: .baseline(excerpt: BaselineExcerpt(text: excerpt))
         )
     }
 
@@ -321,7 +322,6 @@ final class iOSBrowserIntegrationTests: XCTestCase {
             itemMetadata: ItemMetadata(
                 itemId: id,
                 icon: .symbol(iconType: .text),
-                snippet: text,
                 sourceApp: nil,
                 sourceAppBundleId: nil,
                 timestampUnix: 0,

--- a/Tests/iOSTests/iOSHighlightAndEditTests.swift
+++ b/Tests/iOSTests/iOSHighlightAndEditTests.swift
@@ -16,10 +16,10 @@ final class iOSHighlightAndEditTests: XCTestCase {
         )
         let row = DisplayRow(
             metadata: makeMetadata(id: "1"),
-            presentation: .search(presentation: .ready(excerpt: excerpt))
+            presentation: .matched(excerpt: excerpt)
         )
 
-        guard case let .search(.ready(renderedExcerpt)) = row.presentation else {
+        guard case let .matched(renderedExcerpt) = row.presentation else {
             return XCTFail("Expected ready matched excerpt")
         }
         XCTAssertEqual(renderedExcerpt.text, "Decorated excerpt")

--- a/Tests/iOSTests/iOSHighlightAndEditTests.swift
+++ b/Tests/iOSTests/iOSHighlightAndEditTests.swift
@@ -2,38 +2,41 @@ import ClipKittyRust
 @testable import ClipKittyShared
 import XCTest
 
-/// Tests for iOS card highlight rendering from Rust list decorations,
+/// Tests for iOS card highlight rendering from Rust matched excerpts,
 /// preview decoration consumption, and inline edit transitions.
 @MainActor
 final class iOSHighlightAndEditTests: XCTestCase {
-    // MARK: - Card Highlights from ListDecoration
+    // MARK: - Card Highlights from RowPresentation
 
-    func testDisplayRowUsesListDecorationTextWhenAvailable() {
-        let decoration = ListDecoration(
-            text: "Decorated snippet",
+    func testDisplayRowUsesMatchedExcerptTextWhenAvailable() {
+        let excerpt = MatchedExcerpt(
+            text: "Decorated excerpt",
             highlights: [Utf16HighlightRange(utf16Start: 0, utf16End: 9, kind: .exact)],
             lineNumber: 1
         )
         let row = DisplayRow(
-            metadata: makeMetadata(id: "1", snippet: "Raw snippet"),
-            listDecoration: decoration
+            metadata: makeMetadata(id: "1"),
+            presentation: .search(presentation: .ready(excerpt: excerpt))
         )
 
-        // The card should prefer listDecoration.text over metadata.snippet
-        XCTAssertEqual(row.listDecoration?.text, "Decorated snippet")
-        XCTAssertEqual(row.listDecoration?.highlights.count, 1)
-        XCTAssertEqual(row.listDecoration?.highlights.first?.kind, .exact)
+        guard case let .search(.ready(renderedExcerpt)) = row.presentation else {
+            return XCTFail("Expected ready matched excerpt")
+        }
+        XCTAssertEqual(renderedExcerpt.text, "Decorated excerpt")
+        XCTAssertEqual(renderedExcerpt.highlights.count, 1)
+        XCTAssertEqual(renderedExcerpt.highlights.first?.kind, .exact)
     }
 
-    func testDisplayRowFallsBackToMetadataSnippetWithoutDecoration() {
+    func testDisplayRowUsesBaselinePresentation() {
         let row = DisplayRow(
-            metadata: makeMetadata(id: "1", snippet: "Fallback snippet"),
-            listDecoration: nil
+            metadata: makeMetadata(id: "1"),
+            presentation: .baseline(excerpt: BaselineExcerpt(text: "Fallback excerpt"))
         )
 
-        // Without decoration, card should use metadata.snippet
-        XCTAssertNil(row.listDecoration)
-        XCTAssertEqual(row.metadata.snippet, "Fallback snippet")
+        guard case let .baseline(excerpt) = row.presentation else {
+            return XCTFail("Expected baseline excerpt")
+        }
+        XCTAssertEqual(excerpt.text, "Fallback excerpt")
     }
 
     // MARK: - Preview Decoration State
@@ -87,7 +90,7 @@ final class iOSHighlightAndEditTests: XCTestCase {
         let item = makeItem(id: "1", text: "Original text")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Original text")],
+            items: [makeMatch(id: "1", excerpt: "Original text")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -110,7 +113,7 @@ final class iOSHighlightAndEditTests: XCTestCase {
         let item = makeItem(id: "1", text: "Original text")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Original text")],
+            items: [makeMatch(id: "1", excerpt: "Original text")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -146,7 +149,7 @@ final class iOSHighlightAndEditTests: XCTestCase {
         let item = makeItem(id: "1", text: "Original text")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Original text")],
+            items: [makeMatch(id: "1", excerpt: "Original text")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -181,7 +184,7 @@ final class iOSHighlightAndEditTests: XCTestCase {
         let item = makeItem(id: "1", text: "Same text")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "Same text")],
+            items: [makeMatch(id: "1", excerpt: "Same text")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -208,7 +211,7 @@ final class iOSHighlightAndEditTests: XCTestCase {
         let item = makeItem(id: "1", text: "search term here")
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
-            items: [makeMatch(id: "1", snippet: "search term here")],
+            items: [makeMatch(id: "1", excerpt: "search term here")],
             firstPreviewPayload: PreviewPayload(item: item, decoration: nil),
             totalCount: 1
         ))
@@ -278,8 +281,8 @@ final class iOSHighlightAndEditTests: XCTestCase {
         client.enqueueSearchResponse(BrowserSearchResponse(
             request: SearchRequest(text: "", filter: .all),
             items: [
-                makeMatch(id: "1", snippet: "First item"),
-                makeMatch(id: "2", snippet: "Second item"),
+                makeMatch(id: "1", excerpt: "First item"),
+                makeMatch(id: "2", excerpt: "Second item"),
             ],
             firstPreviewPayload: PreviewPayload(item: item1, decoration: nil),
             totalCount: 2
@@ -328,13 +331,11 @@ final class iOSHighlightAndEditTests: XCTestCase {
 
     private func makeMetadata(
         id: String,
-        snippet: String,
         icon: ItemIcon = .symbol(iconType: .text)
     ) -> ItemMetadata {
         ItemMetadata(
             itemId: id,
             icon: icon,
-            snippet: snippet,
             sourceApp: nil,
             sourceAppBundleId: nil,
             timestampUnix: 0,
@@ -344,17 +345,17 @@ final class iOSHighlightAndEditTests: XCTestCase {
 
     private func makeMatch(
         id: String,
-        snippet: String
+        excerpt: String
     ) -> ItemMatch {
         ItemMatch(
-            itemMetadata: makeMetadata(id: id, snippet: snippet),
-            listDecoration: nil
+            itemMetadata: makeMetadata(id: id),
+            presentation: .baseline(excerpt: BaselineExcerpt(text: excerpt))
         )
     }
 
     private func makeItem(id: String, text: String) -> ClipboardItem {
         ClipboardItem(
-            itemMetadata: makeMetadata(id: id, snippet: text),
+            itemMetadata: makeMetadata(id: id),
             content: .text(value: text)
         )
     }

--- a/purr/src/database.rs
+++ b/purr/src/database.rs
@@ -57,33 +57,29 @@ const GENERATED_ITEM_ID_SQL: &str = r#"lower(
 )"#;
 
 /// Intermediate row with raw content prefix; excerpt formatting is deferred to caller.
-struct RawBrowseMetadata {
+struct RawRowMetadata {
     item_metadata: ItemMetadata,
     content_prefix: String,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct BrowseItemMetadata {
+pub(crate) struct RowMetadata {
     pub(crate) item_metadata: ItemMetadata,
     pub(crate) baseline_excerpt: BaselineExcerpt,
 }
 
 /// Intermediate row for search metadata; excerpt formatting is deferred to caller.
-struct RawSearchItemMetadata {
-    row_id: i64,
+struct RawSearchRowMetadata {
     content_hash: String,
     db_type: String,
-    item_metadata: ItemMetadata,
-    content_prefix: String,
+    row_metadata: RawRowMetadata,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SearchItemMetadata {
-    pub(crate) row_id: i64,
+pub(crate) struct SearchRowMetadata {
     pub(crate) content_hash: String,
     pub(crate) db_type: String,
-    pub(crate) item_metadata: ItemMetadata,
-    pub(crate) baseline_excerpt: BaselineExcerpt,
+    pub(crate) row_metadata: RowMetadata,
 }
 
 /// Parse timestamp string from database to DateTime<Utc>
@@ -642,14 +638,14 @@ impl Database {
 
     /// Fetch lightweight item metadata for list display.
     /// No JOINs needed — `thumbnail` covers link images too.
-    pub(crate) fn fetch_item_metadata(
+    pub(crate) fn fetch_browse_row_metadata(
         &self,
         before_timestamp: Option<DateTime<Utc>>,
         limit: usize,
         filter: Option<&ContentTypeFilter>,
         tag: Option<&ItemTag>,
         presentation: ListPresentationProfile,
-    ) -> DatabaseResult<(Vec<BrowseItemMetadata>, u64)> {
+    ) -> DatabaseResult<(Vec<RowMetadata>, u64)> {
         let conn = self.get_conn()?;
 
         let type_filter_clause = Self::content_type_where_clause(filter, "");
@@ -693,7 +689,7 @@ impl Database {
             param_values.push((limit as i64).into());
             stmt.query_map(
                 rusqlite::params_from_iter(param_values),
-                Self::row_to_raw_browse_metadata,
+                Self::row_to_raw_row_metadata,
             )?
             .collect::<Result<Vec<_>, _>>()?
         } else {
@@ -704,14 +700,14 @@ impl Database {
             param_values.push((limit as i64).into());
             stmt.query_map(
                 rusqlite::params_from_iter(param_values),
-                Self::row_to_raw_browse_metadata,
+                Self::row_to_raw_row_metadata,
             )?
             .collect::<Result<Vec<_>, _>>()?
         };
 
         let items = raw_items
             .into_iter()
-            .map(|raw| BrowseItemMetadata {
+            .map(|raw| RowMetadata {
                 item_metadata: raw.item_metadata,
                 baseline_excerpt: BaselineExcerpt {
                     text: generate_preview_for_profile(&raw.content_prefix, presentation),
@@ -761,11 +757,11 @@ impl Database {
     }
 
     /// Fetch lightweight search result metadata by string item_ids, preserving order.
-    pub(crate) fn fetch_search_item_metadata_by_string_ids(
+    pub(crate) fn fetch_search_row_metadata_by_string_ids(
         &self,
         item_ids: &[&str],
         presentation: ListPresentationProfile,
-    ) -> DatabaseResult<Vec<SearchItemMetadata>> {
+    ) -> DatabaseResult<Vec<SearchRowMetadata>> {
         if item_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -773,7 +769,7 @@ impl Database {
         let conn = self.get_conn()?;
         let placeholders = item_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
         let sql = format!(
-            "SELECT id, contentHash, substr(content, 1, {}), contentType, timestamp, sourceApp, sourceAppBundleId, thumbnail, colorRgba, item_id FROM items WHERE item_id IN ({})",
+            "SELECT contentHash, substr(content, 1, {}), contentType, timestamp, sourceApp, sourceAppBundleId, thumbnail, colorRgba, item_id FROM items WHERE item_id IN ({})",
             SEARCH_METADATA_PREFIX_CHARS,
             placeholders
         );
@@ -782,29 +778,33 @@ impl Database {
             .iter()
             .map(|&id| rusqlite::types::Value::from(id.to_string()))
             .collect();
-        let raw_items: Vec<RawSearchItemMetadata> = stmt
+        let raw_items: Vec<RawSearchRowMetadata> = stmt
             .query_map(
                 rusqlite::params_from_iter(params),
-                Self::row_to_raw_search_item_metadata,
+                Self::row_to_raw_search_row_metadata,
             )?
             .collect::<Result<Vec<_>, _>>()?;
 
-        let items: Vec<SearchItemMetadata> = raw_items
+        let items: Vec<SearchRowMetadata> = raw_items
             .into_iter()
-            .map(|raw| SearchItemMetadata {
-                row_id: raw.row_id,
+            .map(|raw| SearchRowMetadata {
                 content_hash: raw.content_hash,
                 db_type: raw.db_type,
-                item_metadata: raw.item_metadata,
-                baseline_excerpt: BaselineExcerpt {
-                    text: generate_preview_for_profile(&raw.content_prefix, presentation),
+                row_metadata: RowMetadata {
+                    item_metadata: raw.row_metadata.item_metadata,
+                    baseline_excerpt: BaselineExcerpt {
+                        text: generate_preview_for_profile(
+                            &raw.row_metadata.content_prefix,
+                            presentation,
+                        ),
+                    },
                 },
             })
             .collect();
 
-        let id_to_item: std::collections::HashMap<String, SearchItemMetadata> = items
+        let id_to_item: std::collections::HashMap<String, SearchRowMetadata> = items
             .into_iter()
-            .map(|item| (item.item_metadata.item_id.clone(), item))
+            .map(|item| (item.row_metadata.item_metadata.item_id.clone(), item))
             .collect();
 
         Ok(item_ids
@@ -1430,8 +1430,8 @@ impl Database {
         Ok(())
     }
 
-    /// Convert a database row to raw browse metadata; excerpt formatting is deferred to caller.
-    fn row_to_raw_browse_metadata(row: &rusqlite::Row) -> rusqlite::Result<RawBrowseMetadata> {
+    /// Convert a database row to raw row metadata; excerpt formatting is deferred to caller.
+    fn row_to_raw_row_metadata(row: &rusqlite::Row) -> rusqlite::Result<RawRowMetadata> {
         let _id: i64 = row.get(0)?;
         let content: String = row.get(1)?;
         let content_type: Option<String> = row.get(2)?;
@@ -1447,7 +1447,7 @@ impl Database {
 
         let icon = ItemIcon::from_database(db_type, color_rgba, thumbnail);
 
-        Ok(RawBrowseMetadata {
+        Ok(RawRowMetadata {
             content_prefix: content,
             item_metadata: ItemMetadata {
                 item_id,
@@ -1460,37 +1460,37 @@ impl Database {
         })
     }
 
-    fn row_to_raw_search_item_metadata(
+    fn row_to_raw_search_row_metadata(
         row: &rusqlite::Row,
-    ) -> rusqlite::Result<RawSearchItemMetadata> {
-        let row_id: i64 = row.get(0)?;
-        let content_hash: String = row.get(1)?;
-        let content_prefix: String = row.get(2)?;
+    ) -> rusqlite::Result<RawSearchRowMetadata> {
+        let content_hash: String = row.get(0)?;
+        let content_prefix: String = row.get(1)?;
         let db_type = row
-            .get::<_, Option<String>>(3)?
+            .get::<_, Option<String>>(2)?
             .unwrap_or_else(|| "text".to_string());
-        let timestamp_str: String = row.get(4)?;
-        let source_app: Option<String> = row.get(5)?;
-        let source_app_bundle_id: Option<String> = row.get(6)?;
-        let thumbnail: Option<Vec<u8>> = row.get(7)?;
-        let color_rgba: Option<u32> = row.get(8)?;
-        let item_id: String = row.get(9)?;
+        let timestamp_str: String = row.get(3)?;
+        let source_app: Option<String> = row.get(4)?;
+        let source_app_bundle_id: Option<String> = row.get(5)?;
+        let thumbnail: Option<Vec<u8>> = row.get(6)?;
+        let color_rgba: Option<u32> = row.get(7)?;
+        let item_id: String = row.get(8)?;
 
         let timestamp = parse_db_timestamp(&timestamp_str);
         let icon = ItemIcon::from_database(&db_type, color_rgba, thumbnail);
 
-        Ok(RawSearchItemMetadata {
-            row_id,
+        Ok(RawSearchRowMetadata {
             content_hash,
             db_type,
-            content_prefix,
-            item_metadata: ItemMetadata {
-                item_id,
-                icon,
-                source_app,
-                source_app_bundle_id,
-                timestamp_unix: timestamp.timestamp(),
-                tags: Vec::new(),
+            row_metadata: RawRowMetadata {
+                content_prefix,
+                item_metadata: ItemMetadata {
+                    item_id,
+                    icon,
+                    source_app,
+                    source_app_bundle_id,
+                    timestamp_unix: timestamp.timestamp(),
+                    tags: Vec::new(),
+                },
             },
         })
     }
@@ -1569,13 +1569,13 @@ mod tests {
     }
 
     #[test]
-    fn test_fetch_item_metadata_preview_handles_large_leading_whitespace() {
+    fn test_fetch_browse_row_metadata_preview_handles_large_leading_whitespace() {
         let db = Database::open_in_memory().unwrap();
         let content = format!("{}Hello world", " \n\t".repeat(2_000));
         seed_base_item(&db, "text", &content, None);
 
         let (items, total_count) = db
-            .fetch_item_metadata(None, 1, None, None, ListPresentationProfile::CompactRow)
+            .fetch_browse_row_metadata(None, 1, None, None, ListPresentationProfile::CompactRow)
             .unwrap();
 
         assert_eq!(total_count, 1);

--- a/purr/src/database.rs
+++ b/purr/src/database.rs
@@ -4,8 +4,8 @@
 //! Uses r2d2 connection pooling to allow concurrent reads without mutex blocking.
 
 use crate::interface::{
-    ClipboardContent, ContentTypeFilter, FileEntry, FileStatus, ItemIcon, ItemMetadata, ItemTag,
-    LinkMetadataState, ListPresentationProfile,
+    BaselineExcerpt, ClipboardContent, ContentTypeFilter, FileEntry, FileStatus, ItemIcon,
+    ItemMetadata, ItemTag, LinkMetadataState, ListPresentationProfile,
 };
 use crate::models::StoredItem;
 use crate::search::{generate_preview_for_profile, SNIPPET_CONTEXT_CHARS};
@@ -56,13 +56,19 @@ const GENERATED_ITEM_ID_SQL: &str = r#"lower(
     hex(randomblob(6))
 )"#;
 
-/// Intermediate row with raw content prefix — snippet formatting deferred to caller.
+/// Intermediate row with raw content prefix; excerpt formatting is deferred to caller.
 struct RawBrowseMetadata {
     item_metadata: ItemMetadata,
     content_prefix: String,
 }
 
-/// Intermediate row for search metadata — snippet formatting deferred to caller.
+#[derive(Debug, Clone)]
+pub(crate) struct BrowseItemMetadata {
+    pub(crate) item_metadata: ItemMetadata,
+    pub(crate) baseline_excerpt: BaselineExcerpt,
+}
+
+/// Intermediate row for search metadata; excerpt formatting is deferred to caller.
 struct RawSearchItemMetadata {
     row_id: i64,
     content_hash: String,
@@ -77,6 +83,7 @@ pub(crate) struct SearchItemMetadata {
     pub(crate) content_hash: String,
     pub(crate) db_type: String,
     pub(crate) item_metadata: ItemMetadata,
+    pub(crate) baseline_excerpt: BaselineExcerpt,
 }
 
 /// Parse timestamp string from database to DateTime<Utc>
@@ -635,14 +642,14 @@ impl Database {
 
     /// Fetch lightweight item metadata for list display.
     /// No JOINs needed — `thumbnail` covers link images too.
-    pub fn fetch_item_metadata(
+    pub(crate) fn fetch_item_metadata(
         &self,
         before_timestamp: Option<DateTime<Utc>>,
         limit: usize,
         filter: Option<&ContentTypeFilter>,
         tag: Option<&ItemTag>,
         presentation: ListPresentationProfile,
-    ) -> DatabaseResult<(Vec<ItemMetadata>, u64)> {
+    ) -> DatabaseResult<(Vec<BrowseItemMetadata>, u64)> {
         let conn = self.get_conn()?;
 
         let type_filter_clause = Self::content_type_where_clause(filter, "");
@@ -704,10 +711,11 @@ impl Database {
 
         let items = raw_items
             .into_iter()
-            .map(|raw| {
-                let mut metadata = raw.item_metadata;
-                metadata.snippet = generate_preview_for_profile(&raw.content_prefix, presentation);
-                metadata
+            .map(|raw| BrowseItemMetadata {
+                item_metadata: raw.item_metadata,
+                baseline_excerpt: BaselineExcerpt {
+                    text: generate_preview_for_profile(&raw.content_prefix, presentation),
+                },
             })
             .collect();
 
@@ -783,15 +791,14 @@ impl Database {
 
         let items: Vec<SearchItemMetadata> = raw_items
             .into_iter()
-            .map(|raw| {
-                let mut metadata = raw.item_metadata;
-                metadata.snippet = generate_preview_for_profile(&raw.content_prefix, presentation);
-                SearchItemMetadata {
-                    row_id: raw.row_id,
-                    content_hash: raw.content_hash,
-                    db_type: raw.db_type,
-                    item_metadata: metadata,
-                }
+            .map(|raw| SearchItemMetadata {
+                row_id: raw.row_id,
+                content_hash: raw.content_hash,
+                db_type: raw.db_type,
+                item_metadata: raw.item_metadata,
+                baseline_excerpt: BaselineExcerpt {
+                    text: generate_preview_for_profile(&raw.content_prefix, presentation),
+                },
             })
             .collect();
 
@@ -1423,7 +1430,7 @@ impl Database {
         Ok(())
     }
 
-    /// Convert a database row to raw browse metadata — snippet formatting deferred to caller.
+    /// Convert a database row to raw browse metadata; excerpt formatting is deferred to caller.
     fn row_to_raw_browse_metadata(row: &rusqlite::Row) -> rusqlite::Result<RawBrowseMetadata> {
         let _id: i64 = row.get(0)?;
         let content: String = row.get(1)?;
@@ -1445,7 +1452,6 @@ impl Database {
             item_metadata: ItemMetadata {
                 item_id,
                 icon,
-                snippet: String::new(),
                 source_app,
                 source_app_bundle_id,
                 timestamp_unix: timestamp.timestamp(),
@@ -1481,7 +1487,6 @@ impl Database {
             item_metadata: ItemMetadata {
                 item_id,
                 icon,
-                snippet: String::new(),
                 source_app,
                 source_app_bundle_id,
                 timestamp_unix: timestamp.timestamp(),
@@ -1576,7 +1581,7 @@ mod tests {
         assert_eq!(total_count, 1);
         assert_eq!(items.len(), 1);
         assert_eq!(
-            items[0].snippet,
+            items[0].baseline_excerpt.text,
             generate_preview_for_profile(&content, ListPresentationProfile::CompactRow)
         );
     }

--- a/purr/src/interface.rs
+++ b/purr/src/interface.rs
@@ -113,7 +113,7 @@ impl ItemTag {
 
 /// Presentation profile for list surfaces.
 ///
-/// Selects how Rust formats excerpts (snippets) for the calling UI.
+/// Selects how Rust formats row excerpts for the calling UI.
 /// Compact rows collapse all whitespace into a single line; cards preserve
 /// meaningful line breaks for multiline display.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, uniffi::Enum)]
@@ -399,7 +399,13 @@ pub struct Utf16HighlightRange {
     pub kind: HighlightKind,
 }
 
-/// Snippet decoration data for list surfaces (compact rows and cards).
+/// Query-independent excerpt for list surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct BaselineExcerpt {
+    pub text: String,
+}
+
+/// Matched excerpt data for list surfaces (compact rows and cards).
 ///
 /// # Display Contract: Two-layer truncation with ellipsis
 ///
@@ -417,8 +423,8 @@ pub struct Utf16HighlightRange {
 /// - Adds "…" prefix if window start > 0, adds "…" suffix if window end < text length
 /// - Adjusts highlight indices: subtracts window start, adds 1 if Swift added prefix ellipsis
 #[derive(Debug, Clone, PartialEq, Default, uniffi::Record)]
-pub struct ListDecoration {
-    /// Snippet text. CompactRow: whitespace-normalized single line. Card: multiline-friendly.
+pub struct MatchedExcerpt {
+    /// Excerpt text. CompactRow: whitespace-normalized single line. Card: multiline-friendly.
     pub text: String,
     /// Highlight ranges into `text`, adjusted for normalization and leading ellipsis prefix.
     pub highlights: Vec<Utf16HighlightRange>,
@@ -426,11 +432,77 @@ pub struct ListDecoration {
     pub line_number: u64,
 }
 
-/// Decoration payload for a single list-decoration request result.
-#[derive(Debug, Clone, PartialEq, uniffi::Record)]
-pub struct ListDecorationResult {
+/// Request needed to resolve a deferred matched excerpt.
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct MatchedExcerptRequest {
     pub item_id: String,
-    pub decoration: Option<ListDecoration>,
+    pub query: String,
+    pub presentation_profile: ListPresentationProfile,
+    /// Guards against resolving stale requests after the item content changed.
+    pub content_hash: String,
+}
+
+/// Why a matched excerpt could not be produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum ExcerptUnavailableReason {
+    ItemMissing,
+    ContentChanged,
+    EmptyQuery,
+}
+
+/// Explicit placeholder to render while a matched excerpt is deferred.
+#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
+pub enum ExcerptPlaceholder {
+    Baseline {
+        excerpt: BaselineExcerpt,
+    },
+    CompatibleCached {
+        source_query: String,
+        excerpt: MatchedExcerpt,
+    },
+    Provisional {
+        excerpt: BaselineExcerpt,
+    },
+}
+
+/// Query-specific row presentation.
+#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
+pub enum SearchRowPresentation {
+    Ready {
+        excerpt: MatchedExcerpt,
+    },
+    Deferred {
+        request: MatchedExcerptRequest,
+        placeholder: ExcerptPlaceholder,
+    },
+    Unavailable {
+        fallback: BaselineExcerpt,
+        reason: ExcerptUnavailableReason,
+    },
+}
+
+/// Complete row presentation state.
+#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
+pub enum RowPresentation {
+    Baseline {
+        excerpt: BaselineExcerpt,
+    },
+    Search {
+        presentation: SearchRowPresentation,
+    },
+}
+
+/// Result of resolving a deferred matched excerpt request.
+#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
+pub enum MatchedExcerptResolution {
+    Ready {
+        item_id: String,
+        excerpt: MatchedExcerpt,
+    },
+    Unavailable {
+        item_id: String,
+        reason: ExcerptUnavailableReason,
+    },
 }
 
 /// Preview-only highlight decoration for the full item content.
@@ -453,7 +525,6 @@ pub struct PreviewPayload {
 pub struct ItemMetadata {
     pub item_id: String,
     pub icon: ItemIcon,
-    pub snippet: String,
     pub source_app: Option<String>,
     pub source_app_bundle_id: Option<String>,
     pub timestamp_unix: i64,
@@ -464,8 +535,7 @@ pub struct ItemMetadata {
 #[derive(Debug, Clone, PartialEq, uniffi::Record)]
 pub struct ItemMatch {
     pub item_metadata: ItemMetadata,
-    /// List decoration data. None for lazy results - call compute_list_decorations to populate.
-    pub list_decoration: Option<ListDecoration>,
+    pub presentation: RowPresentation,
 }
 
 /// Search result container
@@ -654,14 +724,11 @@ pub trait ClipboardStoreApi: Send + Sync {
         presentation: ListPresentationProfile,
     ) -> Result<SearchResult, ClipKittyError>;
 
-    /// Compute list decorations for multiple items given the search query.
-    /// Called on-demand for visible items in the list view.
-    fn compute_list_decorations(
+    /// Resolve deferred matched excerpts for visible rows.
+    fn resolve_matched_excerpts(
         &self,
-        item_ids: Vec<String>,
-        query: String,
-        presentation: ListPresentationProfile,
-    ) -> Result<Vec<ListDecorationResult>, ClipKittyError>;
+        requests: Vec<MatchedExcerptRequest>,
+    ) -> Result<Vec<MatchedExcerptResolution>, ClipKittyError>;
 
     /// Load the preview payload for a single item given the search query.
     fn load_preview_payload(

--- a/purr/src/interface.rs
+++ b/purr/src/interface.rs
@@ -465,10 +465,13 @@ pub enum ExcerptPlaceholder {
     },
 }
 
-/// Query-specific row presentation.
+/// Complete row presentation state.
 #[derive(Debug, Clone, PartialEq, uniffi::Enum)]
-pub enum SearchRowPresentation {
-    Ready {
+pub enum RowPresentation {
+    Baseline {
+        excerpt: BaselineExcerpt,
+    },
+    Matched {
         excerpt: MatchedExcerpt,
     },
     Deferred {
@@ -478,17 +481,6 @@ pub enum SearchRowPresentation {
     Unavailable {
         fallback: BaselineExcerpt,
         reason: ExcerptUnavailableReason,
-    },
-}
-
-/// Complete row presentation state.
-#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
-pub enum RowPresentation {
-    Baseline {
-        excerpt: BaselineExcerpt,
-    },
-    Search {
-        presentation: SearchRowPresentation,
     },
 }
 

--- a/purr/src/match_presentation.rs
+++ b/purr/src/match_presentation.rs
@@ -1,5 +1,5 @@
 use crate::candidate::{ScoringPhase, SearchMatchContext};
-use crate::database::{Database, SearchItemMetadata};
+use crate::database::{Database, SearchRowMetadata};
 use crate::interface::{
     BaselineExcerpt, ClipKittyError, ClipboardItem, ExcerptPlaceholder,
     ExcerptUnavailableReason, ListPresentationProfile, MatchedExcerpt, MatchedExcerptRequest,
@@ -442,13 +442,13 @@ impl<'a> MatchPresentation<'a> {
         let id_refs: Vec<&str> = item_ids.iter().map(|s| s.as_str()).collect();
         let metadata_rows = self
             .db
-            .fetch_search_item_metadata_by_string_ids(&id_refs, ListPresentationProfile::CompactRow)?;
-        let metadata_map: HashMap<String, SearchItemMetadata> = metadata_rows
+            .fetch_search_row_metadata_by_string_ids(&id_refs, ListPresentationProfile::CompactRow)?;
+        let metadata_map: HashMap<String, SearchRowMetadata> = metadata_rows
             .into_iter()
-            .map(|metadata| (metadata.item_metadata.item_id.clone(), metadata))
+            .map(|metadata| (metadata.row_metadata.item_metadata.item_id.clone(), metadata))
             .collect();
         // Find items not in match-context cache (need full content for highlighting).
-        let missing_row_ids: Vec<i64> = requests
+        let missing_item_ids: Vec<String> = requests
             .iter()
             .filter(|request| {
                 let Some(metadata) = metadata_map.get(request.item_id.as_str()) else {
@@ -465,13 +465,9 @@ impl<'a> MatchPresentation<'a> {
                     None => true,
                 }
             })
-            .filter_map(|request| {
-                metadata_map
-                    .get(request.item_id.as_str())
-                    .map(|metadata| metadata.row_id)
-            })
+            .map(|request| request.item_id.clone())
             .collect();
-        let items = self.db.fetch_items_by_ids(&missing_row_ids)?;
+        let items = self.db.fetch_items_by_item_ids(&missing_item_ids)?;
         let item_map: HashMap<String, StoredItem> = items
             .into_iter()
             .map(|item| (item.item_id.clone(), item))

--- a/purr/src/match_presentation.rs
+++ b/purr/src/match_presentation.rs
@@ -1,8 +1,9 @@
 use crate::candidate::{ScoringPhase, SearchMatchContext};
 use crate::database::{Database, SearchItemMetadata};
 use crate::interface::{
-    ClipKittyError, ClipboardItem, ItemMetadata, ListDecoration, ListDecorationResult,
-    ListPresentationProfile, PreviewPayload,
+    BaselineExcerpt, ClipKittyError, ClipboardItem, ExcerptPlaceholder,
+    ExcerptUnavailableReason, ListPresentationProfile, MatchedExcerpt, MatchedExcerptRequest,
+    MatchedExcerptResolution, PreviewPayload,
 };
 use crate::models::StoredItem;
 use crate::search::{self, HighlightAnalysis};
@@ -336,6 +337,30 @@ impl HighlightAnalysisCache {
         cached
     }
 
+    pub(crate) fn get_compatible_ready_match_context(
+        &self,
+        query: &str,
+        item_id: &str,
+        parent_content_hash: &str,
+    ) -> Option<(String, CachedMatchContext, Arc<HighlightAnalysis>)> {
+        let query_key = Self::normalized_query(query)?;
+        let state = self.state.lock();
+        state.query_order.iter().rev().find_map(|source_query| {
+            if source_query == &query_key || !Self::queries_are_compatible(source_query, &query_key) {
+                return None;
+            }
+            let context = state
+                .match_contexts_by_query
+                .get(source_query)
+                .and_then(|entries| entries.get(item_id))?;
+            if !context.matches_parent_hash(parent_content_hash) {
+                return None;
+            }
+            let analysis = context.analysis()?;
+            Some((source_query.clone(), context.clone(), analysis))
+        })
+    }
+
     pub(crate) fn insert_match_context(
         &self,
         query: &str,
@@ -361,6 +386,10 @@ impl HighlightAnalysisCache {
                 scoring_phase,
             ),
         );
+    }
+
+    fn queries_are_compatible(source_query: &str, target_query: &str) -> bool {
+        source_query.starts_with(target_query) || target_query.starts_with(source_query)
     }
 
     pub(crate) fn set_match_context_analysis(
@@ -398,37 +427,49 @@ impl<'a> MatchPresentation<'a> {
         Self { db, cache }
     }
 
-    pub(crate) fn compute_list_decorations(
+    pub(crate) fn resolve_matched_excerpts(
         &self,
-        item_ids: Vec<String>,
-        query: String,
-        profile: ListPresentationProfile,
-    ) -> Result<Vec<ListDecorationResult>, ClipKittyError> {
-        if item_ids.is_empty() {
+        requests: Vec<MatchedExcerptRequest>,
+    ) -> Result<Vec<MatchedExcerptResolution>, ClipKittyError> {
+        if requests.is_empty() {
             return Ok(Vec::new());
         }
 
+        let item_ids: Vec<String> = requests
+            .iter()
+            .map(|request| request.item_id.clone())
+            .collect();
         let id_refs: Vec<&str> = item_ids.iter().map(|s| s.as_str()).collect();
         let metadata_rows = self
             .db
-            .fetch_search_item_metadata_by_string_ids(&id_refs, profile)?;
+            .fetch_search_item_metadata_by_string_ids(&id_refs, ListPresentationProfile::CompactRow)?;
         let metadata_map: HashMap<String, SearchItemMetadata> = metadata_rows
             .into_iter()
             .map(|metadata| (metadata.item_metadata.item_id.clone(), metadata))
             .collect();
         // Find items not in match-context cache (need full content for highlighting).
-        let missing_row_ids: Vec<i64> = item_ids
+        let missing_row_ids: Vec<i64> = requests
             .iter()
-            .filter(|id| {
-                let Some(metadata) = metadata_map.get(id.as_str()) else {
+            .filter(|request| {
+                let Some(metadata) = metadata_map.get(request.item_id.as_str()) else {
                     return true;
                 };
-                match self.cache.get_match_context(&query, id.as_str()) {
-                    Some(context) => !context.matches_parent_hash(&metadata.content_hash),
+                if metadata.content_hash != request.content_hash {
+                    return false;
+                }
+                match self
+                    .cache
+                    .get_match_context(&request.query, request.item_id.as_str())
+                {
+                    Some(context) => !context.matches_parent_hash(&request.content_hash),
                     None => true,
                 }
             })
-            .filter_map(|id| metadata_map.get(id.as_str()).map(|m| m.row_id))
+            .filter_map(|request| {
+                metadata_map
+                    .get(request.item_id.as_str())
+                    .map(|metadata| metadata.row_id)
+            })
             .collect();
         let items = self.db.fetch_items_by_ids(&missing_row_ids)?;
         let item_map: HashMap<String, StoredItem> = items
@@ -437,29 +478,56 @@ impl<'a> MatchPresentation<'a> {
             .collect();
 
         use rayon::prelude::*;
-        Ok(item_ids
+        Ok(requests
             .par_iter()
-            .map(|id| {
-                let cached_context = metadata_map.get(id.as_str()).and_then(|metadata| {
-                    self.cache
-                        .get_match_context(&query, id.as_str())
-                        .filter(|context| context.matches_parent_hash(&metadata.content_hash))
-                });
-                let decoration = if cached_context.is_some() {
-                    Some(self.list_decoration_for_cached_match(id, &query, profile))
-                } else {
-                    item_map.get(id).map(|item| {
-                        self.list_decoration_for_item(
-                            id,
-                            item.content.text_content(),
-                            &query,
-                            profile,
-                        )
-                    })
+            .map(|request| {
+                if request.query.trim().is_empty() {
+                    return MatchedExcerptResolution::Unavailable {
+                        item_id: request.item_id.clone(),
+                        reason: ExcerptUnavailableReason::EmptyQuery,
+                    };
+                }
+
+                let Some(metadata) = metadata_map.get(request.item_id.as_str()) else {
+                    return MatchedExcerptResolution::Unavailable {
+                        item_id: request.item_id.clone(),
+                        reason: ExcerptUnavailableReason::ItemMissing,
+                    };
                 };
-                ListDecorationResult {
-                    item_id: id.clone(),
-                    decoration,
+                if metadata.content_hash != request.content_hash {
+                    return MatchedExcerptResolution::Unavailable {
+                        item_id: request.item_id.clone(),
+                        reason: ExcerptUnavailableReason::ContentChanged,
+                    };
+                }
+
+                let cached_context = self
+                    .cache
+                    .get_match_context(&request.query, request.item_id.as_str())
+                    .filter(|context| context.matches_parent_hash(&request.content_hash));
+                let excerpt = if cached_context.is_some() {
+                    self.matched_excerpt_for_cached_match(
+                        &request.item_id,
+                        &request.query,
+                        request.presentation_profile,
+                    )
+                } else if let Some(item) = item_map.get(request.item_id.as_str()) {
+                    self.matched_excerpt_for_item(
+                        &request.item_id,
+                        item.content.text_content(),
+                        &request.query,
+                        request.presentation_profile,
+                    )
+                } else {
+                    return MatchedExcerptResolution::Unavailable {
+                        item_id: request.item_id.clone(),
+                        reason: ExcerptUnavailableReason::ItemMissing,
+                    };
+                };
+
+                MatchedExcerptResolution::Ready {
+                    item_id: request.item_id.clone(),
+                    excerpt,
                 }
             })
             .collect())
@@ -536,37 +604,48 @@ impl<'a> MatchPresentation<'a> {
         );
     }
 
-    pub(crate) fn apply_match_context_snippet(
+    pub(crate) fn placeholder_for_deferred_match(
         &self,
         item_id: &str,
         query: &str,
-        item_metadata: &mut ItemMetadata,
+        parent_content_hash: &str,
+        baseline_excerpt: &BaselineExcerpt,
         match_context: &SearchMatchContext,
         profile: ListPresentationProfile,
-    ) {
+    ) -> ExcerptPlaceholder {
+        if let Some((source_query, context, analysis)) = self
+            .cache
+            .get_compatible_ready_match_context(query, item_id, parent_content_hash)
+        {
+            return ExcerptPlaceholder::CompatibleCached {
+                source_query,
+                excerpt: search::create_matched_excerpt(context.content(), &analysis.highlights, profile),
+            };
+        }
+
         if matches!(match_context, SearchMatchContext::Chunk(_)) {
-            item_metadata.snippet = self
-                .analysis_for_cached_match_context(item_id, query)
-                .map(|(context, analysis)| {
-                    search::create_list_decoration(context.content(), &analysis.highlights, profile)
-                        .text
-                })
-                .unwrap_or_else(|| {
-                    search::generate_preview_for_profile(match_context.content(), profile)
-                });
+            return ExcerptPlaceholder::Provisional {
+                excerpt: BaselineExcerpt {
+                    text: search::generate_preview_for_profile(match_context.content(), profile),
+                },
+            };
+        }
+
+        ExcerptPlaceholder::Baseline {
+            excerpt: baseline_excerpt.clone(),
         }
     }
 
-    pub(crate) fn list_decoration_for_cached_match(
+    pub(crate) fn matched_excerpt_for_cached_match(
         &self,
         item_id: &str,
         query: &str,
         profile: ListPresentationProfile,
-    ) -> ListDecoration {
+    ) -> MatchedExcerpt {
         if let Some((context, analysis)) = self.analysis_for_cached_match_context(item_id, query) {
-            search::create_list_decoration(context.content(), &analysis.highlights, profile)
+            search::create_matched_excerpt(context.content(), &analysis.highlights, profile)
         } else {
-            ListDecoration {
+            MatchedExcerpt {
                 text: String::new(),
                 highlights: Vec::new(),
                 line_number: 0,
@@ -574,17 +653,17 @@ impl<'a> MatchPresentation<'a> {
         }
     }
 
-    pub(crate) fn list_decoration_for_item(
+    pub(crate) fn matched_excerpt_for_item(
         &self,
         item_id: &str,
         content: &str,
         query: &str,
         profile: ListPresentationProfile,
-    ) -> ListDecoration {
+    ) -> MatchedExcerpt {
         if let Some(analysis) = self.analysis_for_item(item_id, content, query) {
-            search::create_list_decoration(content, &analysis.highlights, profile)
+            search::create_matched_excerpt(content, &analysis.highlights, profile)
         } else {
-            search::compute_list_decoration(content, query, profile)
+            search::compute_matched_excerpt(content, query, profile)
         }
     }
 

--- a/purr/src/models.rs
+++ b/purr/src/models.rs
@@ -7,7 +7,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use crate::interface::{
-    ClipboardContent, ClipboardItem, FileEntry, FileStatus, ItemIcon, ItemMetadata,
+    BaselineExcerpt, ClipboardContent, ClipboardItem, FileEntry, FileStatus, ItemIcon, ItemMetadata,
     ListPresentationProfile,
 };
 #[cfg(test)]
@@ -240,13 +240,10 @@ impl StoredItem {
     }
 
     /// Convert to ItemMetadata for list display
-    /// Preview is generous (SNIPPET_CONTEXT_CHARS * 2) - Swift handles final truncation
     pub fn to_metadata(&self) -> ItemMetadata {
-        use crate::search::SNIPPET_CONTEXT_CHARS;
         ItemMetadata {
             item_id: self.item_id.clone(),
             icon: self.item_icon(),
-            snippet: self.display_text(SNIPPET_CONTEXT_CHARS * 2),
             source_app: self.source_app.clone(),
             source_app_bundle_id: self.source_app_bundle_id.clone(),
             timestamp_unix: self.timestamp_unix,
@@ -254,16 +251,21 @@ impl StoredItem {
         }
     }
 
-    /// Convert to ItemMetadata using a presentation-profile-aware snippet.
-    pub fn to_metadata_for_profile(&self, profile: ListPresentationProfile) -> ItemMetadata {
+    /// Convert to ItemMetadata; row excerpts are modeled separately.
+    pub fn to_metadata_for_profile(&self, _profile: ListPresentationProfile) -> ItemMetadata {
         ItemMetadata {
             item_id: self.item_id.clone(),
             icon: self.item_icon(),
-            snippet: crate::search::generate_preview_for_profile(self.text_content(), profile),
             source_app: self.source_app.clone(),
             source_app_bundle_id: self.source_app_bundle_id.clone(),
             timestamp_unix: self.timestamp_unix,
             tags: Vec::new(),
+        }
+    }
+
+    pub fn baseline_excerpt_for_profile(&self, profile: ListPresentationProfile) -> BaselineExcerpt {
+        BaselineExcerpt {
+            text: crate::search::generate_preview_for_profile(self.text_content(), profile),
         }
     }
 
@@ -396,7 +398,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stored_item_multi_file_snippet() {
+    fn test_stored_item_multi_file_display_text() {
         // 2 files: "a.txt, b.txt"
         let item = StoredItem::new_files(
             vec!["/tmp/a.txt".into(), "/tmp/b.txt".into()],

--- a/purr/src/search.rs
+++ b/purr/src/search.rs
@@ -9,8 +9,7 @@
 use crate::indexer::Indexer;
 use crate::interface::ClipKittyError;
 use crate::interface::{
-    HighlightKind, ItemMatch, ItemMetadata, ListDecoration, ListPresentationProfile,
-    PreviewDecoration, Utf16HighlightRange,
+    HighlightKind, ListPresentationProfile, MatchedExcerpt, PreviewDecoration, Utf16HighlightRange,
 };
 use crate::ranking::{
     does_word_match, does_word_match_fast, does_word_match_fast_raw, prefix_match_for_query_word,
@@ -681,18 +680,18 @@ pub(crate) fn generate_snippet_with_policy(
     (final_snippet, adjusted_highlights, line_number)
 }
 
-/// Create list decoration from full-content scalar highlights, using a presentation profile.
-pub(crate) fn create_list_decoration(
+/// Create a matched excerpt from full-content scalar highlights, using a presentation profile.
+pub(crate) fn create_matched_excerpt(
     content: &str,
     highlights: &[HighlightRange],
     profile: ListPresentationProfile,
-) -> ListDecoration {
+) -> MatchedExcerpt {
     let policy = ExcerptPolicy::for_profile(profile);
     let (text, adjusted_highlights, line_number) =
         generate_snippet_with_policy(content, highlights, &policy);
     let highlights = scalar_highlights_to_utf16(&text, &adjusted_highlights);
 
-    ListDecoration {
+    MatchedExcerpt {
         text,
         highlights,
         line_number,
@@ -741,13 +740,6 @@ pub(crate) fn create_preview_decoration_with_char_offset(
     PreviewDecoration {
         highlights: scalar_highlights_to_utf16(content, &shifted_highlights),
         initial_scroll_highlight_index,
-    }
-}
-
-pub(crate) fn create_lazy_item_match_with_metadata(item_metadata: ItemMetadata) -> ItemMatch {
-    ItemMatch {
-        item_metadata,
-        list_decoration: None,
     }
 }
 
@@ -903,17 +895,17 @@ fn compute_word_match_highlights(content: &str, query: &str) -> Vec<HighlightRan
         .collect()
 }
 
-/// Compute list decoration for an item given a query and presentation profile.
-pub(crate) fn compute_list_decoration(
+/// Compute a matched excerpt for an item given a query and presentation profile.
+pub(crate) fn compute_matched_excerpt(
     content: &str,
     query: &str,
     profile: ListPresentationProfile,
-) -> ListDecoration {
+) -> MatchedExcerpt {
     let trimmed = query.trim();
     if trimmed.is_empty() {
         let policy = ExcerptPolicy::for_profile(profile);
         let (text, _, _) = generate_snippet_with_policy(content, &[], &policy);
-        return ListDecoration {
+        return MatchedExcerpt {
             text,
             highlights: Vec::new(),
             line_number: 0,
@@ -922,7 +914,7 @@ pub(crate) fn compute_list_decoration(
 
     let analysis =
         analyze_content_for_query(content, trimmed).expect("non-empty query should analyze");
-    create_list_decoration(content, &analysis.highlights, profile)
+    create_matched_excerpt(content, &analysis.highlights, profile)
 }
 
 /// Tokenize text into tokens with char offsets.
@@ -1658,7 +1650,7 @@ error: Build failed due to failed dependency";
         );
         assert_eq!(preview.initial_scroll_highlight_index, Some(0));
 
-        let row = compute_list_decoration(content, "func", ListPresentationProfile::CompactRow);
+        let row = compute_matched_excerpt(content, "func", ListPresentationProfile::CompactRow);
         assert!(row.text.contains("func top level"));
     }
 

--- a/purr/src/search_result_builder.rs
+++ b/purr/src/search_result_builder.rs
@@ -1,7 +1,7 @@
-use crate::database::{BrowseItemMetadata, Database, SearchItemMetadata};
+use crate::database::{Database, RowMetadata, SearchRowMetadata};
 use crate::interface::{
     ClipKittyError, ContentTypeFilter, ItemMatch, ItemQueryFilter, ItemTag, ListPresentationProfile,
-    MatchedExcerptRequest, RowPresentation, SearchResult, SearchRowPresentation,
+    MatchedExcerptRequest, RowPresentation, SearchResult,
 };
 use crate::match_presentation::{HighlightAnalysisCache, MatchPresentation};
 use crate::models::StoredItem;
@@ -54,7 +54,7 @@ impl<'a> SearchResultAssembler<'a> {
         filter: ItemQueryFilter,
     ) -> Result<SearchResult, ClipKittyError> {
         let (content_type_filter, tag_filter) = split_filter(filter);
-        let (mut items, total_count) = self.db.fetch_item_metadata(
+        let (mut items, total_count) = self.db.fetch_browse_row_metadata(
             None,
             1000,
             content_type_filter.as_ref(),
@@ -190,7 +190,7 @@ impl<'a> SearchResultAssembler<'a> {
             .collect();
         let metadata_rows = self
             .db
-            .fetch_search_item_metadata_by_string_ids(&ids, self.presentation)?;
+            .fetch_search_row_metadata_by_string_ids(&ids, self.presentation)?;
         if self.token.is_cancelled() {
             return Err(ClipKittyError::Cancelled);
         }
@@ -206,14 +206,16 @@ impl<'a> SearchResultAssembler<'a> {
             None
         };
 
-        let metadata_map: HashMap<String, SearchItemMetadata> = metadata_rows
+        let metadata_map: HashMap<String, SearchRowMetadata> = metadata_rows
             .into_iter()
             .filter(|metadata| match &tagged_ids {
-                Some(tagged_ids) => tagged_ids.contains(&metadata.item_metadata.item_id),
+                Some(tagged_ids) => {
+                    tagged_ids.contains(&metadata.row_metadata.item_metadata.item_id)
+                }
                 None => true,
             })
             .filter(|metadata| metadata_matches_filter(metadata, filter))
-            .map(|metadata| (metadata.item_metadata.item_id.clone(), metadata))
+            .map(|metadata| (metadata.row_metadata.item_metadata.item_id.clone(), metadata))
             .collect();
 
         let presentation = self.presentation();
@@ -246,15 +248,13 @@ impl<'a> SearchResultAssembler<'a> {
                     return Err(ClipKittyError::Cancelled);
                 }
                 ItemMatch {
-                    item_metadata: metadata.item_metadata.clone(),
-                    presentation: RowPresentation::Search {
-                        presentation: SearchRowPresentation::Ready {
-                            excerpt: presentation.matched_excerpt_for_cached_match(
-                                &candidate.id,
-                                query.raw_text(),
-                                self.presentation,
-                            ),
-                        },
+                    item_metadata: metadata.row_metadata.item_metadata.clone(),
+                    presentation: RowPresentation::Matched {
+                        excerpt: presentation.matched_excerpt_for_cached_match(
+                            &candidate.id,
+                            query.raw_text(),
+                            self.presentation,
+                        ),
                     },
                 }
             } else {
@@ -262,22 +262,20 @@ impl<'a> SearchResultAssembler<'a> {
                     &candidate.id,
                     query.raw_text(),
                     &metadata.content_hash,
-                    &metadata.baseline_excerpt,
+                    &metadata.row_metadata.baseline_excerpt,
                     candidate.match_context(),
                     self.presentation,
                 );
                 ItemMatch {
-                    item_metadata: metadata.item_metadata.clone(),
-                    presentation: RowPresentation::Search {
-                        presentation: SearchRowPresentation::Deferred {
-                            request: MatchedExcerptRequest {
-                                item_id: candidate.id.clone(),
-                                query: query.raw_text().to_string(),
-                                presentation_profile: self.presentation,
-                                content_hash: metadata.content_hash.clone(),
-                            },
-                            placeholder,
+                    item_metadata: metadata.row_metadata.item_metadata.clone(),
+                    presentation: RowPresentation::Deferred {
+                        request: MatchedExcerptRequest {
+                            item_id: candidate.id.clone(),
+                            query: query.raw_text().to_string(),
+                            presentation_profile: self.presentation,
+                            content_hash: metadata.content_hash.clone(),
                         },
+                        placeholder,
                     },
                 }
             };
@@ -318,15 +316,13 @@ impl<'a> SearchResultAssembler<'a> {
             .filter_map(|id| {
                 item_map.get(id).map(|item| ItemMatch {
                     item_metadata: item.to_metadata_for_profile(self.presentation),
-                    presentation: RowPresentation::Search {
-                        presentation: SearchRowPresentation::Ready {
-                            excerpt: presentation.matched_excerpt_for_item(
-                                &item.item_id,
-                                item.content.text_content(),
-                                query,
-                                self.presentation,
-                            ),
-                        },
+                    presentation: RowPresentation::Matched {
+                        excerpt: presentation.matched_excerpt_for_item(
+                            &item.item_id,
+                            item.content.text_content(),
+                            query,
+                            self.presentation,
+                        ),
                     },
                 })
             })
@@ -350,7 +346,7 @@ impl<'a> SearchResultAssembler<'a> {
 
     fn hydrate_item_metadata_tags(
         &self,
-        items: &mut [BrowseItemMetadata],
+        items: &mut [RowMetadata],
     ) -> Result<(), ClipKittyError> {
         let ids: Vec<String> = items
             .iter()
@@ -372,7 +368,7 @@ impl<'a> SearchResultAssembler<'a> {
 }
 
 fn metadata_matches_filter(
-    metadata: &SearchItemMetadata,
+    metadata: &SearchRowMetadata,
     filter: Option<&ContentTypeFilter>,
 ) -> bool {
     match filter {

--- a/purr/src/search_result_builder.rs
+++ b/purr/src/search_result_builder.rs
@@ -1,7 +1,7 @@
-use crate::database::{Database, SearchItemMetadata};
+use crate::database::{BrowseItemMetadata, Database, SearchItemMetadata};
 use crate::interface::{
-    ClipKittyError, ContentTypeFilter, ItemMatch, ItemMetadata, ItemQueryFilter, ItemTag,
-    ListPresentationProfile, SearchResult,
+    ClipKittyError, ContentTypeFilter, ItemMatch, ItemQueryFilter, ItemTag, ListPresentationProfile,
+    MatchedExcerptRequest, RowPresentation, SearchResult, SearchRowPresentation,
 };
 use crate::match_presentation::{HighlightAnalysisCache, MatchPresentation};
 use crate::models::StoredItem;
@@ -63,16 +63,20 @@ impl<'a> SearchResultAssembler<'a> {
         )?;
         self.hydrate_item_metadata_tags(&mut items)?;
         let first_preview_payload = self.presentation().load_first_preview_payload(
-            items.first().map(|item| item.item_id.as_str()),
+            items
+                .first()
+                .map(|item| item.item_metadata.item_id.as_str()),
             "",
             self.token,
             self.runtime,
         )?;
         let matches = items
             .into_iter()
-            .map(|item_metadata| ItemMatch {
-                item_metadata,
-                list_decoration: None,
+            .map(|item| ItemMatch {
+                item_metadata: item.item_metadata,
+                presentation: RowPresentation::Baseline {
+                    excerpt: item.baseline_excerpt,
+                },
             })
             .collect();
 
@@ -232,14 +236,6 @@ impl<'a> SearchResultAssembler<'a> {
                 candidate.scoring_phase(),
             );
 
-            let mut item_metadata = metadata.item_metadata.clone();
-            presentation.apply_match_context_snippet(
-                &candidate.id,
-                query.raw_text(),
-                &mut item_metadata,
-                candidate.match_context(),
-                self.presentation,
-            );
             let is_short = candidate.content().len() <= SHORT_CONTENT_THRESHOLD;
             let item_match = if eager_index < EAGER_MATCH_DATA_COUNT
                 || (is_short && eager_index < EAGER_SHORT_MATCH_WINDOW)
@@ -250,15 +246,40 @@ impl<'a> SearchResultAssembler<'a> {
                     return Err(ClipKittyError::Cancelled);
                 }
                 ItemMatch {
-                    item_metadata,
-                    list_decoration: Some(presentation.list_decoration_for_cached_match(
-                        &candidate.id,
-                        query.raw_text(),
-                        self.presentation,
-                    )),
+                    item_metadata: metadata.item_metadata.clone(),
+                    presentation: RowPresentation::Search {
+                        presentation: SearchRowPresentation::Ready {
+                            excerpt: presentation.matched_excerpt_for_cached_match(
+                                &candidate.id,
+                                query.raw_text(),
+                                self.presentation,
+                            ),
+                        },
+                    },
                 }
             } else {
-                search::create_lazy_item_match_with_metadata(item_metadata)
+                let placeholder = presentation.placeholder_for_deferred_match(
+                    &candidate.id,
+                    query.raw_text(),
+                    &metadata.content_hash,
+                    &metadata.baseline_excerpt,
+                    candidate.match_context(),
+                    self.presentation,
+                );
+                ItemMatch {
+                    item_metadata: metadata.item_metadata.clone(),
+                    presentation: RowPresentation::Search {
+                        presentation: SearchRowPresentation::Deferred {
+                            request: MatchedExcerptRequest {
+                                item_id: candidate.id.clone(),
+                                query: query.raw_text().to_string(),
+                                presentation_profile: self.presentation,
+                                content_hash: metadata.content_hash.clone(),
+                            },
+                            placeholder,
+                        },
+                    },
+                }
             };
             if self.token.is_cancelled() {
                 return Err(ClipKittyError::Cancelled);
@@ -297,12 +318,16 @@ impl<'a> SearchResultAssembler<'a> {
             .filter_map(|id| {
                 item_map.get(id).map(|item| ItemMatch {
                     item_metadata: item.to_metadata_for_profile(self.presentation),
-                    list_decoration: Some(presentation.list_decoration_for_item(
-                        &item.item_id,
-                        item.content.text_content(),
-                        query,
-                        self.presentation,
-                    )),
+                    presentation: RowPresentation::Search {
+                        presentation: SearchRowPresentation::Ready {
+                            excerpt: presentation.matched_excerpt_for_item(
+                                &item.item_id,
+                                item.content.text_content(),
+                                query,
+                                self.presentation,
+                            ),
+                        },
+                    },
                 })
             })
             .collect())
@@ -323,11 +348,20 @@ impl<'a> SearchResultAssembler<'a> {
         Ok(())
     }
 
-    fn hydrate_item_metadata_tags(&self, items: &mut [ItemMetadata]) -> Result<(), ClipKittyError> {
-        let ids: Vec<String> = items.iter().map(|item| item.item_id.clone()).collect();
+    fn hydrate_item_metadata_tags(
+        &self,
+        items: &mut [BrowseItemMetadata],
+    ) -> Result<(), ClipKittyError> {
+        let ids: Vec<String> = items
+            .iter()
+            .map(|item| item.item_metadata.item_id.clone())
+            .collect();
         let tags_by_id = self.db.get_tags_for_item_ids(&ids)?;
         for item in items {
-            item.tags = tags_by_id.get(&item.item_id).cloned().unwrap_or_default();
+            item.item_metadata.tags = tags_by_id
+                .get(&item.item_metadata.item_id)
+                .cloned()
+                .unwrap_or_default();
         }
         Ok(())
     }

--- a/purr/src/search_service.rs
+++ b/purr/src/search_service.rs
@@ -1,8 +1,8 @@
 use crate::database::Database;
 use crate::indexer::Indexer;
 use crate::interface::{
-    ClipKittyError, ItemMatch, ItemQueryFilter, ListDecorationResult, ListPresentationProfile,
-    PreviewPayload, SearchResult,
+    ClipKittyError, ItemMatch, ItemQueryFilter, ListPresentationProfile, MatchedExcerptRequest,
+    MatchedExcerptResolution, PreviewPayload, SearchResult,
 };
 use crate::match_presentation::{HighlightAnalysisCache, MatchPresentation};
 use crate::search;
@@ -90,14 +90,12 @@ pub(crate) async fn execute_search(
         .build_search_result(parsed_query.raw_text(), matches)
 }
 
-pub(crate) fn compute_list_decorations(
+pub(crate) fn resolve_matched_excerpts(
     db: &Database,
     cache: &HighlightAnalysisCache,
-    item_ids: Vec<String>,
-    query: String,
-    presentation: ListPresentationProfile,
-) -> Result<Vec<ListDecorationResult>, ClipKittyError> {
-    MatchPresentation::new(db, cache).compute_list_decorations(item_ids, query, presentation)
+    requests: Vec<MatchedExcerptRequest>,
+) -> Result<Vec<MatchedExcerptResolution>, ClipKittyError> {
+    MatchPresentation::new(db, cache).resolve_matched_excerpts(requests)
 }
 
 pub(crate) fn load_preview_payload(

--- a/purr/src/store.rs
+++ b/purr/src/store.rs
@@ -4,8 +4,8 @@ use crate::database::Database;
 use crate::indexer::{IndexInspection, Indexer};
 use crate::interface::{
     ClipKittyError, ClipboardItem, ClipboardStoreApi, ItemQueryFilter, ItemTag,
-    ListDecorationResult, ListPresentationProfile, PreviewPayload, SearchOutcome, SearchResult,
-    StoreBootstrapPlan,
+    ListPresentationProfile, MatchedExcerptRequest, MatchedExcerptResolution, PreviewPayload,
+    SearchOutcome, SearchResult, StoreBootstrapPlan,
 };
 #[cfg(feature = "sync")]
 use crate::sync_bridge::{RealSyncEmitter, SyncEmitter};
@@ -385,19 +385,11 @@ impl ClipboardStoreApi for ClipboardStore {
         Ok(items)
     }
 
-    fn compute_list_decorations(
+    fn resolve_matched_excerpts(
         &self,
-        item_ids: Vec<String>,
-        query: String,
-        presentation: ListPresentationProfile,
-    ) -> Result<Vec<ListDecorationResult>, ClipKittyError> {
-        search_service::compute_list_decorations(
-            &self.db,
-            &self.analysis_cache,
-            item_ids,
-            query,
-            presentation,
-        )
+        requests: Vec<MatchedExcerptRequest>,
+    ) -> Result<Vec<MatchedExcerptResolution>, ClipKittyError> {
+        search_service::resolve_matched_excerpts(&self.db, &self.analysis_cache, requests)
     }
 
     fn load_preview_payload(

--- a/purr/tests/snippet_tests.rs
+++ b/purr/tests/snippet_tests.rs
@@ -3,7 +3,7 @@
 use purr::search::generate_preview;
 use purr::{
     ClipboardStore, ClipboardStoreApi, HighlightKind, ListPresentationProfile, MatchedExcerpt,
-    RowPresentation, SearchRowPresentation,
+    RowPresentation,
 };
 use tempfile::TempDir;
 
@@ -28,9 +28,7 @@ async fn matched_excerpt_for_profile(
 
     let result = store.search(query.to_string(), profile).await.unwrap();
     match &result.matches[0].presentation {
-        RowPresentation::Search {
-            presentation: SearchRowPresentation::Ready { excerpt },
-        } => excerpt.clone(),
+        RowPresentation::Matched { excerpt } => excerpt.clone(),
         other => panic!("expected ready matched excerpt, got {other:?}"),
     }
 }
@@ -102,9 +100,7 @@ async fn trigram_search_eagerly_decorates_initial_short_results() {
             .iter()
             .all(|item| matches!(
                 item.presentation,
-                RowPresentation::Search {
-                    presentation: SearchRowPresentation::Ready { .. }
-                }
+                RowPresentation::Matched { .. }
             )),
         "expected every short initial trigram match to have a ready matched excerpt"
     );

--- a/purr/tests/snippet_tests.rs
+++ b/purr/tests/snippet_tests.rs
@@ -1,8 +1,9 @@
-//! Tests for preview text generation and list-decoration snippet output.
+//! Tests for preview text generation and matched excerpt output.
 
 use purr::search::generate_preview;
 use purr::{
-    ClipboardStore, ClipboardStoreApi, HighlightKind, ListDecoration, ListPresentationProfile,
+    ClipboardStore, ClipboardStoreApi, HighlightKind, ListPresentationProfile, MatchedExcerpt,
+    RowPresentation, SearchRowPresentation,
 };
 use tempfile::TempDir;
 
@@ -11,22 +12,27 @@ fn utf16_slice(text: &str, start: u64, end: u64) -> String {
     String::from_utf16(&code_units[start as usize..end as usize]).unwrap()
 }
 
-async fn list_decoration_for(content: &str, query: &str) -> ListDecoration {
-    list_decoration_for_profile(content, query, ListPresentationProfile::CompactRow).await
+async fn matched_excerpt_for(content: &str, query: &str) -> MatchedExcerpt {
+    matched_excerpt_for_profile(content, query, ListPresentationProfile::CompactRow).await
 }
 
-async fn list_decoration_for_profile(
+async fn matched_excerpt_for_profile(
     content: &str,
     query: &str,
     profile: ListPresentationProfile,
-) -> ListDecoration {
+) -> MatchedExcerpt {
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("test.db");
     let store = ClipboardStore::new(db_path.to_str().unwrap().to_string()).unwrap();
     store.save_text(content.to_string(), None, None).unwrap();
 
     let result = store.search(query.to_string(), profile).await.unwrap();
-    result.matches[0].list_decoration.clone().unwrap()
+    match &result.matches[0].presentation {
+        RowPresentation::Search {
+            presentation: SearchRowPresentation::Ready { excerpt },
+        } => excerpt.clone(),
+        other => panic!("expected ready matched excerpt, got {other:?}"),
+    }
 }
 
 #[test]
@@ -58,8 +64,8 @@ fn preview_normalizes_whitespace() {
 }
 
 #[tokio::test]
-async fn list_decoration_short_text_returns_full_content() {
-    let row = list_decoration_for("Hello World", "Hello").await;
+async fn matched_excerpt_short_text_returns_full_content() {
+    let row = matched_excerpt_for("Hello World", "Hello").await;
     assert_eq!(row.text, "Hello World");
     assert_eq!(row.line_number, 1);
     assert_eq!(
@@ -94,26 +100,31 @@ async fn trigram_search_eagerly_decorates_initial_short_results() {
         result
             .matches
             .iter()
-            .all(|item| item.list_decoration.is_some()),
-        "expected every short initial trigram match to be eagerly decorated"
+            .all(|item| matches!(
+                item.presentation,
+                RowPresentation::Search {
+                    presentation: SearchRowPresentation::Ready { .. }
+                }
+            )),
+        "expected every short initial trigram match to have a ready matched excerpt"
     );
 }
 
 #[tokio::test]
-async fn list_decoration_normalizes_whitespace() {
-    let row = list_decoration_for("Hello\n\n\nWorld", "Hello").await;
+async fn matched_excerpt_normalizes_whitespace() {
+    let row = matched_excerpt_for("Hello\n\n\nWorld", "Hello").await;
     assert_eq!(row.text, "Hello World");
 }
 
 #[tokio::test]
-async fn list_decoration_calculates_line_number() {
-    let row = list_decoration_for("Line 1\nLine 2\nLine 3 with MATCH", "MATCH").await;
+async fn matched_excerpt_calculates_line_number() {
+    let row = matched_excerpt_for("Line 1\nLine 2\nLine 3 with MATCH", "MATCH").await;
     assert_eq!(row.line_number, 3);
 }
 
 #[tokio::test]
-async fn list_decoration_extracts_utf16_highlight_correctly() {
-    let row = list_decoration_for("The quick brown fox jumps over the lazy dog", "fox").await;
+async fn matched_excerpt_extracts_utf16_highlight_correctly() {
+    let row = matched_excerpt_for("The quick brown fox jumps over the lazy dog", "fox").await;
     assert!(row.text.contains("fox"));
     assert_eq!(
         utf16_slice(
@@ -126,20 +137,20 @@ async fn list_decoration_extracts_utf16_highlight_correctly() {
 }
 
 #[tokio::test]
-async fn list_decoration_marks_truncation_with_ellipsis() {
+async fn matched_excerpt_marks_truncation_with_ellipsis() {
     let content = format!("{} MATCH {}", "x".repeat(500), "y".repeat(500));
-    let row = list_decoration_for(&content, "MATCH").await;
+    let row = matched_excerpt_for(&content, "MATCH").await;
     assert!(row.text.contains("MATCH"));
     assert!(row.text.starts_with('…'));
     assert!(row.text.ends_with('…'));
 }
 
 #[tokio::test]
-async fn list_decoration_preserves_prefix_vs_exact_highlight_kind() {
-    let prefix = list_decoration_for("Alpha beta", "al").await;
+async fn matched_excerpt_preserves_prefix_vs_exact_highlight_kind() {
+    let prefix = matched_excerpt_for("Alpha beta", "al").await;
     assert_eq!(prefix.highlights[0].kind, HighlightKind::Prefix);
 
-    let exact = list_decoration_for("zz Alpha beta", "ph").await;
+    let exact = matched_excerpt_for("zz Alpha beta", "ph").await;
     assert_eq!(exact.highlights[0].kind, HighlightKind::Exact);
 }
 
@@ -148,9 +159,9 @@ async fn list_decoration_preserves_prefix_vs_exact_highlight_kind() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn card_decoration_preserves_meaningful_newlines() {
+async fn card_matched_excerpt_preserves_meaningful_newlines() {
     let content = "Line one\nLine two\nLine three with MATCH\nLine four";
-    let row = list_decoration_for_profile(content, "MATCH", ListPresentationProfile::Card).await;
+    let row = matched_excerpt_for_profile(content, "MATCH", ListPresentationProfile::Card).await;
     // Card mode should keep newlines in the output
     assert!(
         row.text.contains('\n'),
@@ -162,9 +173,9 @@ async fn card_decoration_preserves_meaningful_newlines() {
 }
 
 #[tokio::test]
-async fn card_decoration_collapses_pathological_whitespace() {
+async fn card_matched_excerpt_collapses_pathological_whitespace() {
     let content = "Line one\n\n\n\n\n\n\n\nLine two with MATCH";
-    let row = list_decoration_for_profile(content, "MATCH", ListPresentationProfile::Card).await;
+    let row = matched_excerpt_for_profile(content, "MATCH", ListPresentationProfile::Card).await;
     // Should collapse 8 newlines down to at most 2
     let newline_count = row.text.chars().filter(|&c| c == '\n').count();
     assert!(
@@ -176,11 +187,11 @@ async fn card_decoration_collapses_pathological_whitespace() {
 }
 
 #[tokio::test]
-async fn card_decoration_has_larger_budget_than_compact() {
+async fn card_matched_excerpt_has_larger_budget_than_compact() {
     let content = format!("MATCH {}", "word ".repeat(200));
     let compact =
-        list_decoration_for_profile(&content, "MATCH", ListPresentationProfile::CompactRow).await;
-    let card = list_decoration_for_profile(&content, "MATCH", ListPresentationProfile::Card).await;
+        matched_excerpt_for_profile(&content, "MATCH", ListPresentationProfile::CompactRow).await;
+    let card = matched_excerpt_for_profile(&content, "MATCH", ListPresentationProfile::Card).await;
     // Card should produce a longer excerpt
     assert!(
         card.text.len() > compact.text.len(),
@@ -191,9 +202,9 @@ async fn card_decoration_has_larger_budget_than_compact() {
 }
 
 #[tokio::test]
-async fn card_decoration_highlight_is_correct() {
+async fn card_matched_excerpt_highlight_is_correct() {
     let content = "First line\nSecond line\nThird line with MATCH here";
-    let row = list_decoration_for_profile(content, "MATCH", ListPresentationProfile::Card).await;
+    let row = matched_excerpt_for_profile(content, "MATCH", ListPresentationProfile::Card).await;
     assert!(!row.highlights.is_empty());
     let highlighted = utf16_slice(
         &row.text,
@@ -207,7 +218,7 @@ async fn card_decoration_highlight_is_correct() {
 async fn compact_row_collapses_newlines() {
     let content = "Line one\nLine two\nLine three with MATCH";
     let row =
-        list_decoration_for_profile(content, "MATCH", ListPresentationProfile::CompactRow).await;
+        matched_excerpt_for_profile(content, "MATCH", ListPresentationProfile::CompactRow).await;
     // CompactRow should NOT contain newlines
     assert!(
         !row.text.contains('\n'),


### PR DESCRIPTION
## Summary
- Replace implicit snippet/list-decoration flow with explicit row presentation enums
- Model baseline, ready, deferred, and unavailable excerpt states directly in the shared Rust and Swift APIs
- Route stale-placeholder handling through explicit matched excerpt requests and resolutions
- Update macOS and iOS rendering, view models, and tests to consume the new presentation model

## Testing
- Rust unit and integration coverage passed, including `purr` and `snippet_tests`
- macOS `BrowserViewModelTests` passed
- iOS `iOSHighlightAndEditTests` and `iOSBrowserIntegrationTests` passed