### PR TITLE
opt perf

### DIFF
--- a/Sources/MacApp/Browser/BrowserRenderingSupport.swift
+++ b/Sources/MacApp/Browser/BrowserRenderingSupport.swift
@@ -1217,6 +1217,84 @@ private enum RowIconCache {
     }
 }
 
+private enum RowThumbnailCache {
+    private static let cache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 128
+        cache.totalCostLimit = 16 * 1024 * 1024
+        return cache
+    }()
+
+    static func key(itemId: String, data: Data) -> String {
+        var hasher = Hasher()
+        hasher.combine(itemId)
+        hasher.combine(data.count)
+        data.withUnsafeBytes { rawBuffer in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            for byte in bytes.prefix(16) {
+                hasher.combine(byte)
+            }
+            if bytes.count > 16 {
+                for byte in bytes.suffix(16) {
+                    hasher.combine(byte)
+                }
+            }
+        }
+        return "\(itemId)-\(data.count)-\(hasher.finalize())"
+    }
+
+    static func image(forKey key: String) -> NSImage? {
+        cache.object(forKey: key as NSString)
+    }
+
+    static func setImage(_ image: NSImage, forKey key: String, cost: Int) {
+        cache.setObject(image, forKey: key as NSString, cost: cost)
+    }
+}
+
+private struct RowThumbnailView: View {
+    let itemId: String
+    let data: Data
+
+    @State private var decodedImage: NSImage?
+
+    private var cacheKey: String {
+        RowThumbnailCache.key(itemId: itemId, data: data)
+    }
+
+    var body: some View {
+        Group {
+            if let image = decodedImage ?? RowThumbnailCache.image(forKey: cacheKey) {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                Image(systemName: "photo")
+                    .resizable()
+            }
+        }
+        .task(id: cacheKey) {
+            await decodeImage(cacheKey: cacheKey, data: data)
+        }
+    }
+
+    @MainActor
+    private func decodeImage(cacheKey: String, data: Data) async {
+        if let cachedImage = RowThumbnailCache.image(forKey: cacheKey) {
+            decodedImage = cachedImage
+            return
+        }
+
+        decodedImage = nil
+        let image = await Task.detached(priority: .utility) { [data] in
+            NSImage(data: data)
+        }.value
+        guard !Task.isCancelled, let image else { return }
+        RowThumbnailCache.setImage(image, forKey: cacheKey, cost: data.count)
+        decodedImage = image
+    }
+}
+
 struct ItemRow: View {
     let metadata: ItemMetadata
     let presentation: RowPresentation
@@ -1284,14 +1362,7 @@ struct ItemRow: View {
                             Group {
                                 switch metadata.icon {
                                 case let .thumbnail(bytes):
-                                    if let nsImage = NSImage(data: Data(bytes)) {
-                                        Image(nsImage: nsImage)
-                                            .resizable()
-                                            .aspectRatio(contentMode: .fill)
-                                    } else {
-                                        Image(systemName: "photo")
-                                            .resizable()
-                                    }
+                                    RowThumbnailView(itemId: metadata.itemId, data: bytes)
                                 case let .colorSwatch(rgba):
                                     RoundedRectangle(cornerRadius: 6)
                                         .fill(Color(nsColor: NSColor(

--- a/Sources/MacApp/Browser/BrowserResultsList.swift
+++ b/Sources/MacApp/Browser/BrowserResultsList.swift
@@ -14,7 +14,8 @@ struct BrowserResultsList: View {
     var body: some View {
         ScrollViewReader { proxy in
             List {
-                ForEach(Array(viewModel.displayRows.enumerated()), id: \.element.metadata.itemId) { index, row in
+                ForEach(viewModel.displayRows) { row in
+                    let index = viewModel.indexOfItem(row.metadata.itemId) ?? 0
                     ItemRow(
                         metadata: row.metadata,
                         presentation: row.presentation,

--- a/Sources/Shared/BrowserViewModel.swift
+++ b/Sources/Shared/BrowserViewModel.swift
@@ -72,6 +72,9 @@ public final class BrowserViewModel {
         private var metadataTask: Task<Void, Never>?
     #endif
     private var matchedExcerptTasks: [String: Task<Void, Never>] = [:]
+    private var pendingMatchedExcerptItemIds: Set<String> = []
+    private var prefetchTask: Task<Void, Never>?
+    private var previewSpinnerTask: Task<Void, Never>?
     private var pendingDeleteTask: Task<Void, Never>?
     private var pendingTagSettleTask: Task<Void, Never>?
     private var queryGeneration = 0
@@ -209,6 +212,11 @@ public final class BrowserViewModel {
         #endif
         matchedExcerptTasks.values.forEach { $0.cancel() }
         matchedExcerptTasks.removeAll()
+        pendingMatchedExcerptItemIds.removeAll()
+        prefetchTask?.cancel()
+        prefetchTask = nil
+        previewSpinnerTask?.cancel()
+        previewSpinnerTask = nil
         pendingDeleteTask?.cancel()
         pendingDeleteTask = nil
         pendingTagSettleTask?.cancel()
@@ -220,7 +228,7 @@ public final class BrowserViewModel {
         #endif
         latestKnownContentRevision = contentRevision
         lastLoadedContentRevision = nil
-        previewSpinnerVisible = false
+        hidePreviewSpinner()
         hasUserNavigated = false
         prefetchCache.removeAll()
         previewPayloadsByItemId.removeAll()
@@ -362,7 +370,9 @@ public final class BrowserViewModel {
         let uniqueIds = Array(Set(ids)).sorted()
         guard !uniqueIds.isEmpty else { return }
 
-        let excerptRequests = uniqueIds.compactMap { deferredMatchedExcerptRequest(for: $0) }
+        let excerptRequests = uniqueIds
+            .filter { !pendingMatchedExcerptItemIds.contains($0) }
+            .compactMap { deferredMatchedExcerptRequest(for: $0) }
         guard !excerptRequests.isEmpty else { return }
 
         let generation = queryGeneration
@@ -371,12 +381,20 @@ public final class BrowserViewModel {
             .joined(separator: ",")
         let key = "\(generation)|\(requestSignature)"
         guard matchedExcerptTasks[key] == nil else { return }
+        let pendingItemIds = excerptRequests.map { $0.itemId }
+        pendingMatchedExcerptItemIds.formUnion(pendingItemIds)
 
         matchedExcerptTasks[key] = Task { [weak self] in
             guard let self else { return }
             let results = await self.client.resolveMatchedExcerpts(requests: excerptRequests)
             await MainActor.run {
-                defer { self.matchedExcerptTasks[key] = nil }
+                defer {
+                    self.matchedExcerptTasks[key] = nil
+                    if self.queryGeneration == generation {
+                        self.pendingMatchedExcerptItemIds.subtract(pendingItemIds)
+                    }
+                }
+                guard !Task.isCancelled else { return }
                 guard self.queryGeneration == generation,
                       self.contentState.request == request
                 else {
@@ -677,6 +695,9 @@ public final class BrowserViewModel {
         searchExecution.cancel()
         matchedExcerptTasks.values.forEach { $0.cancel() }
         matchedExcerptTasks.removeAll()
+        pendingMatchedExcerptItemIds.removeAll()
+        prefetchTask?.cancel()
+        prefetchTask = nil
 
         if displayedContent?.response.request != request {
             setDisplayedSelection(selectionDuringSearchTransition(to: request))
@@ -907,6 +928,8 @@ public final class BrowserViewModel {
         defer { os_signpost(.end, log: poi, name: "loadSelectedItem", signpostID: signpostID) }
 
         previewTask?.cancel()
+        prefetchTask?.cancel()
+        prefetchTask = nil
         #if ENABLE_LINK_PREVIEWS
             metadataTask?.cancel()
         #endif
@@ -928,7 +951,7 @@ public final class BrowserViewModel {
             #if ENABLE_LINK_PREVIEWS
                 maybeRefreshLinkMetadata(for: firstPreviewPayload.item, generation: generation)
             #endif
-            previewSpinnerVisible = false
+            hidePreviewSpinner()
             guard !previewPayloadSatisfiesDecorationRequirement(firstPreviewPayload, for: request) else {
                 return
             }
@@ -948,7 +971,7 @@ public final class BrowserViewModel {
             #if ENABLE_LINK_PREVIEWS
                 maybeRefreshLinkMetadata(for: cachedPreviewPayload.item, generation: generation)
             #endif
-            previewSpinnerVisible = false
+            hidePreviewSpinner()
             guard !previewPayloadSatisfiesDecorationRequirement(cachedPreviewPayload, for: request) else {
                 return
             }
@@ -982,7 +1005,7 @@ public final class BrowserViewModel {
             #if ENABLE_LINK_PREVIEWS
                 maybeRefreshLinkMetadata(for: cachedItem, generation: generation)
             #endif
-            previewSpinnerVisible = false
+            hidePreviewSpinner()
             guard requiresPreviewDecoration(for: cachedItem, request: request) else {
                 return
             }
@@ -1005,7 +1028,7 @@ public final class BrowserViewModel {
                         return
                     }
 
-                    self.previewSpinnerVisible = false
+                    self.hidePreviewSpinner()
                     self.setDisplayedSelection(.failed(itemId: itemId, origin: origin))
                 }
                 return
@@ -1032,7 +1055,7 @@ public final class BrowserViewModel {
                 #endif
 
                 guard self.requiresPreviewDecoration(for: item, request: request) else {
-                    self.previewSpinnerVisible = false
+                    self.hidePreviewSpinner()
                     return
                 }
 
@@ -1064,7 +1087,7 @@ public final class BrowserViewModel {
                     return
                 }
 
-                self.previewSpinnerVisible = false
+                self.hidePreviewSpinner()
                 guard let payload else {
                     self.resolveSelectionWithoutPreviewDecoration(itemId: itemId, origin: origin)
                     return
@@ -1160,13 +1183,19 @@ public final class BrowserViewModel {
         let start = max(0, currentIndex - prefetchRadius)
         let end = min(itemIds.count - 1, currentIndex + prefetchRadius)
         guard start <= end else { return }
-        let idsToPrefetch = (start ... end).map { itemIds[$0] }
+        let idsToPrefetch = (start ... end).map { itemIds[$0] }.filter { prefetchCache[$0] == nil }
+        guard !idsToPrefetch.isEmpty else { return }
+        let generation = queryGeneration
 
-        Task { [weak self] in
+        prefetchTask?.cancel()
+        prefetchTask = Task { [weak self] in
             guard let self else { return }
-            for itemId in idsToPrefetch where self.prefetchCache[itemId] == nil {
+            for itemId in idsToPrefetch {
+                guard !Task.isCancelled else { return }
                 guard let item = await self.client.fetchItem(id: itemId) else { continue }
+                guard !Task.isCancelled else { return }
                 await MainActor.run {
+                    guard self.queryGeneration == generation else { return }
                     if self.indexOfItem(itemId) != nil {
                         self.prefetchCache[itemId] = item
                     }
@@ -1189,10 +1218,17 @@ public final class BrowserViewModel {
         )
     }
 
-    private func schedulePreviewSpinner(for generation: Int, itemId: String) {
+    private func hidePreviewSpinner() {
+        previewSpinnerTask?.cancel()
+        previewSpinnerTask = nil
         previewSpinnerVisible = false
-        Task { [weak self] in
+    }
+
+    private func schedulePreviewSpinner(for generation: Int, itemId: String) {
+        hidePreviewSpinner()
+        previewSpinnerTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
             await MainActor.run {
                 guard let self,
                       self.previewGeneration == generation,
@@ -1201,6 +1237,7 @@ public final class BrowserViewModel {
                 else {
                     return
                 }
+                self.previewSpinnerTask = nil
                 self.previewSpinnerVisible = true
             }
         }
@@ -1810,9 +1847,13 @@ public final class BrowserViewModel {
             ))
         }
 
-        itemIds = nextItemIds
-        itemIndexById = nextIndexById
-        displayRows = nextDisplayRows
+        if itemIds != nextItemIds {
+            itemIds = nextItemIds
+            itemIndexById = nextIndexById
+        }
+        if displayRows != nextDisplayRows {
+            displayRows = nextDisplayRows
+        }
     }
 
     private func presentationApplyingResolvedExcerpt(_ presentation: RowPresentation, itemId: String) -> RowPresentation {

--- a/Sources/iOSApp/Views/CardView.swift
+++ b/Sources/iOSApp/Views/CardView.swift
@@ -13,7 +13,12 @@ struct CardView: View {
     @Environment(HapticsClient.self) private var haptics
 
     @State private var isShareLoading = false
-    @State private var fullImage: UIImage?
+
+    private static let relativeDateFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter
+    }()
 
     private var metadata: ItemMetadata {
         row.metadata
@@ -178,40 +183,28 @@ struct CardView: View {
     @ViewBuilder
     private func thumbnailPreview(bytes: Data) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            Group {
-                if let uiImage = fullImage ?? UIImage(data: bytes) {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                        .aspectRatio(uiImage.size, contentMode: .fit)
-                        .frame(maxWidth: .infinity)
-                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                } else {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(.secondary.opacity(0.1))
-                        .aspectRatio(16.0 / 9.0, contentMode: .fit)
-                        .overlay(
-                            Image(systemName: "photo")
-                                .font(.title)
-                                .foregroundStyle(.secondary)
-                        )
-                }
+            DecodedImageView(
+                namespace: "card-thumbnail",
+                itemId: metadata.itemId,
+                data: bytes
+            ) {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(.secondary.opacity(0.1))
+                    .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                    .overlay(
+                        Image(systemName: "photo")
+                            .font(.title)
+                            .foregroundStyle(.secondary)
+                    )
             }
+            .frame(maxWidth: .infinity)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
             if !displayExcerpt.text.isEmpty {
                 highlightedText(displayExcerpt.text, highlights: displayExcerpt.highlights, font: .custom(FontManager.sansSerif, size: 15))
                     .lineLimit(2)
             }
         }
-        .task(id: metadata.itemId) {
-            await loadFullImage(itemId: metadata.itemId)
-        }
-    }
-
-    private func loadFullImage(itemId: String) async {
-        fullImage = nil
-        guard let item = await container.storeClient.fetchItem(id: itemId) else { return }
-        guard case let .image(data, _, _) = item.content else { return }
-        guard !Task.isCancelled else { return }
-        fullImage = UIImage(data: data)
     }
 
     // MARK: - Context menu
@@ -318,9 +311,7 @@ struct CardView: View {
 
     private var relativeTime: String {
         let date = Date(timeIntervalSince1970: TimeInterval(metadata.timestampUnix))
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
+        return Self.relativeDateFormatter.localizedString(for: date, relativeTo: Date())
     }
 
     private func colorFromRGBA(_ rgba: UInt32) -> Color {

--- a/Sources/iOSApp/Views/DecodedImageView.swift
+++ b/Sources/iOSApp/Views/DecodedImageView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import UIKit
+
+private enum DecodedImageCache {
+    private static let cache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.countLimit = 64
+        cache.totalCostLimit = 32 * 1024 * 1024
+        return cache
+    }()
+
+    static func key(namespace: String, itemId: String, data: Data) -> String {
+        var hasher = Hasher()
+        hasher.combine(namespace)
+        hasher.combine(itemId)
+        hasher.combine(data.count)
+        data.withUnsafeBytes { rawBuffer in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            for byte in bytes.prefix(16) {
+                hasher.combine(byte)
+            }
+            if bytes.count > 16 {
+                for byte in bytes.suffix(16) {
+                    hasher.combine(byte)
+                }
+            }
+        }
+        return "\(namespace)-\(itemId)-\(data.count)-\(hasher.finalize())"
+    }
+
+    static func image(forKey key: String) -> UIImage? {
+        cache.object(forKey: key as NSString)
+    }
+
+    static func setImage(_ image: UIImage, forKey key: String, cost: Int) {
+        cache.setObject(image, forKey: key as NSString, cost: cost)
+    }
+}
+
+struct DecodedImageView<Placeholder: View>: View {
+    let namespace: String
+    let itemId: String
+    let data: Data
+    let contentMode: ContentMode
+    let placeholder: () -> Placeholder
+
+    @State private var decodedImage: UIImage?
+
+    private var cacheKey: String {
+        DecodedImageCache.key(namespace: namespace, itemId: itemId, data: data)
+    }
+
+    init(
+        namespace: String,
+        itemId: String,
+        data: Data,
+        contentMode: ContentMode = .fit,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.namespace = namespace
+        self.itemId = itemId
+        self.data = data
+        self.contentMode = contentMode
+        self.placeholder = placeholder
+    }
+
+    var body: some View {
+        Group {
+            if let image = decodedImage ?? DecodedImageCache.image(forKey: cacheKey) {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(image.size, contentMode: contentMode)
+            } else {
+                placeholder()
+            }
+        }
+        .task(id: cacheKey) {
+            await decodeImage(cacheKey: cacheKey, data: data)
+        }
+    }
+
+    @MainActor
+    private func decodeImage(cacheKey: String, data: Data) async {
+        if let cachedImage = DecodedImageCache.image(forKey: cacheKey) {
+            decodedImage = cachedImage
+            return
+        }
+
+        decodedImage = nil
+        let image = await Task.detached(priority: .utility) { [data] in
+            let image = UIImage(data: data)
+            return image?.preparingForDisplay() ?? image
+        }.value
+        guard !Task.isCancelled, let image else { return }
+        DecodedImageCache.setImage(image, forKey: cacheKey, cost: data.count)
+        decodedImage = image
+    }
+}

--- a/Sources/iOSApp/Views/PreviewScreen.swift
+++ b/Sources/iOSApp/Views/PreviewScreen.swift
@@ -16,6 +16,12 @@ struct PreviewScreen: View {
     @State private var showDeleteConfirmation = false
 
     private let isUITestPreviewDebugEnabled = CommandLine.arguments.contains("--use-simulated-db")
+    private static let detailDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .medium
+        return formatter
+    }()
 
     var body: some View {
         Group {
@@ -266,12 +272,16 @@ struct PreviewScreen: View {
 
     private func imageContent(data: Data, description: String, highlights: [Utf16HighlightRange]) -> some View {
         VStack(spacing: 8) {
-            if let uiImage = UIImage(data: data) {
-                Image(uiImage: uiImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(maxWidth: .infinity)
+            DecodedImageView(
+                namespace: "preview-image",
+                itemId: itemId,
+                data: data
+            ) {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 180)
             }
+            .frame(maxWidth: .infinity)
+
             if !description.isEmpty {
                 if highlights.isEmpty {
                     Text(description)
@@ -314,10 +324,7 @@ struct PreviewScreen: View {
 
     private func formattedDate(from unix: Int64) -> String {
         let date = Date(timeIntervalSince1970: TimeInterval(unix))
-        let formatter = DateFormatter()
-        formatter.dateStyle = .long
-        formatter.timeStyle = .medium
-        return formatter.string(from: date)
+        return Self.detailDateFormatter.string(from: date)
     }
 
     // MARK: - Action Bar

--- a/Tests/UnitTests/BrowserViewModelTests.swift
+++ b/Tests/UnitTests/BrowserViewModelTests.swift
@@ -654,6 +654,40 @@ final class BrowserViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.previewDecoration?.highlights.first?.utf16End, 2)
     }
 
+    func testMatchedExcerptLoadingDeduplicatesItemsAlreadyInFlight() async {
+        let client = MockBrowserStoreClient()
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {}
+        )
+
+        viewModel.updateSearchText("a")
+        try? await Task.sleep(for: .milliseconds(75))
+        await flushMainActor()
+
+        client.resumeSearch(with: BrowserSearchResponse(
+            request: SearchRequest(text: "a", filter: .all),
+            items: [
+                makeDeferredMatch(id: "1", text: "alpha", query: "a"),
+                makeDeferredMatch(id: "2", text: "beta", query: "a"),
+                makeDeferredMatch(id: "3", text: "gamma", query: "a"),
+            ],
+            firstPreviewPayload: nil,
+            totalCount: 3
+        ))
+        await flushMainActor()
+
+        viewModel.loadMatchedExcerptsForItems(["1", "2"])
+        viewModel.loadMatchedExcerptsForItems(["2", "3"])
+        await flushMainActor()
+
+        XCTAssertEqual(client.resolveMatchedExcerptRequests.count, 2)
+        XCTAssertTrue(client.resolveMatchedExcerptRequests.contains(.init(itemIds: ["1", "2"], query: "a")))
+        XCTAssertTrue(client.resolveMatchedExcerptRequests.contains(.init(itemIds: ["3"], query: "a")))
+    }
+
     func testDeleteFailureRollsBackSearchAndSelection() async {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(


### PR DESCRIPTION


- Deduped overlapping row decoration requests so visible rows stop stampeding Rust with repeated highlight work: [BrowserViewModel.swift](/Users/julsh/.codex/worktrees/03ba/clipkitty/Sources/Shared/BrowserViewModel.swift:366)
- Cancelled stale prefetch and preview-spinner tasks during fast navigation/search churn: [BrowserViewModel.swift](/Users/julsh/.codex/worktrees/03ba/clipkitty/Sources/Shared/BrowserViewModel.swift:1172)
- Avoided redundant SwiftUI invalidations when rebuilt rows/ids are unchanged.
- Removed full `Array(enumerated())` allocation from every macOS results-list render: [BrowserResultsList.swift](/Users/julsh/.codex/worktrees/03ba/clipkitty/Sources/MacApp/Browser/BrowserResultsList.swift:17)
- Moved macOS row thumbnail decoding out of `body` into async cached decoding: [BrowserRenderingSupport.swift](/Users/julsh/.codex/worktrees/03ba/clipkitty/Sources/MacApp/Browser/BrowserRenderingSupport.swift:1220)
- Added shared async/cached iOS image decoding and used it for feed thumbnails and preview images: [DecodedImageView.swift](/Users/julsh/.codex/worktrees/03ba/clipkitty/Sources/iOSApp/Views/DecodedImageView.swift:40)
- Stopped iOS feed cards from eagerly fetching and decoding full-size images for every visible image card: [CardView.swift](/Users/julsh/.codex/worktrees/03ba/clipkitty/Sources/iOSApp/Views/CardView.swift:176)
- Added a regression test for in-flight row decoration dedupe: [BrowserViewModelTests.swift](/Users/julsh/.codex/worktrees/03ba/clipkitty/Tests/UnitTests/BrowserViewModelTests.swift:657)

Verification:
- `git diff --check` passed.
- Standalone iOS typecheck for `DecodedImageView.swift` passed.
- Standalone macOS typecheck for the new row thumbnail cache/view pattern passed.
- Full `xcodebuild` could not be run because this worktree had no generated workspace; `make workspace` began a long multi-target Nix/Rust bridge build and I stopped it after it was still compiling.