### PR TITLE
Add Apple Shortcuts support

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -497,6 +497,7 @@ private let macAppCoreDependencies: [TargetDependency] = [
     .target(name: "ClipKittyShared"),
     .target(name: "ClipKittyAppleServices"),
     .target(name: "ClipKittyMacPlatform"),
+    .target(name: "ClipKittyShortcuts"),
     .sdk(name: "SystemConfiguration", type: .framework),
     .external(name: "STTextKitPlus"),
 ]
@@ -686,6 +687,26 @@ let project = Project(
             )
         ),
 
+        // MARK: ClipKittyShortcuts — App Intents exposed to Apple Shortcuts
+
+        .target(
+            name: "ClipKittyShortcuts",
+            destinations: [.mac, .iPhone],
+            product: .staticLibrary,
+            bundleId: "com.eviljuliette.clipkitty.shortcuts",
+            deploymentTargets: .multiplatform(iOS: "26.0", macOS: "14.0"),
+            sources: ["Sources/Shortcuts/**"],
+            dependencies: [
+                .target(name: "ClipKittyRust"),
+                .target(name: "ClipKittyShared"),
+            ],
+            settings: .settings(
+                base: [
+                    "SKIP_INSTALL": "YES",
+                ]
+            )
+        ),
+
     ] + makeMacAppTargets() + [
         // MARK: ClipKittyTests — Unit tests
 
@@ -704,6 +725,7 @@ let project = Project(
                 .target(name: "ClipKittyShared"),
                 .target(name: "ClipKittyAppleServices"),
                 .target(name: "ClipKittyMacPlatform"),
+                .target(name: "ClipKittyShortcuts"),
             ],
             settings: .settings(
                 base: [
@@ -767,6 +789,7 @@ let project = Project(
                 .target(name: "ClipKittyRust"),
                 .target(name: "ClipKittyShared"),
                 .target(name: "ClipKittyAppleServices"),
+                .target(name: "ClipKittyShortcuts"),
                 .target(name: "ClipKittyShare"),
             ],
             settings: .settings(
@@ -848,6 +871,7 @@ let project = Project(
                 .target(name: "ClipKittyRust"),
                 .target(name: "ClipKittyShared"),
                 .target(name: "ClipKittyAppleServices"),
+                .target(name: "ClipKittyShortcuts"),
             ],
             settings: .settings(
                 base: [
@@ -880,6 +904,7 @@ let project = Project(
                 .target(name: "ClipKittyRust"),
                 .target(name: "ClipKittyShared"),
                 .target(name: "ClipKittyAppleServices"),
+                .target(name: "ClipKittyShortcuts"),
             ],
             settings: .settings(
                 base: [

--- a/Sources/MacApp/ClipKittyApp.swift
+++ b/Sources/MacApp/ClipKittyApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ClipKittyShortcuts
 import SwiftUI
 
 extension Notification.Name {
@@ -8,6 +9,10 @@ extension Notification.Name {
 @main
 struct ClipKittyApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    init() {
+        ClipKittyAppShortcuts.updateAppShortcutParameters()
+    }
 
     var body: some Scene {
         Settings {

--- a/Sources/Shortcuts/ClipKittyShortcutIntents.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutIntents.swift
@@ -16,7 +16,7 @@ public struct SaveTextToClipKittyIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let saved = try await ClipKittyShortcutService().saveText(text)
+        let saved = try await ClipKittyShortcutRuntime.makeService().saveText(text)
         return .result(value: text, dialog: ShortcutIntentResult.dialog(for: saved))
     }
 }
@@ -29,7 +29,7 @@ public struct SaveClipboardToClipKittyIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let saved = try await ClipKittyShortcutService().saveCurrentClipboard()
+        let saved = try await ClipKittyShortcutRuntime.makeService().saveCurrentClipboard()
         return .result(
             value: ShortcutIntentResult.value(for: saved),
             dialog: ShortcutIntentResult.dialog(for: saved)
@@ -51,7 +51,7 @@ public struct SearchClipKittyTextIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<[String]> {
-        let values = try await ClipKittyShortcutService().searchText(query: query, limit: limit)
+        let values = try await ClipKittyShortcutRuntime.makeService().searchText(query: query, limit: limit)
         return .result(value: values)
     }
 }
@@ -67,7 +67,7 @@ public struct GetRecentClipKittyTextIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<[String]> {
-        let values = try await ClipKittyShortcutService().fetchRecentText(limit: limit)
+        let values = try await ClipKittyShortcutRuntime.makeService().fetchRecentText(limit: limit)
         return .result(value: values)
     }
 }
@@ -80,7 +80,7 @@ public struct CopyLatestClipKittyTextIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let value = try await ClipKittyShortcutService().copyLatestText()
+        let value = try await ClipKittyShortcutRuntime.makeService().copyLatestText()
         return .result(value: value, dialog: "Copied to clipboard.")
     }
 }

--- a/Sources/Shortcuts/ClipKittyShortcutIntents.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutIntents.swift
@@ -1,0 +1,162 @@
+import AppIntents
+import Foundation
+
+public struct ClipKittyShortcutsPackage: AppIntentsPackage {
+    public init() {}
+}
+
+public struct SaveTextToClipKittyIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Save Text to ClipKitty"
+    public static var description: IntentDescription? = "Save text into ClipKitty's clipboard history."
+    public static var openAppWhenRun = false
+
+    @Parameter(title: "Text")
+    public var text: String
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let saved = try await ClipKittyShortcutService().saveText(text)
+        return .result(value: text, dialog: ShortcutIntentResult.dialog(for: saved))
+    }
+}
+
+public struct SaveClipboardToClipKittyIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Save Clipboard to ClipKitty"
+    public static var description: IntentDescription? = "Save the current text or image clipboard item into ClipKitty."
+    public static var openAppWhenRun = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let saved = try await ClipKittyShortcutService().saveCurrentClipboard()
+        return .result(
+            value: ShortcutIntentResult.value(for: saved),
+            dialog: ShortcutIntentResult.dialog(for: saved)
+        )
+    }
+}
+
+public struct SearchClipKittyTextIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Search ClipKitty Text"
+    public static var description: IntentDescription? = "Search ClipKitty's text clipboard history."
+    public static var openAppWhenRun = false
+
+    @Parameter(title: "Query")
+    public var query: String
+
+    @Parameter(title: "Maximum Results", default: 5)
+    public var limit: Int
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<[String]> {
+        let values = try await ClipKittyShortcutService().searchText(query: query, limit: limit)
+        return .result(value: values)
+    }
+}
+
+public struct GetRecentClipKittyTextIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Get Recent ClipKitty Text"
+    public static var description: IntentDescription? = "Get recent text clips from ClipKitty."
+    public static var openAppWhenRun = false
+
+    @Parameter(title: "Maximum Results", default: 5)
+    public var limit: Int
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<[String]> {
+        let values = try await ClipKittyShortcutService().fetchRecentText(limit: limit)
+        return .result(value: values)
+    }
+}
+
+public struct CopyLatestClipKittyTextIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Copy Latest ClipKitty Text"
+    public static var description: IntentDescription? = "Copy ClipKitty's most recent text clip to the system clipboard."
+    public static var openAppWhenRun = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let value = try await ClipKittyShortcutService().copyLatestText()
+        return .result(value: value, dialog: "Copied to clipboard.")
+    }
+}
+
+public struct ClipKittyAppShortcuts: AppShortcutsProvider {
+    public static var shortcutTileColor: ShortcutTileColor { .pink }
+
+    public static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: SaveTextToClipKittyIntent(),
+            phrases: [
+                "Save text to \(.applicationName)",
+                "Add text to \(.applicationName)",
+            ],
+            shortTitle: "Save Text",
+            systemImageName: "plus"
+        )
+
+        AppShortcut(
+            intent: SaveClipboardToClipKittyIntent(),
+            phrases: [
+                "Save clipboard to \(.applicationName)",
+                "Add clipboard to \(.applicationName)",
+            ],
+            shortTitle: "Save Clipboard",
+            systemImageName: "clipboard"
+        )
+
+        AppShortcut(
+            intent: SearchClipKittyTextIntent(),
+            phrases: [
+                "Search \(.applicationName)",
+                "Find text in \(.applicationName)",
+            ],
+            shortTitle: "Search Text",
+            systemImageName: "magnifyingglass"
+        )
+
+        AppShortcut(
+            intent: GetRecentClipKittyTextIntent(),
+            phrases: [
+                "Get recent text from \(.applicationName)",
+                "Get recent clips from \(.applicationName)",
+            ],
+            shortTitle: "Recent Text",
+            systemImageName: "clock"
+        )
+
+        AppShortcut(
+            intent: CopyLatestClipKittyTextIntent(),
+            phrases: [
+                "Copy latest text from \(.applicationName)",
+                "Copy latest clip from \(.applicationName)",
+            ],
+            shortTitle: "Copy Latest",
+            systemImageName: "doc.on.clipboard"
+        )
+    }
+}
+
+private enum ShortcutIntentResult {
+    static func dialog(for saved: ShortcutSavedClip) -> IntentDialog {
+        switch saved {
+        case .inserted:
+            return "Saved to ClipKitty."
+        case .duplicate:
+            return "Already in ClipKitty."
+        }
+    }
+
+    static func value(for saved: ShortcutSavedClip) -> String {
+        switch saved {
+        case let .inserted(id):
+            return id
+        case .duplicate:
+            return "Already in ClipKitty"
+        }
+    }
+}

--- a/Sources/Shortcuts/ClipKittyShortcutPasteboard.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutPasteboard.swift
@@ -1,0 +1,156 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+#if os(macOS)
+    import AppKit
+#elseif os(iOS)
+    import UIKit
+#endif
+
+enum ShortcutSavableContent: Sendable {
+    case text(String)
+    case image(data: Data, thumbnail: Data?, isAnimated: Bool)
+}
+
+enum ShortcutPasteboardRead: Sendable {
+    case content(ShortcutSavableContent)
+    case empty
+    case unsupported(String)
+}
+
+@MainActor
+enum ShortcutPasteboard {
+    static func read() -> ShortcutPasteboardRead {
+        #if os(macOS)
+            readMacPasteboard()
+        #elseif os(iOS)
+            readIOSPasteboard()
+        #else
+            .unsupported("ClipKitty Shortcuts support is available on macOS and iOS.")
+        #endif
+    }
+
+    static func writeText(_ text: String) {
+        #if os(macOS)
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(text, forType: .string)
+        #elseif os(iOS)
+            UIPasteboard.general.string = text
+        #endif
+    }
+
+    #if os(macOS)
+        private static func readMacPasteboard() -> ShortcutPasteboardRead {
+            let pasteboard = NSPasteboard.general
+            let availableTypes = Set(pasteboard.types ?? [])
+            guard !availableTypes.isEmpty else { return .empty }
+
+            let gifType = NSPasteboard.PasteboardType("com.compuserve.gif")
+            if availableTypes.contains(gifType),
+               let data = pasteboard.data(forType: gifType) {
+                return .content(.image(
+                    data: data,
+                    thumbnail: ShortcutImageThumbnail.makeThumbnail(from: data),
+                    isAnimated: true
+                ))
+            }
+
+            for type in [NSPasteboard.PasteboardType.tiff, .png] where availableTypes.contains(type) {
+                guard let data = pasteboard.data(forType: type) else { continue }
+                return .content(.image(
+                    data: data,
+                    thumbnail: ShortcutImageThumbnail.makeThumbnail(from: data),
+                    isAnimated: false
+                ))
+            }
+
+            if availableTypes.contains(.string),
+               let text = pasteboard.string(forType: .string),
+               !text.isEmpty {
+                return .content(.text(text))
+            }
+
+            return .unsupported("The current clipboard item is not text or an image.")
+        }
+    #endif
+
+    #if os(iOS)
+        private static func readIOSPasteboard() -> ShortcutPasteboardRead {
+            let pasteboard = UIPasteboard.general
+
+            if let image = pasteboard.image,
+               let data = image.pngData() {
+                return .content(.image(
+                    data: data,
+                    thumbnail: ShortcutImageThumbnail.makeThumbnail(from: data),
+                    isAnimated: false
+                ))
+            }
+
+            if let url = pasteboard.url {
+                return .content(.text(url.absoluteString))
+            }
+
+            if let text = pasteboard.string, !text.isEmpty {
+                return .content(.text(text))
+            }
+
+            if pasteboard.hasImages || pasteboard.hasURLs || pasteboard.hasStrings {
+                return .unsupported("The current clipboard item could not be read by ClipKitty.")
+            }
+
+            return .empty
+        }
+    #endif
+}
+
+private enum ShortcutImageThumbnail {
+    static func makeThumbnail(from data: Data, maxDimension: Int = 200) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return nil
+        }
+
+        let scale = min(
+            CGFloat(maxDimension) / CGFloat(image.width),
+            CGFloat(maxDimension) / CGFloat(image.height),
+            1.0
+        )
+        let targetWidth = max(1, Int(CGFloat(image.width) * scale))
+        let targetHeight = max(1, Int(CGFloat(image.height) * scale))
+
+        guard let context = CGContext(
+            data: nil,
+            width: targetWidth,
+            height: targetHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
+        guard let thumbnail = context.makeImage() else { return nil }
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output as CFMutableData,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            return nil
+        }
+
+        let options = [kCGImageDestinationLossyCompressionQuality: 0.7] as CFDictionary
+        CGImageDestinationAddImage(destination, thumbnail, options)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+}

--- a/Sources/Shortcuts/ClipKittyShortcutService.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutService.swift
@@ -1,0 +1,237 @@
+import ClipKittyRust
+import ClipKittyShared
+import Foundation
+
+enum ClipKittyShortcutError: LocalizedError, Sendable {
+    case emptyText
+    case emptyClipboard
+    case unsupportedClipboardContent(String)
+    case databasePathUnavailable(String)
+    case databaseOpenFailed(String)
+    case operationFailed(String)
+    case noTextClips
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyText:
+            return "Text cannot be empty."
+        case .emptyClipboard:
+            return "The clipboard is empty."
+        case let .unsupportedClipboardContent(reason):
+            return reason
+        case let .databasePathUnavailable(reason):
+            return "Could not locate ClipKitty's database: \(reason)"
+        case let .databaseOpenFailed(reason):
+            return "Could not open ClipKitty's database: \(reason)"
+        case let .operationFailed(reason):
+            return reason
+        case .noTextClips:
+            return "ClipKitty does not have any text clips yet."
+        }
+    }
+}
+
+enum ShortcutSavedClip: Equatable, Sendable {
+    case inserted(id: String)
+    case duplicate
+}
+
+private enum ShortcutTextLookup: Sendable {
+    case found(String)
+    case notFound
+}
+
+private enum ShortcutTextExtraction: Sendable {
+    case value(String)
+    case unsupported
+
+    static func parse(_ content: ClipboardContent) -> Self {
+        switch content {
+        case let .text(value):
+            return .value(value)
+        case .color, .link, .image, .file:
+            return .unsupported
+        }
+    }
+}
+
+final class ClipKittyShortcutService {
+    private let databasePathProvider: () throws -> String
+
+    init(databasePathProvider: @escaping () throws -> String = ShortcutDatabasePath.resolve) {
+        self.databasePathProvider = databasePathProvider
+    }
+
+    convenience init(databasePath: String) {
+        self.init(databasePathProvider: { databasePath })
+    }
+
+    func saveText(_ text: String) async throws -> ShortcutSavedClip {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ClipKittyShortcutError.emptyText
+        }
+
+        let repository = try makeRepository()
+        let result = await repository.saveText(
+            text: text,
+            sourceApp: "Shortcuts",
+            sourceAppBundleId: "com.apple.shortcuts"
+        )
+        return try savedClip(from: result)
+    }
+
+    func saveCurrentClipboard() async throws -> ShortcutSavedClip {
+        let clipboardRead = await ShortcutPasteboard.read()
+        switch clipboardRead {
+        case let .content(content):
+            return try await save(content)
+        case .empty:
+            throw ClipKittyShortcutError.emptyClipboard
+        case let .unsupported(reason):
+            throw ClipKittyShortcutError.unsupportedClipboardContent(reason)
+        }
+    }
+
+    func searchText(query: String, limit: Int) async throws -> [String] {
+        try await fetchText(query: query, limit: limit)
+    }
+
+    func fetchRecentText(limit: Int) async throws -> [String] {
+        try await fetchText(query: "", limit: limit)
+    }
+
+    func copyLatestText() async throws -> String {
+        let values = try await fetchRecentText(limit: 1)
+        switch firstText(in: values) {
+        case let .found(value):
+            await ShortcutPasteboard.writeText(value)
+            return value
+        case .notFound:
+            throw ClipKittyShortcutError.noTextClips
+        }
+    }
+
+    private func save(_ content: ShortcutSavableContent) async throws -> ShortcutSavedClip {
+        switch content {
+        case let .text(text):
+            return try await saveText(text)
+        case let .image(data, thumbnail, isAnimated):
+            let repository = try makeRepository()
+            let result = await repository.saveImage(
+                imageData: data,
+                thumbnail: thumbnail,
+                sourceApp: "Shortcuts",
+                sourceAppBundleId: "com.apple.shortcuts",
+                isAnimated: isAnimated
+            )
+            return try savedClip(from: result)
+        }
+    }
+
+    private func fetchText(query: String, limit: Int) async throws -> [String] {
+        let repository = try makeRepository()
+        let result = await repository.search(
+            query: query,
+            filter: .contentType(contentType: .text),
+            presentation: .compactRow
+        )
+
+        let matches: [ItemMatch]
+        switch result {
+        case let .success(searchResult):
+            matches = searchResult.matches
+        case .cancelled:
+            throw ClipKittyShortcutError.operationFailed("The ClipKitty search was cancelled.")
+        case let .failure(error):
+            throw ClipKittyShortcutError.operationFailed(error.localizedDescription)
+        }
+
+        let clampedLimit = Self.clampLimit(limit)
+        var values: [String] = []
+        for match in matches.prefix(clampedLimit) {
+            guard let item = await repository.fetchItem(id: match.itemMetadata.itemId) else {
+                continue
+            }
+            switch ShortcutTextExtraction.parse(item.content) {
+            case let .value(value):
+                values.append(value)
+            case .unsupported:
+                continue
+            }
+        }
+        return values
+    }
+
+    private func makeRepository() throws -> ClipboardRepository {
+        let dbPath: String
+        do {
+            dbPath = try databasePathProvider()
+        } catch let error as ClipKittyShortcutError {
+            throw error
+        } catch {
+            throw ClipKittyShortcutError.databasePathUnavailable(error.localizedDescription)
+        }
+
+        let plan: StoreBootstrapPlan
+        do {
+            plan = try inspectStoreBootstrap(dbPath: dbPath)
+        } catch {
+            throw ClipKittyShortcutError.databaseOpenFailed(error.localizedDescription)
+        }
+
+        let store: ClipKittyRust.ClipboardStore
+        do {
+            store = try ClipKittyRust.ClipboardStore(dbPath: dbPath)
+            switch plan {
+            case .ready:
+                break
+            case .rebuildIndex:
+                try store.rebuildIndex()
+            }
+        } catch {
+            throw ClipKittyShortcutError.databaseOpenFailed(error.localizedDescription)
+        }
+
+        return ClipboardRepository(store: store)
+    }
+
+    private func savedClip(from result: Result<String, ClipboardError>) throws -> ShortcutSavedClip {
+        switch result {
+        case let .success(itemId):
+            if itemId.isEmpty {
+                return .duplicate
+            }
+            return .inserted(id: itemId)
+        case let .failure(error):
+            throw ClipKittyShortcutError.operationFailed(error.localizedDescription)
+        }
+    }
+
+    private func firstText(in values: [String]) -> ShortcutTextLookup {
+        guard let first = values.first else { return .notFound }
+        return .found(first)
+    }
+
+    private static func clampLimit(_ limit: Int) -> Int {
+        min(max(limit, 1), 50)
+    }
+}
+
+private enum ShortcutDatabasePath {
+    static func resolve() throws -> String {
+        #if os(macOS)
+            guard let appSupport = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first else {
+                throw ClipKittyShortcutError.databasePathUnavailable("Application Support is unavailable.")
+            }
+            let appDir = appSupport.appendingPathComponent("ClipKitty", isDirectory: true)
+            try FileManager.default.createDirectory(at: appDir, withIntermediateDirectories: true)
+            return appDir.appendingPathComponent("clipboard.sqlite").path
+        #else
+            DatabasePath.migrateIfNeeded()
+            return try DatabasePath.resolve()
+        #endif
+    }
+}

--- a/Sources/Shortcuts/ClipKittyShortcutService.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutService.swift
@@ -2,7 +2,39 @@ import ClipKittyRust
 import ClipKittyShared
 import Foundation
 
-enum ClipKittyShortcutError: LocalizedError, Sendable {
+protocol ClipKittyShortcutServicing: Sendable {
+    func saveText(_ text: String) async throws -> ShortcutSavedClip
+    func saveCurrentClipboard() async throws -> ShortcutSavedClip
+    func searchText(query: String, limit: Int) async throws -> [String]
+    func fetchRecentText(limit: Int) async throws -> [String]
+    func copyLatestText() async throws -> String
+}
+
+enum ClipKittyShortcutRuntime {
+    @TaskLocal static var serviceFactory: @Sendable () -> any ClipKittyShortcutServicing = {
+        ClipKittyShortcutService()
+    }
+
+    static func makeService() -> any ClipKittyShortcutServicing {
+        serviceFactory()
+    }
+}
+
+struct ShortcutPasteboardClient: Sendable {
+    let read: @Sendable () async -> ShortcutPasteboardRead
+    let writeText: @Sendable (String) async -> Void
+
+    static let live = ShortcutPasteboardClient(
+        read: {
+            await ShortcutPasteboard.read()
+        },
+        writeText: { text in
+            await ShortcutPasteboard.writeText(text)
+        }
+    )
+}
+
+enum ClipKittyShortcutError: Equatable, LocalizedError, Sendable {
     case emptyText
     case emptyClipboard
     case unsupportedClipboardContent(String)
@@ -55,15 +87,22 @@ private enum ShortcutTextExtraction: Sendable {
     }
 }
 
-final class ClipKittyShortcutService {
-    private let databasePathProvider: () throws -> String
+final class ClipKittyShortcutService: ClipKittyShortcutServicing {
+    private let databasePathProvider: @Sendable () throws -> String
+    private let pasteboardClient: ShortcutPasteboardClient
 
-    init(databasePathProvider: @escaping () throws -> String = ShortcutDatabasePath.resolve) {
+    init(
+        databasePathProvider: @escaping @Sendable () throws -> String = {
+            try ShortcutDatabasePath.resolve()
+        },
+        pasteboardClient: ShortcutPasteboardClient = .live
+    ) {
         self.databasePathProvider = databasePathProvider
+        self.pasteboardClient = pasteboardClient
     }
 
-    convenience init(databasePath: String) {
-        self.init(databasePathProvider: { databasePath })
+    convenience init(databasePath: String, pasteboardClient: ShortcutPasteboardClient = .live) {
+        self.init(databasePathProvider: { databasePath }, pasteboardClient: pasteboardClient)
     }
 
     func saveText(_ text: String) async throws -> ShortcutSavedClip {
@@ -81,7 +120,7 @@ final class ClipKittyShortcutService {
     }
 
     func saveCurrentClipboard() async throws -> ShortcutSavedClip {
-        let clipboardRead = await ShortcutPasteboard.read()
+        let clipboardRead = await pasteboardClient.read()
         switch clipboardRead {
         case let .content(content):
             return try await save(content)
@@ -104,7 +143,7 @@ final class ClipKittyShortcutService {
         let values = try await fetchRecentText(limit: 1)
         switch firstText(in: values) {
         case let .found(value):
-            await ShortcutPasteboard.writeText(value)
+            await pasteboardClient.writeText(value)
             return value
         case .notFound:
             throw ClipKittyShortcutError.noTextClips

--- a/Sources/iOSApp/ClipKittyiOSApp.swift
+++ b/Sources/iOSApp/ClipKittyiOSApp.swift
@@ -1,6 +1,7 @@
 import ClipKittyAppleServices
 import ClipKittyRust
 import ClipKittyShared
+import ClipKittyShortcuts
 import SwiftUI
 
 // MARK: - App Launch State
@@ -253,6 +254,7 @@ struct ClipKittyiOSApp: App {
 
     init() {
         FontManager.registerFonts()
+        ClipKittyAppShortcuts.updateAppShortcutParameters()
     }
 
     var body: some Scene {

--- a/Sources/iOSSmokeTest/iOSSmokeTest.swift
+++ b/Sources/iOSSmokeTest/iOSSmokeTest.swift
@@ -11,6 +11,7 @@
 import ClipKittyAppleServices
 import ClipKittyRust
 import ClipKittyShared
+import ClipKittyShortcuts
 import SwiftUI
 
 @main

--- a/Tests/UnitTests/ClipKittyShortcutIntentTests.swift
+++ b/Tests/UnitTests/ClipKittyShortcutIntentTests.swift
@@ -1,0 +1,189 @@
+import AppIntents
+@testable import ClipKittyShortcuts
+import XCTest
+
+final class ClipKittyShortcutIntentTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clipkitty-shortcut-intents-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+        super.tearDown()
+    }
+
+    func testSaveTextIntentPersistsProvidedText() async throws {
+        let service = makeService()
+        let intent = SaveTextToClipKittyIntent()
+        intent.text = "saved through intent"
+
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        XCTAssertEqual(result.value, "saved through intent")
+        let recent = try await service.fetchRecentText(limit: 1)
+        XCTAssertEqual(recent, ["saved through intent"])
+    }
+
+    func testSaveTextIntentRejectsEmptyText() async {
+        let service = makeService()
+        let intent = SaveTextToClipKittyIntent()
+        intent.text = " \n\t "
+
+        await assertThrowsShortcutError(.emptyText) {
+            _ = try await withShortcutService(service) {
+                try await intent.perform()
+            }
+        }
+    }
+
+    func testSaveClipboardIntentPersistsReadableTextClipboard() async throws {
+        let service = makeService(pasteboardRead: .content(.text("clipboard through intent")))
+        let intent = SaveClipboardToClipKittyIntent()
+
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        XCTAssertFalse(result.value?.isEmpty ?? true)
+        let recent = try await service.fetchRecentText(limit: 1)
+        XCTAssertEqual(recent, ["clipboard through intent"])
+    }
+
+    func testSaveClipboardIntentReportsEmptyClipboard() async {
+        let service = makeService(pasteboardRead: .empty)
+        let intent = SaveClipboardToClipKittyIntent()
+
+        await assertThrowsShortcutError(.emptyClipboard) {
+            _ = try await withShortcutService(service) {
+                try await intent.perform()
+            }
+        }
+    }
+
+    func testSearchTextIntentReturnsMatchingValues() async throws {
+        let service = makeService()
+        _ = try await service.saveText("intent alpha")
+        _ = try await service.saveText("intent beta")
+        _ = try await service.saveText("outside query")
+
+        let intent = SearchClipKittyTextIntent()
+        intent.query = "intent"
+        intent.limit = 2
+
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        XCTAssertEqual(result.value?.count, 2)
+        XCTAssertTrue(result.value?.contains("intent alpha") ?? false)
+        XCTAssertTrue(result.value?.contains("intent beta") ?? false)
+    }
+
+    func testGetRecentTextIntentReturnsNewestText() async throws {
+        let service = makeService()
+        _ = try await service.saveText("older intent clip")
+        try await Task.sleep(nanoseconds: 10_000_000)
+        _ = try await service.saveText("newer intent clip")
+
+        let intent = GetRecentClipKittyTextIntent()
+        intent.limit = 1
+
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        XCTAssertEqual(result.value, ["newer intent clip"])
+    }
+
+    func testCopyLatestTextIntentReturnsAndWritesNewestText() async throws {
+        let recorder = RecordedPasteboard()
+        let service = makeService(pasteboardRecorder: recorder)
+        _ = try await service.saveText("older copy intent clip")
+        try await Task.sleep(nanoseconds: 10_000_000)
+        _ = try await service.saveText("newer copy intent clip")
+
+        let intent = CopyLatestClipKittyTextIntent()
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        let writtenValues = await recorder.values()
+        XCTAssertEqual(result.value, "newer copy intent clip")
+        XCTAssertEqual(writtenValues, ["newer copy intent clip"])
+    }
+
+    func testCopyLatestTextIntentReportsEmptyDatabase() async {
+        let service = makeService()
+        let intent = CopyLatestClipKittyTextIntent()
+
+        await assertThrowsShortcutError(.noTextClips) {
+            _ = try await withShortcutService(service) {
+                try await intent.perform()
+            }
+        }
+    }
+
+    private func makeService(
+        pasteboardRead: ShortcutPasteboardRead = .empty,
+        pasteboardRecorder: RecordedPasteboard = RecordedPasteboard()
+    ) -> ClipKittyShortcutService {
+        ClipKittyShortcutService(
+            databasePath: dbPath(),
+            pasteboardClient: ShortcutPasteboardClient(
+                read: { pasteboardRead },
+                writeText: { text in
+                    await pasteboardRecorder.record(text)
+                }
+            )
+        )
+    }
+
+    private func withShortcutService<T>(
+        _ service: ClipKittyShortcutService,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await ClipKittyShortcutRuntime.$serviceFactory.withValue({ service }) {
+            try await operation()
+        }
+    }
+
+    private func assertThrowsShortcutError<T>(
+        _ expectedError: ClipKittyShortcutError,
+        operation: () async throws -> T
+    ) async {
+        do {
+            _ = try await operation()
+            XCTFail("Expected \(expectedError) to throw")
+        } catch let error as ClipKittyShortcutError {
+            XCTAssertEqual(error, expectedError)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    private func dbPath() -> String {
+        tempDir.appendingPathComponent("clipboard.sqlite").path
+    }
+}
+
+private actor RecordedPasteboard {
+    private var writtenValues: [String] = []
+
+    func record(_ value: String) {
+        writtenValues.append(value)
+    }
+
+    func values() -> [String] {
+        writtenValues
+    }
+}

--- a/Tests/UnitTests/ClipKittyShortcutServiceTests.swift
+++ b/Tests/UnitTests/ClipKittyShortcutServiceTests.swift
@@ -1,0 +1,78 @@
+@testable import ClipKittyShortcuts
+import XCTest
+
+final class ClipKittyShortcutServiceTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clipkitty-shortcuts-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+        super.tearDown()
+    }
+
+    func testSaveTextAndFetchRecentText() async throws {
+        let service = ClipKittyShortcutService(databasePath: dbPath())
+
+        let saved = try await service.saveText("hello from shortcuts")
+        switch saved {
+        case let .inserted(id):
+            XCTAssertFalse(id.isEmpty)
+        case .duplicate:
+            XCTFail("First save should insert a new clip")
+        }
+
+        let values = try await service.fetchRecentText(limit: 3)
+        XCTAssertEqual(values.first, "hello from shortcuts")
+    }
+
+    func testDuplicateSaveIsExplicitState() async throws {
+        let service = ClipKittyShortcutService(databasePath: dbPath())
+
+        _ = try await service.saveText("same clip")
+        let savedAgain = try await service.saveText("same clip")
+
+        switch savedAgain {
+        case .inserted:
+            XCTFail("Duplicate save should not report a new clip")
+        case .duplicate:
+            break
+        }
+    }
+
+    func testSaveTextRejectsEmptyInput() async {
+        let service = ClipKittyShortcutService(databasePath: dbPath())
+
+        do {
+            _ = try await service.saveText(" \n\t ")
+            XCTFail("Expected empty text to throw")
+        } catch ClipKittyShortcutError.emptyText {
+            return
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testSearchTextHonorsLimit() async throws {
+        let service = ClipKittyShortcutService(databasePath: dbPath())
+
+        _ = try await service.saveText("shortcut alpha")
+        _ = try await service.saveText("shortcut beta")
+        _ = try await service.saveText("shortcut gamma")
+
+        let values = try await service.searchText(query: "shortcut", limit: 2)
+        XCTAssertEqual(values.count, 2)
+    }
+
+    private func dbPath() -> String {
+        tempDir.appendingPathComponent("clipboard.sqlite").path
+    }
+}


### PR DESCRIPTION
## Summary
- Add a cross-platform `ClipKittyShortcuts` target for macOS and iOS App Intents.
- Wire Shortcuts registration into the macOS and iOS app launch paths.
- Add unit coverage for shortcut save, duplicate, empty input, and search behavior.

## Testing
- Unit tests added for `ClipKittyShortcutService`.
- Verified the new Shortcuts target compiles for macOS, iOS simulator, and iOS device.
- Verified the macOS app build succeeds with the new target linked in.