### PR TITLE
Add Apple Shortcuts support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,11 +159,13 @@ jobs:
           AGE_SECRET_KEY: ${{ secrets.AGE_SECRET_KEY }}
 
       - name: Build App (AppStore)
+        timeout-minutes: 45
         run: make app-app-store
         env:
           AGE_SECRET_KEY: ${{ secrets.AGE_SECRET_KEY }}
 
       - name: Stage Hardened App
+        timeout-minutes: 30
         run: make app-hardened
         env:
           AGE_SECRET_KEY: ${{ secrets.AGE_SECRET_KEY }}
@@ -288,12 +290,14 @@ jobs:
           echo "Hardened feature surface verified."
 
       - name: Build iOS Smoke Test
+        timeout-minutes: 15
         run: nix build '.#checks.aarch64-darwin.clipkitty-ios-smoke-build' -L
 
       - name: Generate Xcode Workspace
         run: make workspace
 
       - name: Build iOS App (AppStore)
+        timeout-minutes: 20
         run: |
           VERSION=$(make release-version FIELD=version)
           COMMIT_COUNT=$(make release-version FIELD=build-number)
@@ -371,6 +375,7 @@ jobs:
           sleep 5
 
       - name: Generate Marketing Screenshots
+        timeout-minutes: 20
         run: |
           SKIP_SIGNING=1 LOCKED=1 make screenshots-macos
           ls -lh marketing/*/screenshot_*.png
@@ -385,6 +390,7 @@ jobs:
         run: make site-icon
 
       - name: Build and Sign DMG
+        timeout-minutes: 30
         run: |
           make release-dmg
           codesign --force --sign "Developer ID Application" ClipKitty.dmg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,11 +311,15 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Generate iOS Marketing Screenshots
+        env:
+          CLIPKITTY_SCREENSHOT_LOCALES: ${{ github.event_name == 'pull_request' && 'en' || '' }}
         run: |
           unset TOOLCHAINS
           make screenshots-ios
 
       - name: Generate iPad Marketing Screenshots
+        env:
+          CLIPKITTY_SCREENSHOT_LOCALES: ${{ github.event_name == 'pull_request' && 'en' || '' }}
         run: |
           unset TOOLCHAINS
           make screenshots-ipad

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,15 +311,13 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Generate iOS Marketing Screenshots
-        env:
-          CLIPKITTY_SCREENSHOT_LOCALES: ${{ github.event_name == 'pull_request' && 'en' || '' }}
+        if: github.event_name != 'pull_request'
         run: |
           unset TOOLCHAINS
           make screenshots-ios
 
       - name: Generate iPad Marketing Screenshots
-        env:
-          CLIPKITTY_SCREENSHOT_LOCALES: ${{ github.event_name == 'pull_request' && 'en' || '' }}
+        if: github.event_name != 'pull_request'
         run: |
           unset TOOLCHAINS
           make screenshots-ipad

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,14 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'release'))
         run: |
           TARGET_BRANCH="${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}"
-          VERSION=$(make release-version FIELD=version)
+          BASE_VERSION=$(awk -F '"' '/"MARKETING_VERSION"[[:space:]]*:/ { print $4; exit }' Project.swift)
+          if [ -z "$BASE_VERSION" ]; then
+            echo "::error::Could not resolve MARKETING_VERSION from Project.swift"
+            exit 1
+          fi
+          MAJOR_MINOR="${BASE_VERSION%.*}"
+          COMMIT_COUNT=$(git rev-list --count HEAD)
+          VERSION="${MAJOR_MINOR}.${COMMIT_COUNT}"
           echo "Resolved release version: $VERSION"
 
           if [ "$TARGET_BRANCH" = "main" ]; then
@@ -111,7 +118,9 @@ jobs:
           fi
 
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "BUILD_NUMBER=$COMMIT_COUNT" >> "$GITHUB_ENV"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_number=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "release_title=$RELEASE_TITLE" >> "$GITHUB_OUTPUT"
@@ -299,8 +308,6 @@ jobs:
       - name: Build iOS App (AppStore)
         timeout-minutes: 20
         run: |
-          VERSION=$(make release-version FIELD=version)
-          COMMIT_COUNT=$(make release-version FIELD=build-number)
           xcodebuild build \
             -workspace ClipKitty.xcworkspace \
             -scheme ClipKittyiOS-AppStore \
@@ -311,7 +318,7 @@ jobs:
             -authenticationKeyID ${{ steps.xcode-auth.outputs.key_id }} \
             -authenticationKeyIssuerID ${{ steps.xcode-auth.outputs.issuer_id }} \
             MARKETING_VERSION="$VERSION" \
-            CURRENT_PROJECT_VERSION="$COMMIT_COUNT" \
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             CODE_SIGNING_ALLOWED=NO
 
       - name: Generate iOS Marketing Screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -323,6 +323,7 @@ jobs:
           make screenshots-ipad
 
       - name: Run UI Tests
+        timeout-minutes: 45
         env:
           LOCKED: "1"
         run: |
@@ -331,6 +332,9 @@ jobs:
             -workspace ClipKitty.xcworkspace \
             -scheme ClipKittyUITests \
             -destination "platform=macOS" \
+            -destination-timeout 120 \
+            -test-timeouts-enabled YES \
+            -maximum-test-execution-time-allowance 600 \
             -derivedDataPath DerivedData \
             CODE_SIGNING_ALLOWED=NO \
             -skip-testing:ClipKittyUITests/ClipKittyUITests/testRecordIntroVideo \

--- a/Project.swift
+++ b/Project.swift
@@ -11,6 +11,7 @@ enum Capability: String, CaseIterable {
     case iCloudSync // ENABLE_ICLOUD_SYNC
     case sparkleUpdates // ENABLE_SPARKLE_UPDATES
     case buildAttestationLink // ENABLE_BUILD_ATTESTATION_LINK
+    case appleShortcuts // ENABLE_APP_SHORTCUTS
     case hardened // CLIPKITTY_HARDENED
 
     var compileCondition: String {
@@ -21,6 +22,7 @@ enum Capability: String, CaseIterable {
         case .iCloudSync: return "ENABLE_ICLOUD_SYNC"
         case .sparkleUpdates: return "ENABLE_SPARKLE_UPDATES"
         case .buildAttestationLink: return "ENABLE_BUILD_ATTESTATION_LINK"
+        case .appleShortcuts: return "ENABLE_APP_SHORTCUTS"
         case .hardened: return "CLIPKITTY_HARDENED"
         }
     }
@@ -96,10 +98,10 @@ enum MacBuildVariant: CaseIterable {
 
     var capabilities: Set<Capability> {
         switch self {
-        case .debug: return [.syntheticPaste, .fileClipboardItems, .linkPreviews, .iCloudSync, .buildAttestationLink]
-        case .release: return [.syntheticPaste, .fileClipboardItems, .linkPreviews, .iCloudSync, .buildAttestationLink]
-        case .sparkle: return [.syntheticPaste, .fileClipboardItems, .linkPreviews, .iCloudSync, .buildAttestationLink, .sparkleUpdates]
-        case .appStore: return [.syntheticPaste, .fileClipboardItems, .linkPreviews, .iCloudSync, .buildAttestationLink]
+        case .debug: return [.syntheticPaste, .fileClipboardItems, .linkPreviews, .iCloudSync, .buildAttestationLink, .appleShortcuts]
+        case .release: return [.syntheticPaste, .fileClipboardItems, .linkPreviews, .iCloudSync, .buildAttestationLink, .appleShortcuts]
+        case .sparkle: return [.syntheticPaste, .fileClipboardItems, .linkPreviews, .iCloudSync, .buildAttestationLink, .sparkleUpdates, .appleShortcuts]
+        case .appStore: return [.syntheticPaste, .fileClipboardItems, .linkPreviews, .iCloudSync, .buildAttestationLink, .appleShortcuts]
         case .hardened: return [.syntheticPaste, .hardened]
         }
     }
@@ -134,14 +136,19 @@ enum MacBuildVariant: CaseIterable {
 
     // MARK: Target Name — which macOS app target this variant builds
 
-    /// The Sparkle variant builds its own target (ClipKittySpark) that depends on
-    /// SparkleUpdater. All other variants build the plain ClipKitty target which
-    /// has no Sparkle in its dependency graph at all.
+    /// Variants with different dependency/resource surfaces get distinct targets.
+    /// This keeps Sparkle and Apple Shortcuts out of builds that do not support them.
     var macAppTargetName: String {
         switch self {
         case .sparkle: return "ClipKittySpark"
-        case .debug, .release, .appStore, .hardened: return "ClipKitty"
+        case .hardened: return "ClipKittyHardened"
+        case .debug, .release, .appStore: return "ClipKitty"
         }
+    }
+
+    var shortcutCompilationConditions: String {
+        capabilities.intersection([.appleShortcuts])
+            .map(\.compileCondition).sorted().joined(separator: " ")
     }
 
     /// Whether this variant requires SparkleUpdater in the target dependency graph.
@@ -330,11 +337,11 @@ enum IOSBuildVariant: CaseIterable {
     var compilationConditions: String {
         switch self {
         case .debug, .release:
-            return "ENABLE_ICLOUD_SYNC ENABLE_LINK_PREVIEWS"
+            return "ENABLE_APP_SHORTCUTS ENABLE_ICLOUD_SYNC ENABLE_LINK_PREVIEWS"
         case .sparkle, .hardened:
             return "" // no-op configs
         case .appStore:
-            return "ENABLE_ICLOUD_SYNC ENABLE_LINK_PREVIEWS"
+            return "ENABLE_APP_SHORTCUTS ENABLE_ICLOUD_SYNC ENABLE_LINK_PREVIEWS"
         }
     }
 
@@ -503,6 +510,33 @@ private let macAppCoreDependencies: [TargetDependency] = [
     .external(name: "STTextKitPlus"),
 ]
 
+func macAppResources(for variant: MacBuildVariant) -> ResourceFileElements {
+    if case .hardened = variant {
+        return [
+            .folderReference(path: "Sources/MacApp/Resources/Fonts"),
+            "Sources/MacApp/Resources/menu-bar.svg",
+            "Sources/MacApp/Resources/Localizable.xcstrings",
+            "Sources/MacApp/Assets.xcassets",
+            "Sources/MacApp/PrivacyInfo.xcprivacy",
+        ]
+    }
+    return macAppResources
+}
+
+func macAppDependencies(for variant: MacBuildVariant) -> [TargetDependency] {
+    if case .hardened = variant {
+        return [
+            .target(name: "ClipKittyRust"),
+            .target(name: "ClipKittyShared"),
+            .target(name: "ClipKittyAppleServices"),
+            .target(name: "ClipKittyMacPlatform"),
+            .sdk(name: "SystemConfiguration", type: .framework),
+            .external(name: "STTextKitPlus"),
+        ]
+    }
+    return macAppCoreDependencies + variant.additionalTargetDependencies
+}
+
 /// Creates macOS app targets, one per distinct `macAppTargetName`.
 ///
 /// Variants are grouped by target name. Each group produces one Tuist target
@@ -556,8 +590,8 @@ func makeMacAppTargets() -> [Target] {
             deploymentTargets: .macOS("14.0"),
             infoPlist: .extendingDefault(with: infoPlist),
             sources: macAppSources,
-            resources: macAppResources,
-            dependencies: macAppCoreDependencies + representative.additionalTargetDependencies,
+            resources: macAppResources(for: representative),
+            dependencies: macAppDependencies(for: representative),
             settings: .settings(
                 base: baseSettings,
                 configurations: configurations
@@ -704,7 +738,15 @@ let project = Project(
             settings: .settings(
                 base: [
                     "SKIP_INSTALL": "YES",
-                ]
+                ],
+                configurations: MacBuildVariant.allCases.map { variant in
+                    let settings: SettingsDictionary = [
+                        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": .string(variant.shortcutCompilationConditions),
+                    ]
+                    return variant.isRelease
+                        ? .release(name: variant.configurationName, settings: settings)
+                        : .debug(name: variant.configurationName, settings: settings)
+                }
             )
         ),
 

--- a/Project.swift
+++ b/Project.swift
@@ -487,6 +487,7 @@ private let macAppResources: ResourceFileElements = [
     .folderReference(path: "Sources/MacApp/Resources/Fonts"),
     "Sources/MacApp/Resources/menu-bar.svg",
     "Sources/MacApp/Resources/Localizable.xcstrings",
+    "Sources/MacApp/Resources/AppShortcuts.xcstrings",
     "Sources/MacApp/Assets.xcassets",
     "Sources/MacApp/PrivacyInfo.xcprivacy",
 ]
@@ -783,6 +784,7 @@ let project = Project(
                 "AppIcon.icon",
                 "Sources/iOSApp/Resources/Fonts/**",
                 "Sources/iOSApp/Resources/Localizable.xcstrings",
+                "Sources/iOSApp/Resources/AppShortcuts.xcstrings",
                 "Sources/iOSApp/PrivacyInfo.xcprivacy",
             ],
             dependencies: [

--- a/Project.swift
+++ b/Project.swift
@@ -497,6 +497,7 @@ private let macAppCoreDependencies: [TargetDependency] = [
     .target(name: "ClipKittyShared"),
     .target(name: "ClipKittyAppleServices"),
     .target(name: "ClipKittyMacPlatform"),
+    .target(name: "ClipKittyShortcuts"),
     .sdk(name: "SystemConfiguration", type: .framework),
     .external(name: "STTextKitPlus"),
 ]
@@ -686,6 +687,26 @@ let project = Project(
             )
         ),
 
+        // MARK: ClipKittyShortcuts — App Intents exposed to Apple Shortcuts
+
+        .target(
+            name: "ClipKittyShortcuts",
+            destinations: [.mac, .iPhone],
+            product: .staticLibrary,
+            bundleId: "com.eviljuliette.clipkitty.shortcuts",
+            deploymentTargets: .multiplatform(iOS: "26.0", macOS: "14.0"),
+            sources: ["Sources/Shortcuts/**"],
+            dependencies: [
+                .target(name: "ClipKittyRust"),
+                .target(name: "ClipKittyShared"),
+            ],
+            settings: .settings(
+                base: [
+                    "SKIP_INSTALL": "YES",
+                ]
+            )
+        ),
+
     ] + makeMacAppTargets() + [
         // MARK: ClipKittyTests — Unit tests
 
@@ -704,6 +725,7 @@ let project = Project(
                 .target(name: "ClipKittyShared"),
                 .target(name: "ClipKittyAppleServices"),
                 .target(name: "ClipKittyMacPlatform"),
+                .target(name: "ClipKittyShortcuts"),
             ],
             settings: .settings(
                 base: [
@@ -767,6 +789,7 @@ let project = Project(
                 .target(name: "ClipKittyRust"),
                 .target(name: "ClipKittyShared"),
                 .target(name: "ClipKittyAppleServices"),
+                .target(name: "ClipKittyShortcuts"),
                 .target(name: "ClipKittyShare"),
             ],
             settings: .settings(
@@ -848,6 +871,7 @@ let project = Project(
                 .target(name: "ClipKittyRust"),
                 .target(name: "ClipKittyShared"),
                 .target(name: "ClipKittyAppleServices"),
+                .target(name: "ClipKittyShortcuts"),
             ],
             settings: .settings(
                 base: [
@@ -880,6 +904,7 @@ let project = Project(
                 .target(name: "ClipKittyRust"),
                 .target(name: "ClipKittyShared"),
                 .target(name: "ClipKittyAppleServices"),
+                .target(name: "ClipKittyShortcuts"),
             ],
             settings: .settings(
                 base: [

--- a/Project.swift
+++ b/Project.swift
@@ -166,7 +166,8 @@ enum MacBuildVariant: CaseIterable {
 
     /// Additional target-level base build settings (e.g. Sparkle feed config).
     var additionalTargetBaseSettings: SettingsDictionary {
-        if requiresSparkle {
+        switch self {
+        case .sparkle:
             return [
                 "PRODUCT_NAME": "ClipKitty",
                 "SPARKLE_FEED_URL": "https://jul-sh.github.io/clipkitty/appcast.xml",
@@ -175,8 +176,13 @@ enum MacBuildVariant: CaseIterable {
                 "SPARKLE_AUTO_UPDATE": "YES",
                 "SPARKLE_INSTALLER_SERVICE": "YES",
             ]
+        case .hardened:
+            return [
+                "PRODUCT_NAME": "ClipKitty",
+            ]
+        case .debug, .release, .appStore:
+            return [:]
         }
-        return [:]
     }
 
     /// Additional Info.plist entries for this variant's target.

--- a/Sources/MacApp/AppDelegate.swift
+++ b/Sources/MacApp/AppDelegate.swift
@@ -2,9 +2,11 @@ import AppKit
 import ClipKittyMacPlatform
 import ClipKittyRust
 import ClipKittyShared
-import ClipKittyShortcuts
 import Combine
 import SwiftUI
+#if ENABLE_APP_SHORTCUTS
+    import ClipKittyShortcuts
+#endif
 #if ENABLE_SPARKLE_UPDATES
     import SparkleUpdater
 #endif
@@ -73,7 +75,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         case .simulatedDatabase:
             store = ClipboardStore(screenshotMode: true)
         }
-        configureShortcutRuntime()
+        #if ENABLE_APP_SHORTCUTS
+            configureShortcutRuntime()
+        #endif
         #if ENABLE_ICLOUD_SYNC
             configureSyncPreferenceController()
         #endif
@@ -165,15 +169,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
-    private func configureShortcutRuntime() {
-        ClipKittyShortcutRuntime.useRepositoryProvider { [weak store] in
-            guard let store else {
-                return .unavailable("ClipKitty has not finished launching.")
+    #if ENABLE_APP_SHORTCUTS
+        private func configureShortcutRuntime() {
+            ClipKittyShortcutRuntime.useRepositoryProvider { [weak store] in
+                guard let store else {
+                    return .unavailable("ClipKitty has not finished launching.")
+                }
+                await store.awaitReady()
+                return store.shortcutRepositoryAvailability()
             }
-            await store.awaitReady()
-            return store.shortcutRepositoryAvailability()
         }
-    }
+    #endif
 
     /// Ensure the simulated database directory exists (UI Test runner handles file placement)
     private func populateTestDatabase() {

--- a/Sources/MacApp/AppDelegate.swift
+++ b/Sources/MacApp/AppDelegate.swift
@@ -2,6 +2,7 @@ import AppKit
 import ClipKittyMacPlatform
 import ClipKittyRust
 import ClipKittyShared
+import ClipKittyShortcuts
 import Combine
 import SwiftUI
 #if ENABLE_SPARKLE_UPDATES
@@ -72,6 +73,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         case .simulatedDatabase:
             store = ClipboardStore(screenshotMode: true)
         }
+        configureShortcutRuntime()
         #if ENABLE_ICLOUD_SYNC
             configureSyncPreferenceController()
         #endif
@@ -160,6 +162,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 panelController.show()
                 NSApp.activate(ignoringOtherApps: true)
             }
+        }
+    }
+
+    private func configureShortcutRuntime() {
+        ClipKittyShortcutRuntime.useRepositoryProvider { [weak store] in
+            guard let store else {
+                return .unavailable("ClipKitty has not finished launching.")
+            }
+            await store.awaitReady()
+            return store.shortcutRepositoryAvailability()
         }
     }
 

--- a/Sources/MacApp/ClipKittyApp.swift
+++ b/Sources/MacApp/ClipKittyApp.swift
@@ -1,6 +1,8 @@
 import AppKit
-import ClipKittyShortcuts
 import SwiftUI
+#if ENABLE_APP_SHORTCUTS
+    import ClipKittyShortcuts
+#endif
 
 extension Notification.Name {
     static let clipKittyOpenSettings = Notification.Name("ClipKittyOpenSettings")
@@ -11,7 +13,9 @@ struct ClipKittyApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     init() {
-        ClipKittyAppShortcuts.updateAppShortcutParameters()
+        #if ENABLE_APP_SHORTCUTS
+            ClipKittyAppShortcuts.updateAppShortcutParameters()
+        #endif
     }
 
     var body: some Scene {

--- a/Sources/MacApp/ClipKittyApp.swift
+++ b/Sources/MacApp/ClipKittyApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ClipKittyShortcuts
 import SwiftUI
 
 extension Notification.Name {
@@ -8,6 +9,10 @@ extension Notification.Name {
 @main
 struct ClipKittyApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    init() {
+        ClipKittyAppShortcuts.updateAppShortcutParameters()
+    }
 
     var body: some Scene {
         Settings {

--- a/Sources/MacApp/ClipboardStore.swift
+++ b/Sources/MacApp/ClipboardStore.swift
@@ -3,13 +3,15 @@ import ClipKittyAppleServices
 import ClipKittyMacPlatform
 import ClipKittyRust
 import ClipKittyShared
-import ClipKittyShortcuts
 import Foundation
 import ImageIO
 import Observation
 import os
 import QuartzCore
 import UniformTypeIdentifiers
+#if ENABLE_APP_SHORTCUTS
+    import ClipKittyShortcuts
+#endif
 
 // MARK: - Logging
 
@@ -316,19 +318,21 @@ final class ClipboardStore {
         _ = try? await task.value
     }
 
-    func shortcutRepositoryAvailability() -> ClipKittyShortcutRepositoryAvailability {
-        switch lifecycle {
-        case .ready:
-            if let repository {
-                return .ready(repository)
+    #if ENABLE_APP_SHORTCUTS
+        func shortcutRepositoryAvailability() -> ClipKittyShortcutRepositoryAvailability {
+            switch lifecycle {
+            case .ready:
+                if let repository {
+                    return .ready(repository)
+                }
+                return .unavailable("ClipKitty's database is not ready yet.")
+            case .initializing, .rebuildingIndex:
+                return .unavailable("ClipKitty is still preparing its database.")
+            case let .failed(reason):
+                return .unavailable(reason)
             }
-            return .unavailable("ClipKitty's database is not ready yet.")
-        case .initializing, .rebuildingIndex:
-            return .unavailable("ClipKitty is still preparing its database.")
-        case let .failed(reason):
-            return .unavailable(reason)
         }
-    }
+    #endif
 
     // MARK: - Public API
 

--- a/Sources/MacApp/ClipboardStore.swift
+++ b/Sources/MacApp/ClipboardStore.swift
@@ -3,6 +3,7 @@ import ClipKittyAppleServices
 import ClipKittyMacPlatform
 import ClipKittyRust
 import ClipKittyShared
+import ClipKittyShortcuts
 import Foundation
 import ImageIO
 import Observation
@@ -313,6 +314,20 @@ final class ClipboardStore {
     func awaitReady() async {
         guard let task = bootstrapTask else { return }
         _ = try? await task.value
+    }
+
+    func shortcutRepositoryAvailability() -> ClipKittyShortcutRepositoryAvailability {
+        switch lifecycle {
+        case .ready:
+            if let repository {
+                return .ready(repository)
+            }
+            return .unavailable("ClipKitty's database is not ready yet.")
+        case .initializing, .rebuildingIndex:
+            return .unavailable("ClipKitty is still preparing its database.")
+        case let .failed(reason):
+            return .unavailable(reason)
+        }
     }
 
     // MARK: - Public API

--- a/Sources/MacApp/Resources/AppShortcuts.xcstrings
+++ b/Sources/MacApp/Resources/AppShortcuts.xcstrings
@@ -1,0 +1,518 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "Save text to ${applicationName}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text in ${applicationName} speichern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save text to ${applicationName}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar texto en ${applicationName}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer le texte dans ${applicationName}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストを${applicationName}に保存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트를 ${applicationName}에 저장"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar texto no ${applicationName}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить текст в ${applicationName}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将文本保存到 ${applicationName}"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將文字儲存到 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Add text to ${applicationName}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text zu ${applicationName} hinzufügen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add text to ${applicationName}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar texto a ${applicationName}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter du texte à ${applicationName}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストを${applicationName}に追加"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "텍스트를 ${applicationName}에 추가"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar texto ao ${applicationName}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить текст в ${applicationName}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将文本添加到 ${applicationName}"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將文字加入 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Save clipboard to ${applicationName}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischenablage in ${applicationName} speichern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save clipboard to ${applicationName}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar portapapeles en ${applicationName}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer le presse-papiers dans ${applicationName}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリップボードを${applicationName}に保存"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클립보드를 ${applicationName}에 저장"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvar área de transferência no ${applicationName}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить буфер обмена в ${applicationName}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将剪贴板保存到 ${applicationName}"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將剪貼簿儲存到 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Add clipboard to ${applicationName}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischenablage zu ${applicationName} hinzufügen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add clipboard to ${applicationName}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agregar portapapeles a ${applicationName}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter le presse-papiers à ${applicationName}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリップボードを${applicationName}に追加"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "클립보드를 ${applicationName}에 추가"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar área de transferência ao ${applicationName}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить буфер обмена в ${applicationName}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将剪贴板添加到 ${applicationName}"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將剪貼簿加入 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Search ${applicationName}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName} durchsuchen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search ${applicationName}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar en ${applicationName}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher dans ${applicationName}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName}を検索"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName} 검색"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pesquisar ${applicationName}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Искать в ${applicationName}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索 ${applicationName}"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Find text in ${applicationName}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text in ${applicationName} finden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Find text in ${applicationName}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar texto en ${applicationName}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trouver du texte dans ${applicationName}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName}内のテキストを検索"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName}에서 텍스트 찾기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Encontrar texto no ${applicationName}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Найти текст в ${applicationName}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 ${applicationName} 中查找文本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 ${applicationName} 中尋找文字"
+          }
+        }
+      }
+    },
+    "Get recent text from ${applicationName}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuellen Text aus ${applicationName} abrufen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get recent text from ${applicationName}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtener texto reciente de ${applicationName}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtenir le texte récent de ${applicationName}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName}から最近のテキストを取得"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName}에서 최근 텍스트 가져오기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obter texto recente do ${applicationName}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Получить недавний текст из ${applicationName}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 ${applicationName} 获取最近的文本"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從 ${applicationName} 取得最近的文字"
+          }
+        }
+      }
+    },
+    "Get recent clips from ${applicationName}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuelle Clips aus ${applicationName} abrufen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get recent clips from ${applicationName}"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtener clips recientes de ${applicationName}"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obtenir les clips récents de ${applicationName}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName}から最近のクリップを取得"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "${applicationName}에서 최근 클립 가져오기"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Obter clipes recentes do ${applicationName}"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Получить недавние фрагменты из ${applicationName}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 ${applicationName} 获取最近的剪辑"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從 ${applicationName} 取得最近的片段"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Sources/MacApp/Resources/Localizable.xcstrings
+++ b/Sources/MacApp/Resources/Localizable.xcstrings
@@ -10478,7 +10478,1095 @@
         }
       }
     },
-    "✏️": {}
+    "✏️": {},
+      "Save Text to ClipKitty": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Text in ClipKitty speichern"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Save Text to ClipKitty"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Guardar texto en ClipKitty"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Enregistrer le texte dans ClipKitty"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "テキストをClipKittyに保存"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "텍스트를 ClipKitty에 저장"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Salvar texto no ClipKitty"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Сохранить текст в ClipKitty"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "将文本保存到 ClipKitty"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "將文字儲存到 ClipKitty"
+                  }
+              }
+          }
+      },
+      "Save text into ClipKitty's clipboard history.": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Text im ClipKitty-Zwischenablageverlauf speichern."
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Save text into ClipKitty's clipboard history."
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Guarda texto en el historial del portapapeles de ClipKitty."
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Enregistrez le texte dans l’historique du presse-papiers de ClipKitty."
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "テキストをClipKittyのクリップボード履歴に保存します。"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "텍스트를 ClipKitty 클립보드 기록에 저장합니다."
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Salve texto no histórico da área de transferência do ClipKitty."
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Сохранить текст в истории буфера обмена ClipKitty."
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "将文本保存到 ClipKitty 的剪贴板历史记录中。"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "將文字儲存到 ClipKitty 的剪貼簿記錄中。"
+                  }
+              }
+          }
+      },
+      "Save Clipboard to ClipKitty": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Zwischenablage in ClipKitty speichern"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Save Clipboard to ClipKitty"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Guardar portapapeles en ClipKitty"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Enregistrer le presse-papiers dans ClipKitty"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "クリップボードをClipKittyに保存"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "클립보드를 ClipKitty에 저장"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Salvar área de transferência no ClipKitty"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Сохранить буфер обмена в ClipKitty"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "将剪贴板保存到 ClipKitty"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "將剪貼簿儲存到 ClipKitty"
+                  }
+              }
+          }
+      },
+      "Save the current text or image clipboard item into ClipKitty.": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Aktuellen Text- oder Bildinhalt der Zwischenablage in ClipKitty speichern."
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Save the current text or image clipboard item into ClipKitty."
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Guarda en ClipKitty el texto o la imagen actual del portapapeles."
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Enregistrez le texte ou l’image actuelle du presse-papiers dans ClipKitty."
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "現在のクリップボードのテキストまたは画像をClipKittyに保存します。"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "현재 클립보드의 텍스트 또는 이미지를 ClipKitty에 저장합니다."
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Salve no ClipKitty o texto ou a imagem atual da área de transferência."
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Сохранить текущий текст или изображение из буфера обмена в ClipKitty."
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "将当前剪贴板中的文本或图像保存到 ClipKitty。"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "將目前剪貼簿中的文字或影像儲存到 ClipKitty。"
+                  }
+              }
+          }
+      },
+      "Search ClipKitty Text": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKitty-Text durchsuchen"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Search ClipKitty Text"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Buscar texto en ClipKitty"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Rechercher du texte dans ClipKitty"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKittyのテキストを検索"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKitty 텍스트 검색"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Pesquisar texto no ClipKitty"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Искать текст в ClipKitty"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "搜索 ClipKitty 文本"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "搜尋 ClipKitty 文字"
+                  }
+              }
+          }
+      },
+      "Search ClipKitty's text clipboard history.": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Den Textverlauf der ClipKitty-Zwischenablage durchsuchen."
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Search ClipKitty's text clipboard history."
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Busca en el historial de texto del portapapeles de ClipKitty."
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Recherchez dans l’historique du presse-papiers texte de ClipKitty."
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKittyのテキストクリップボード履歴を検索します。"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKitty의 텍스트 클립보드 기록을 검색합니다."
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Pesquise no histórico de texto da área de transferência do ClipKitty."
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Искать в текстовой истории буфера обмена ClipKitty."
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "搜索 ClipKitty 的文本剪贴板历史记录。"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "搜尋 ClipKitty 的文字剪貼簿記錄。"
+                  }
+              }
+          }
+      },
+      "Get Recent ClipKitty Text": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Aktuellen ClipKitty-Text abrufen"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Get Recent ClipKitty Text"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Obtener texto reciente de ClipKitty"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Obtenir le texte récent de ClipKitty"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "最近のClipKittyテキストを取得"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "최근 ClipKitty 텍스트 가져오기"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Obter texto recente do ClipKitty"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Получить недавний текст ClipKitty"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "获取最近的 ClipKitty 文本"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "取得最近的 ClipKitty 文字"
+                  }
+              }
+          }
+      },
+      "Get recent text clips from ClipKitty.": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Aktuelle Textclips aus ClipKitty abrufen."
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Get recent text clips from ClipKitty."
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Obtén clips de texto recientes de ClipKitty."
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Obtenez les clips de texte récents de ClipKitty."
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKittyから最近のテキストクリップを取得します。"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKitty에서 최근 텍스트 클립을 가져옵니다."
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Obtenha clipes de texto recentes do ClipKitty."
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Получить недавние текстовые фрагменты из ClipKitty."
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "从 ClipKitty 获取最近的文本剪辑。"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "從 ClipKitty 取得最近的文字片段。"
+                  }
+              }
+          }
+      },
+      "Query": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Suchbegriff"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Query"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Consulta"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Requête"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "検索語句"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "쿼리"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Consulta"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Запрос"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "查询"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "查詢"
+                  }
+              }
+          }
+      },
+      "Maximum Results": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Maximale Ergebnisse"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Maximum Results"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Resultados máximos"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Nombre maximal de résultats"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "最大結果数"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "최대 결과 수"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Máximo de resultados"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Максимум результатов"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "最大结果数"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "最大結果數"
+                  }
+              }
+          }
+      },
+      "Save Text": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Text speichern"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Save Text"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Guardar texto"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Enregistrer le texte"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "テキストを保存"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "텍스트 저장"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Salvar texto"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Сохранить текст"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "保存文本"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "儲存文字"
+                  }
+              }
+          }
+      },
+      "Save Clipboard": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Zwischenablage speichern"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Save Clipboard"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Guardar portapapeles"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Enregistrer le presse-papiers"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "クリップボードを保存"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "클립보드 저장"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Salvar área de transferência"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Сохранить буфер обмена"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "保存剪贴板"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "儲存剪貼簿"
+                  }
+              }
+          }
+      },
+      "Search Text": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Text suchen"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Search Text"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Buscar texto"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Rechercher le texte"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "テキストを検索"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "텍스트 검색"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Pesquisar texto"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Искать текст"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "搜索文本"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "搜尋文字"
+                  }
+              }
+          }
+      },
+      "Recent Text": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Aktueller Text"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Recent Text"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Texto reciente"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Texte récent"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "最近のテキスト"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "최근 텍스트"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Texto recente"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Недавний текст"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "最近文本"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "最近文字"
+                  }
+              }
+          }
+      },
+      "Saved to ClipKitty.": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "In ClipKitty gespeichert."
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Saved to ClipKitty."
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Guardado en ClipKitty."
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Enregistré dans ClipKitty."
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKittyに保存しました。"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "ClipKitty에 저장됨."
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Salvo no ClipKitty."
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Сохранено в ClipKitty."
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "已保存到 ClipKitty。"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "已儲存到 ClipKitty。"
+                  }
+              }
+          }
+      },
+      "Already in ClipKitty.": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Bereits in ClipKitty."
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Already in ClipKitty."
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Ya está en ClipKitty."
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Déjà dans ClipKitty."
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "すでにClipKittyにあります。"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "이미 ClipKitty에 있습니다."
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Já está no ClipKitty."
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Уже в ClipKitty."
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "已在 ClipKitty 中。"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "已在 ClipKitty 中。"
+                  }
+              }
+          }
+      },
+      "Already in ClipKitty": {
+          "localizations": {
+              "de": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Bereits in ClipKitty"
+                  }
+              },
+              "en": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Already in ClipKitty"
+                  }
+              },
+              "es": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Ya está en ClipKitty"
+                  }
+              },
+              "fr": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Déjà dans ClipKitty"
+                  }
+              },
+              "ja": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "すでにClipKittyにあります"
+                  }
+              },
+              "ko": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "이미 ClipKitty에 있습니다"
+                  }
+              },
+              "pt-BR": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Já está no ClipKitty"
+                  }
+              },
+              "ru": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "Уже в ClipKitty"
+                  }
+              },
+              "zh-Hans": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "已在 ClipKitty 中"
+                  }
+              },
+              "zh-Hant": {
+                  "stringUnit": {
+                      "state": "translated",
+                      "value": "已在 ClipKitty 中"
+                  }
+              }
+          }
+      }
   },
   "version": "1.0"
 }

--- a/Sources/Shared/ClipboardRepository.swift
+++ b/Sources/Shared/ClipboardRepository.swift
@@ -53,7 +53,7 @@ public func runRepositoryOperation<T: Sendable>(
     }
 }
 
-public final class ClipboardRepository {
+public final class ClipboardRepository: @unchecked Sendable {
     public let store: ClipKittyRust.ClipboardStore
 
     public init(store: ClipKittyRust.ClipboardStore) {

--- a/Sources/Shortcuts/ClipKittyShortcutIntents.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutIntents.swift
@@ -1,3 +1,4 @@
+#if ENABLE_APP_SHORTCUTS
 import AppIntents
 import Foundation
 
@@ -137,3 +138,4 @@ private enum ShortcutIntentResult {
         }
     }
 }
+#endif

--- a/Sources/Shortcuts/ClipKittyShortcutIntents.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutIntents.swift
@@ -16,7 +16,7 @@ public struct SaveTextToClipKittyIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let saved = try await ClipKittyShortcutService().saveText(text)
+        let saved = try await ClipKittyShortcutRuntime.makeService().saveText(text)
         return .result(value: text, dialog: ShortcutIntentResult.dialog(for: saved))
     }
 }
@@ -29,7 +29,7 @@ public struct SaveClipboardToClipKittyIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let saved = try await ClipKittyShortcutService().saveCurrentClipboard()
+        let saved = try await ClipKittyShortcutRuntime.makeService().saveCurrentClipboard()
         return .result(
             value: ShortcutIntentResult.value(for: saved),
             dialog: ShortcutIntentResult.dialog(for: saved)
@@ -51,7 +51,7 @@ public struct SearchClipKittyTextIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<[String]> {
-        let values = try await ClipKittyShortcutService().searchText(query: query, limit: limit)
+        let values = try await ClipKittyShortcutRuntime.makeService().searchText(query: query, limit: limit)
         return .result(value: values)
     }
 }
@@ -67,7 +67,7 @@ public struct GetRecentClipKittyTextIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<[String]> {
-        let values = try await ClipKittyShortcutService().fetchRecentText(limit: limit)
+        let values = try await ClipKittyShortcutRuntime.makeService().fetchRecentText(limit: limit)
         return .result(value: values)
     }
 }
@@ -80,7 +80,7 @@ public struct CopyLatestClipKittyTextIntent: AppIntent {
     public init() {}
 
     public func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let value = try await ClipKittyShortcutService().copyLatestText()
+        let value = try await ClipKittyShortcutRuntime.makeService().copyLatestText()
         return .result(value: value, dialog: "Copied to clipboard.")
     }
 }

--- a/Sources/Shortcuts/ClipKittyShortcutIntents.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutIntents.swift
@@ -72,19 +72,6 @@ public struct GetRecentClipKittyTextIntent: AppIntent {
     }
 }
 
-public struct CopyLatestClipKittyTextIntent: AppIntent {
-    public static var title: LocalizedStringResource = "Copy Latest ClipKitty Text"
-    public static var description: IntentDescription? = "Copy ClipKitty's most recent text clip to the system clipboard."
-    public static var openAppWhenRun = false
-
-    public init() {}
-
-    public func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
-        let value = try await ClipKittyShortcutRuntime.makeService().copyLatestText()
-        return .result(value: value, dialog: "Copied to clipboard.")
-    }
-}
-
 public struct ClipKittyAppShortcuts: AppShortcutsProvider {
     public static var shortcutTileColor: ShortcutTileColor { .pink }
 
@@ -127,16 +114,6 @@ public struct ClipKittyAppShortcuts: AppShortcutsProvider {
             ],
             shortTitle: "Recent Text",
             systemImageName: "clock"
-        )
-
-        AppShortcut(
-            intent: CopyLatestClipKittyTextIntent(),
-            phrases: [
-                "Copy latest text from \(.applicationName)",
-                "Copy latest clip from \(.applicationName)",
-            ],
-            shortTitle: "Copy Latest",
-            systemImageName: "doc.on.clipboard"
         )
     }
 }

--- a/Sources/Shortcuts/ClipKittyShortcutIntents.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutIntents.swift
@@ -1,0 +1,162 @@
+import AppIntents
+import Foundation
+
+public struct ClipKittyShortcutsPackage: AppIntentsPackage {
+    public init() {}
+}
+
+public struct SaveTextToClipKittyIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Save Text to ClipKitty"
+    public static var description: IntentDescription? = "Save text into ClipKitty's clipboard history."
+    public static var openAppWhenRun = false
+
+    @Parameter(title: "Text")
+    public var text: String
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let saved = try await ClipKittyShortcutService().saveText(text)
+        return .result(value: text, dialog: ShortcutIntentResult.dialog(for: saved))
+    }
+}
+
+public struct SaveClipboardToClipKittyIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Save Clipboard to ClipKitty"
+    public static var description: IntentDescription? = "Save the current text or image clipboard item into ClipKitty."
+    public static var openAppWhenRun = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let saved = try await ClipKittyShortcutService().saveCurrentClipboard()
+        return .result(
+            value: ShortcutIntentResult.value(for: saved),
+            dialog: ShortcutIntentResult.dialog(for: saved)
+        )
+    }
+}
+
+public struct SearchClipKittyTextIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Search ClipKitty Text"
+    public static var description: IntentDescription? = "Search ClipKitty's text clipboard history."
+    public static var openAppWhenRun = false
+
+    @Parameter(title: "Query")
+    public var query: String
+
+    @Parameter(title: "Maximum Results", default: 5)
+    public var limit: Int
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<[String]> {
+        let values = try await ClipKittyShortcutService().searchText(query: query, limit: limit)
+        return .result(value: values)
+    }
+}
+
+public struct GetRecentClipKittyTextIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Get Recent ClipKitty Text"
+    public static var description: IntentDescription? = "Get recent text clips from ClipKitty."
+    public static var openAppWhenRun = false
+
+    @Parameter(title: "Maximum Results", default: 5)
+    public var limit: Int
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<[String]> {
+        let values = try await ClipKittyShortcutService().fetchRecentText(limit: limit)
+        return .result(value: values)
+    }
+}
+
+public struct CopyLatestClipKittyTextIntent: AppIntent {
+    public static var title: LocalizedStringResource = "Copy Latest ClipKitty Text"
+    public static var description: IntentDescription? = "Copy ClipKitty's most recent text clip to the system clipboard."
+    public static var openAppWhenRun = false
+
+    public init() {}
+
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let value = try await ClipKittyShortcutService().copyLatestText()
+        return .result(value: value, dialog: "Copied to clipboard.")
+    }
+}
+
+public struct ClipKittyAppShortcuts: AppShortcutsProvider {
+    public static var shortcutTileColor: ShortcutTileColor { .pink }
+
+    public static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: SaveTextToClipKittyIntent(),
+            phrases: [
+                "Save text to \(.applicationName)",
+                "Add text to \(.applicationName)",
+            ],
+            shortTitle: "Save Text",
+            systemImageName: "plus"
+        )
+
+        AppShortcut(
+            intent: SaveClipboardToClipKittyIntent(),
+            phrases: [
+                "Save clipboard to \(.applicationName)",
+                "Add clipboard to \(.applicationName)",
+            ],
+            shortTitle: "Save Clipboard",
+            systemImageName: "clipboard"
+        )
+
+        AppShortcut(
+            intent: SearchClipKittyTextIntent(),
+            phrases: [
+                "Search \(.applicationName)",
+                "Find text in \(.applicationName)",
+            ],
+            shortTitle: "Search Text",
+            systemImageName: "magnifyingglass"
+        )
+
+        AppShortcut(
+            intent: GetRecentClipKittyTextIntent(),
+            phrases: [
+                "Get recent text from \(.applicationName)",
+                "Get recent clips from \(.applicationName)",
+            ],
+            shortTitle: "Recent Text",
+            systemImageName: "clock"
+        )
+
+        AppShortcut(
+            intent: CopyLatestClipKittyTextIntent(),
+            phrases: [
+                "Copy latest text from \(.applicationName)",
+                "Copy latest clip from \(.applicationName)",
+            ],
+            shortTitle: "Copy Latest",
+            systemImageName: "doc.on.clipboard"
+        )
+    }
+}
+
+private enum ShortcutIntentResult {
+    static func dialog(for saved: ShortcutSavedClip) -> IntentDialog {
+        switch saved {
+        case .inserted:
+            return "Saved to ClipKitty."
+        case .duplicate:
+            return "Already in ClipKitty."
+        }
+    }
+
+    static func value(for saved: ShortcutSavedClip) -> String {
+        switch saved {
+        case let .inserted(id):
+            return id
+        case .duplicate:
+            return "Already in ClipKitty"
+        }
+    }
+}

--- a/Sources/Shortcuts/ClipKittyShortcutIntents.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutIntents.swift
@@ -15,7 +15,7 @@ public struct SaveTextToClipKittyIntent: AppIntent {
 
     public init() {}
 
-    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
         let saved = try await ClipKittyShortcutRuntime.makeService().saveText(text)
         return .result(value: text, dialog: ShortcutIntentResult.dialog(for: saved))
     }
@@ -28,7 +28,7 @@ public struct SaveClipboardToClipKittyIntent: AppIntent {
 
     public init() {}
 
-    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
         let saved = try await ClipKittyShortcutRuntime.makeService().saveCurrentClipboard()
         return .result(
             value: ShortcutIntentResult.value(for: saved),
@@ -79,7 +79,7 @@ public struct CopyLatestClipKittyTextIntent: AppIntent {
 
     public init() {}
 
-    public func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    public func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
         let value = try await ClipKittyShortcutRuntime.makeService().copyLatestText()
         return .result(value: value, dialog: "Copied to clipboard.")
     }

--- a/Sources/Shortcuts/ClipKittyShortcutPasteboard.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutPasteboard.swift
@@ -1,0 +1,156 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+#if os(macOS)
+    import AppKit
+#elseif os(iOS)
+    import UIKit
+#endif
+
+enum ShortcutSavableContent: Sendable {
+    case text(String)
+    case image(data: Data, thumbnail: Data?, isAnimated: Bool)
+}
+
+enum ShortcutPasteboardRead: Sendable {
+    case content(ShortcutSavableContent)
+    case empty
+    case unsupported(String)
+}
+
+@MainActor
+enum ShortcutPasteboard {
+    static func read() -> ShortcutPasteboardRead {
+        #if os(macOS)
+            readMacPasteboard()
+        #elseif os(iOS)
+            readIOSPasteboard()
+        #else
+            .unsupported("ClipKitty Shortcuts support is available on macOS and iOS.")
+        #endif
+    }
+
+    static func writeText(_ text: String) {
+        #if os(macOS)
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(text, forType: .string)
+        #elseif os(iOS)
+            UIPasteboard.general.string = text
+        #endif
+    }
+
+    #if os(macOS)
+        private static func readMacPasteboard() -> ShortcutPasteboardRead {
+            let pasteboard = NSPasteboard.general
+            let availableTypes = Set(pasteboard.types ?? [])
+            guard !availableTypes.isEmpty else { return .empty }
+
+            let gifType = NSPasteboard.PasteboardType("com.compuserve.gif")
+            if availableTypes.contains(gifType),
+               let data = pasteboard.data(forType: gifType) {
+                return .content(.image(
+                    data: data,
+                    thumbnail: ShortcutImageThumbnail.makeThumbnail(from: data),
+                    isAnimated: true
+                ))
+            }
+
+            for type in [NSPasteboard.PasteboardType.tiff, .png] where availableTypes.contains(type) {
+                guard let data = pasteboard.data(forType: type) else { continue }
+                return .content(.image(
+                    data: data,
+                    thumbnail: ShortcutImageThumbnail.makeThumbnail(from: data),
+                    isAnimated: false
+                ))
+            }
+
+            if availableTypes.contains(.string),
+               let text = pasteboard.string(forType: .string),
+               !text.isEmpty {
+                return .content(.text(text))
+            }
+
+            return .unsupported("The current clipboard item is not text or an image.")
+        }
+    #endif
+
+    #if os(iOS)
+        private static func readIOSPasteboard() -> ShortcutPasteboardRead {
+            let pasteboard = UIPasteboard.general
+
+            if let image = pasteboard.image,
+               let data = image.pngData() {
+                return .content(.image(
+                    data: data,
+                    thumbnail: ShortcutImageThumbnail.makeThumbnail(from: data),
+                    isAnimated: false
+                ))
+            }
+
+            if let url = pasteboard.url {
+                return .content(.text(url.absoluteString))
+            }
+
+            if let text = pasteboard.string, !text.isEmpty {
+                return .content(.text(text))
+            }
+
+            if pasteboard.hasImages || pasteboard.hasURLs || pasteboard.hasStrings {
+                return .unsupported("The current clipboard item could not be read by ClipKitty.")
+            }
+
+            return .empty
+        }
+    #endif
+}
+
+private enum ShortcutImageThumbnail {
+    static func makeThumbnail(from data: Data, maxDimension: Int = 200) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return nil
+        }
+
+        let scale = min(
+            CGFloat(maxDimension) / CGFloat(image.width),
+            CGFloat(maxDimension) / CGFloat(image.height),
+            1.0
+        )
+        let targetWidth = max(1, Int(CGFloat(image.width) * scale))
+        let targetHeight = max(1, Int(CGFloat(image.height) * scale))
+
+        guard let context = CGContext(
+            data: nil,
+            width: targetWidth,
+            height: targetHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
+        guard let thumbnail = context.makeImage() else { return nil }
+
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            output as CFMutableData,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        ) else {
+            return nil
+        }
+
+        let options = [kCGImageDestinationLossyCompressionQuality: 0.7] as CFDictionary
+        CGImageDestinationAddImage(destination, thumbnail, options)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+}

--- a/Sources/Shortcuts/ClipKittyShortcutPasteboard.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutPasteboard.swift
@@ -32,16 +32,6 @@ enum ShortcutPasteboard {
         #endif
     }
 
-    static func writeText(_ text: String) {
-        #if os(macOS)
-            let pasteboard = NSPasteboard.general
-            pasteboard.clearContents()
-            pasteboard.setString(text, forType: .string)
-        #elseif os(iOS)
-            UIPasteboard.general.string = text
-        #endif
-    }
-
     #if os(macOS)
         private static func readMacPasteboard() -> ShortcutPasteboardRead {
             let pasteboard = NSPasteboard.general

--- a/Sources/Shortcuts/ClipKittyShortcutService.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutService.swift
@@ -1,0 +1,237 @@
+import ClipKittyRust
+import ClipKittyShared
+import Foundation
+
+enum ClipKittyShortcutError: LocalizedError, Sendable {
+    case emptyText
+    case emptyClipboard
+    case unsupportedClipboardContent(String)
+    case databasePathUnavailable(String)
+    case databaseOpenFailed(String)
+    case operationFailed(String)
+    case noTextClips
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyText:
+            return "Text cannot be empty."
+        case .emptyClipboard:
+            return "The clipboard is empty."
+        case let .unsupportedClipboardContent(reason):
+            return reason
+        case let .databasePathUnavailable(reason):
+            return "Could not locate ClipKitty's database: \(reason)"
+        case let .databaseOpenFailed(reason):
+            return "Could not open ClipKitty's database: \(reason)"
+        case let .operationFailed(reason):
+            return reason
+        case .noTextClips:
+            return "ClipKitty does not have any text clips yet."
+        }
+    }
+}
+
+enum ShortcutSavedClip: Equatable, Sendable {
+    case inserted(id: String)
+    case duplicate
+}
+
+private enum ShortcutTextLookup: Sendable {
+    case found(String)
+    case notFound
+}
+
+private enum ShortcutTextExtraction: Sendable {
+    case value(String)
+    case unsupported
+
+    static func parse(_ content: ClipboardContent) -> Self {
+        switch content {
+        case let .text(value):
+            return .value(value)
+        case .color, .link, .image, .file:
+            return .unsupported
+        }
+    }
+}
+
+final class ClipKittyShortcutService {
+    private let databasePathProvider: () throws -> String
+
+    init(databasePathProvider: @escaping () throws -> String = ShortcutDatabasePath.resolve) {
+        self.databasePathProvider = databasePathProvider
+    }
+
+    convenience init(databasePath: String) {
+        self.init(databasePathProvider: { databasePath })
+    }
+
+    func saveText(_ text: String) async throws -> ShortcutSavedClip {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ClipKittyShortcutError.emptyText
+        }
+
+        let repository = try makeRepository()
+        let result = await repository.saveText(
+            text: text,
+            sourceApp: "Shortcuts",
+            sourceAppBundleId: "com.apple.shortcuts"
+        )
+        return try savedClip(from: result)
+    }
+
+    func saveCurrentClipboard() async throws -> ShortcutSavedClip {
+        let clipboardRead = await ShortcutPasteboard.read()
+        switch clipboardRead {
+        case let .content(content):
+            return try await save(content)
+        case .empty:
+            throw ClipKittyShortcutError.emptyClipboard
+        case let .unsupported(reason):
+            throw ClipKittyShortcutError.unsupportedClipboardContent(reason)
+        }
+    }
+
+    func searchText(query: String, limit: Int) async throws -> [String] {
+        try await fetchText(query: query, limit: limit)
+    }
+
+    func fetchRecentText(limit: Int) async throws -> [String] {
+        try await fetchText(query: "", limit: limit)
+    }
+
+    func copyLatestText() async throws -> String {
+        let values = try await fetchRecentText(limit: 1)
+        switch firstText(in: values) {
+        case let .found(value):
+            await ShortcutPasteboard.writeText(value)
+            return value
+        case .notFound:
+            throw ClipKittyShortcutError.noTextClips
+        }
+    }
+
+    private func save(_ content: ShortcutSavableContent) async throws -> ShortcutSavedClip {
+        switch content {
+        case let .text(text):
+            return try await saveText(text)
+        case let .image(data, thumbnail, isAnimated):
+            let repository = try makeRepository()
+            let result = await repository.saveImage(
+                imageData: data,
+                thumbnail: thumbnail,
+                sourceApp: "Shortcuts",
+                sourceAppBundleId: "com.apple.shortcuts",
+                isAnimated: isAnimated
+            )
+            return try savedClip(from: result)
+        }
+    }
+
+    private func fetchText(query: String, limit: Int) async throws -> [String] {
+        let repository = try makeRepository()
+        let result = await repository.search(
+            query: query,
+            filter: .contentType(contentType: .text),
+            presentation: .compactRow
+        )
+
+        let matches: [ItemMatch]
+        switch result {
+        case let .success(searchResult):
+            matches = searchResult.matches
+        case .cancelled:
+            throw ClipKittyShortcutError.operationFailed("The ClipKitty search was cancelled.")
+        case let .failure(error):
+            throw ClipKittyShortcutError.operationFailed(error.localizedDescription)
+        }
+
+        let clampedLimit = Self.clampLimit(limit)
+        var values: [String] = []
+        for match in matches.prefix(clampedLimit) {
+            guard let item = await repository.fetchItem(id: match.itemMetadata.itemId) else {
+                continue
+            }
+            switch ShortcutTextExtraction.parse(item.content) {
+            case let .value(value):
+                values.append(value)
+            case .unsupported:
+                continue
+            }
+        }
+        return values
+    }
+
+    private func makeRepository() throws -> ClipboardRepository {
+        let dbPath: String
+        do {
+            dbPath = try databasePathProvider()
+        } catch let error as ClipKittyShortcutError {
+            throw error
+        } catch {
+            throw ClipKittyShortcutError.databasePathUnavailable(error.localizedDescription)
+        }
+
+        let plan: StoreBootstrapPlan
+        do {
+            plan = try inspectStoreBootstrap(dbPath: dbPath)
+        } catch {
+            throw ClipKittyShortcutError.databaseOpenFailed(error.localizedDescription)
+        }
+
+        let store: ClipKittyRust.ClipboardStore
+        do {
+            store = try ClipKittyRust.ClipboardStore(dbPath: dbPath)
+            switch plan {
+            case .ready:
+                break
+            case .rebuildIndex:
+                try store.rebuildIndex()
+            }
+        } catch {
+            throw ClipKittyShortcutError.databaseOpenFailed(error.localizedDescription)
+        }
+
+        return ClipboardRepository(store: store)
+    }
+
+    private func savedClip(from result: Result<String, ClipboardError>) throws -> ShortcutSavedClip {
+        switch result {
+        case let .success(itemId):
+            if itemId.isEmpty {
+                return .duplicate
+            }
+            return .inserted(id: itemId)
+        case let .failure(error):
+            throw ClipKittyShortcutError.operationFailed(error.localizedDescription)
+        }
+    }
+
+    private func firstText(in values: [String]) -> ShortcutTextLookup {
+        guard let first = values.first else { return .notFound }
+        return .found(first)
+    }
+
+    private static func clampLimit(_ limit: Int) -> Int {
+        min(max(limit, 1), 50)
+    }
+}
+
+private enum ShortcutDatabasePath {
+    static func resolve() throws -> String {
+        #if os(macOS)
+            guard let appSupport = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first else {
+                throw ClipKittyShortcutError.databasePathUnavailable("Application Support is unavailable.")
+            }
+            let appDir = appSupport.appendingPathComponent("ClipKitty", isDirectory: true)
+            try FileManager.default.createDirectory(at: appDir, withIntermediateDirectories: true)
+            return appDir.appendingPathComponent("clipboard.sqlite").path
+        #else
+            DatabasePath.migrateIfNeeded()
+            return try DatabasePath.resolve()
+        #endif
+    }
+}

--- a/Sources/Shortcuts/ClipKittyShortcutService.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutService.swift
@@ -10,13 +10,47 @@ protocol ClipKittyShortcutServicing: Sendable {
     func copyLatestText() async throws -> String
 }
 
-enum ClipKittyShortcutRuntime {
+public enum ClipKittyShortcutRepositoryAvailability: Sendable {
+    case ready(ClipboardRepository)
+    case unavailable(String)
+}
+
+public enum ClipKittyShortcutRuntime {
+    private static let registry = ShortcutServiceRegistry()
+
     @TaskLocal static var serviceFactory: @Sendable () -> any ClipKittyShortcutServicing = {
-        ClipKittyShortcutService()
+        registry.makeService()
     }
 
     static func makeService() -> any ClipKittyShortcutServicing {
         serviceFactory()
+    }
+
+    public static func useRepositoryProvider(
+        _ provider: @escaping @MainActor @Sendable () async -> ClipKittyShortcutRepositoryAvailability
+    ) {
+        registry.install {
+            ClipKittyShortcutService(repositoryProvider: provider)
+        }
+    }
+}
+
+private final class ShortcutServiceRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var serviceFactory: @Sendable () -> any ClipKittyShortcutServicing = {
+        ClipKittyShortcutService()
+    }
+
+    func install(_ factory: @escaping @Sendable () -> any ClipKittyShortcutServicing) {
+        lock.lock()
+        defer { lock.unlock() }
+        serviceFactory = factory
+    }
+
+    func makeService() -> any ClipKittyShortcutServicing {
+        lock.lock()
+        defer { lock.unlock() }
+        return serviceFactory()
     }
 }
 
@@ -87,8 +121,13 @@ private enum ShortcutTextExtraction: Sendable {
     }
 }
 
+private enum ShortcutRepositorySource: Sendable {
+    case appRepository(@MainActor @Sendable () async -> ClipKittyShortcutRepositoryAvailability)
+    case databasePath(@Sendable () throws -> String)
+}
+
 final class ClipKittyShortcutService: ClipKittyShortcutServicing {
-    private let databasePathProvider: @Sendable () throws -> String
+    private let repositorySource: ShortcutRepositorySource
     private let pasteboardClient: ShortcutPasteboardClient
 
     init(
@@ -97,7 +136,15 @@ final class ClipKittyShortcutService: ClipKittyShortcutServicing {
         },
         pasteboardClient: ShortcutPasteboardClient = .live
     ) {
-        self.databasePathProvider = databasePathProvider
+        repositorySource = .databasePath(databasePathProvider)
+        self.pasteboardClient = pasteboardClient
+    }
+
+    init(
+        repositoryProvider: @escaping @MainActor @Sendable () async -> ClipKittyShortcutRepositoryAvailability,
+        pasteboardClient: ShortcutPasteboardClient = .live
+    ) {
+        repositorySource = .appRepository(repositoryProvider)
         self.pasteboardClient = pasteboardClient
     }
 
@@ -110,7 +157,7 @@ final class ClipKittyShortcutService: ClipKittyShortcutServicing {
             throw ClipKittyShortcutError.emptyText
         }
 
-        let repository = try makeRepository()
+        let repository = try await makeRepository()
         let result = await repository.saveText(
             text: text,
             sourceApp: "Shortcuts",
@@ -155,7 +202,7 @@ final class ClipKittyShortcutService: ClipKittyShortcutServicing {
         case let .text(text):
             return try await saveText(text)
         case let .image(data, thumbnail, isAnimated):
-            let repository = try makeRepository()
+            let repository = try await makeRepository()
             let result = await repository.saveImage(
                 imageData: data,
                 thumbnail: thumbnail,
@@ -168,7 +215,7 @@ final class ClipKittyShortcutService: ClipKittyShortcutServicing {
     }
 
     private func fetchText(query: String, limit: Int) async throws -> [String] {
-        let repository = try makeRepository()
+        let repository = try await makeRepository()
         let result = await repository.search(
             query: query,
             filter: .contentType(contentType: .text),
@@ -201,7 +248,23 @@ final class ClipKittyShortcutService: ClipKittyShortcutServicing {
         return values
     }
 
-    private func makeRepository() throws -> ClipboardRepository {
+    private func makeRepository() async throws -> ClipboardRepository {
+        switch repositorySource {
+        case let .appRepository(provider):
+            switch await provider() {
+            case let .ready(repository):
+                return repository
+            case let .unavailable(reason):
+                throw ClipKittyShortcutError.databaseOpenFailed(reason)
+            }
+        case let .databasePath(databasePathProvider):
+            return try makeStandaloneRepository(databasePathProvider: databasePathProvider)
+        }
+    }
+
+    private func makeStandaloneRepository(
+        databasePathProvider: @Sendable () throws -> String
+    ) throws -> ClipboardRepository {
         let dbPath: String
         do {
             dbPath = try databasePathProvider()

--- a/Sources/Shortcuts/ClipKittyShortcutService.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutService.swift
@@ -7,7 +7,6 @@ protocol ClipKittyShortcutServicing: Sendable {
     func saveCurrentClipboard() async throws -> ShortcutSavedClip
     func searchText(query: String, limit: Int) async throws -> [String]
     func fetchRecentText(limit: Int) async throws -> [String]
-    func copyLatestText() async throws -> String
 }
 
 public enum ClipKittyShortcutRepositoryAvailability: Sendable {
@@ -56,14 +55,10 @@ private final class ShortcutServiceRegistry: @unchecked Sendable {
 
 struct ShortcutPasteboardClient: Sendable {
     let read: @Sendable () async -> ShortcutPasteboardRead
-    let writeText: @Sendable (String) async -> Void
 
     static let live = ShortcutPasteboardClient(
         read: {
             await ShortcutPasteboard.read()
-        },
-        writeText: { text in
-            await ShortcutPasteboard.writeText(text)
         }
     )
 }
@@ -75,7 +70,6 @@ enum ClipKittyShortcutError: Equatable, LocalizedError, Sendable {
     case databasePathUnavailable(String)
     case databaseOpenFailed(String)
     case operationFailed(String)
-    case noTextClips
 
     var errorDescription: String? {
         switch self {
@@ -91,8 +85,6 @@ enum ClipKittyShortcutError: Equatable, LocalizedError, Sendable {
             return "Could not open ClipKitty's database: \(reason)"
         case let .operationFailed(reason):
             return reason
-        case .noTextClips:
-            return "ClipKitty does not have any text clips yet."
         }
     }
 }
@@ -100,11 +92,6 @@ enum ClipKittyShortcutError: Equatable, LocalizedError, Sendable {
 enum ShortcutSavedClip: Equatable, Sendable {
     case inserted(id: String)
     case duplicate
-}
-
-private enum ShortcutTextLookup: Sendable {
-    case found(String)
-    case notFound
 }
 
 private enum ShortcutTextExtraction: Sendable {
@@ -184,17 +171,6 @@ final class ClipKittyShortcutService: ClipKittyShortcutServicing {
 
     func fetchRecentText(limit: Int) async throws -> [String] {
         try await fetchText(query: "", limit: limit)
-    }
-
-    func copyLatestText() async throws -> String {
-        let values = try await fetchRecentText(limit: 1)
-        switch firstText(in: values) {
-        case let .found(value):
-            await pasteboardClient.writeText(value)
-            return value
-        case .notFound:
-            throw ClipKittyShortcutError.noTextClips
-        }
     }
 
     private func save(_ content: ShortcutSavableContent) async throws -> ShortcutSavedClip {
@@ -307,11 +283,6 @@ final class ClipKittyShortcutService: ClipKittyShortcutServicing {
         case let .failure(error):
             throw ClipKittyShortcutError.operationFailed(error.localizedDescription)
         }
-    }
-
-    private func firstText(in values: [String]) -> ShortcutTextLookup {
-        guard let first = values.first else { return .notFound }
-        return .found(first)
     }
 
     private static func clampLimit(_ limit: Int) -> Int {

--- a/Sources/Shortcuts/ClipKittyShortcutService.swift
+++ b/Sources/Shortcuts/ClipKittyShortcutService.swift
@@ -2,7 +2,39 @@ import ClipKittyRust
 import ClipKittyShared
 import Foundation
 
-enum ClipKittyShortcutError: LocalizedError, Sendable {
+protocol ClipKittyShortcutServicing: Sendable {
+    func saveText(_ text: String) async throws -> ShortcutSavedClip
+    func saveCurrentClipboard() async throws -> ShortcutSavedClip
+    func searchText(query: String, limit: Int) async throws -> [String]
+    func fetchRecentText(limit: Int) async throws -> [String]
+    func copyLatestText() async throws -> String
+}
+
+enum ClipKittyShortcutRuntime {
+    @TaskLocal static var serviceFactory: @Sendable () -> any ClipKittyShortcutServicing = {
+        ClipKittyShortcutService()
+    }
+
+    static func makeService() -> any ClipKittyShortcutServicing {
+        serviceFactory()
+    }
+}
+
+struct ShortcutPasteboardClient: Sendable {
+    let read: @Sendable () async -> ShortcutPasteboardRead
+    let writeText: @Sendable (String) async -> Void
+
+    static let live = ShortcutPasteboardClient(
+        read: {
+            await ShortcutPasteboard.read()
+        },
+        writeText: { text in
+            await ShortcutPasteboard.writeText(text)
+        }
+    )
+}
+
+enum ClipKittyShortcutError: Equatable, LocalizedError, Sendable {
     case emptyText
     case emptyClipboard
     case unsupportedClipboardContent(String)
@@ -55,15 +87,22 @@ private enum ShortcutTextExtraction: Sendable {
     }
 }
 
-final class ClipKittyShortcutService {
-    private let databasePathProvider: () throws -> String
+final class ClipKittyShortcutService: ClipKittyShortcutServicing {
+    private let databasePathProvider: @Sendable () throws -> String
+    private let pasteboardClient: ShortcutPasteboardClient
 
-    init(databasePathProvider: @escaping () throws -> String = ShortcutDatabasePath.resolve) {
+    init(
+        databasePathProvider: @escaping @Sendable () throws -> String = {
+            try ShortcutDatabasePath.resolve()
+        },
+        pasteboardClient: ShortcutPasteboardClient = .live
+    ) {
         self.databasePathProvider = databasePathProvider
+        self.pasteboardClient = pasteboardClient
     }
 
-    convenience init(databasePath: String) {
-        self.init(databasePathProvider: { databasePath })
+    convenience init(databasePath: String, pasteboardClient: ShortcutPasteboardClient = .live) {
+        self.init(databasePathProvider: { databasePath }, pasteboardClient: pasteboardClient)
     }
 
     func saveText(_ text: String) async throws -> ShortcutSavedClip {
@@ -81,7 +120,7 @@ final class ClipKittyShortcutService {
     }
 
     func saveCurrentClipboard() async throws -> ShortcutSavedClip {
-        let clipboardRead = await ShortcutPasteboard.read()
+        let clipboardRead = await pasteboardClient.read()
         switch clipboardRead {
         case let .content(content):
             return try await save(content)
@@ -104,7 +143,7 @@ final class ClipKittyShortcutService {
         let values = try await fetchRecentText(limit: 1)
         switch firstText(in: values) {
         case let .found(value):
-            await ShortcutPasteboard.writeText(value)
+            await pasteboardClient.writeText(value)
             return value
         case .notFound:
             throw ClipKittyShortcutError.noTextClips

--- a/Sources/iOSApp/App/AppContainer.swift
+++ b/Sources/iOSApp/App/AppContainer.swift
@@ -1,6 +1,7 @@
 import ClipKittyAppleServices
 import ClipKittyRust
 import ClipKittyShared
+import ClipKittyShortcuts
 import Foundation
 
 /// Owns all app-scoped services. Created once at launch.
@@ -110,6 +111,10 @@ final class AppContainer {
                 return "Could not open database: \(reason)"
             }
         }
+    }
+
+    func shortcutRepositoryAvailability() -> ClipKittyShortcutRepositoryAvailability {
+        .ready(repository)
     }
 
 }

--- a/Sources/iOSApp/ClipKittyiOSApp.swift
+++ b/Sources/iOSApp/ClipKittyiOSApp.swift
@@ -312,6 +312,9 @@ struct ClipKittyiOSApp: App {
         let customPath = ProcessInfo.processInfo.environment["CLIPKITTY_SCREENSHOT_DB"]
         switch AppContainer.bootstrap(databasePath: customPath) {
         case let .success(container):
+            ClipKittyShortcutRuntime.useRepositoryProvider {
+                container.shortcutRepositoryAvailability()
+            }
             let appState = AppState(container: container)
             #if ENABLE_ICLOUD_SYNC
                 let coordinator = iOSSyncCoordinator(

--- a/Sources/iOSApp/ClipKittyiOSApp.swift
+++ b/Sources/iOSApp/ClipKittyiOSApp.swift
@@ -1,6 +1,7 @@
 import ClipKittyAppleServices
 import ClipKittyRust
 import ClipKittyShared
+import ClipKittyShortcuts
 import SwiftUI
 
 // MARK: - App Launch State
@@ -253,6 +254,7 @@ struct ClipKittyiOSApp: App {
 
     init() {
         FontManager.registerFonts()
+        ClipKittyAppShortcuts.updateAppShortcutParameters()
     }
 
     var body: some Scene {

--- a/Sources/iOSApp/Resources/AppShortcuts.xcstrings
+++ b/Sources/iOSApp/Resources/AppShortcuts.xcstrings
@@ -1,0 +1,518 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Save text to ${applicationName}" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text in ${applicationName} speichern"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save text to ${applicationName}"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar texto en ${applicationName}"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer le texte dans ${applicationName}"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストを${applicationName}に保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트를 ${applicationName}에 저장"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvar texto no ${applicationName}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранить текст в ${applicationName}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将文本保存到 ${applicationName}"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將文字儲存到 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Add text to ${applicationName}" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text zu ${applicationName} hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add text to ${applicationName}"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar texto a ${applicationName}"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter du texte à ${applicationName}"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストを${applicationName}に追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트를 ${applicationName}에 추가"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar texto ao ${applicationName}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить текст в ${applicationName}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将文本添加到 ${applicationName}"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將文字加入 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Save clipboard to ${applicationName}" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischenablage in ${applicationName} speichern"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save clipboard to ${applicationName}"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar portapapeles en ${applicationName}"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer le presse-papiers dans ${applicationName}"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードを${applicationName}に保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드를 ${applicationName}에 저장"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvar área de transferência no ${applicationName}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранить буфер обмена в ${applicationName}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将剪贴板保存到 ${applicationName}"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將剪貼簿儲存到 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Add clipboard to ${applicationName}" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischenablage zu ${applicationName} hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add clipboard to ${applicationName}"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar portapapeles a ${applicationName}"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter le presse-papiers à ${applicationName}"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードを${applicationName}に追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드를 ${applicationName}에 추가"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar área de transferência ao ${applicationName}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить буфер обмена в ${applicationName}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将剪贴板添加到 ${applicationName}"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將剪貼簿加入 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Search ${applicationName}" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName} durchsuchen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search ${applicationName}"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar en ${applicationName}"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher dans ${applicationName}"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}を検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName} 검색"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar ${applicationName}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Искать в ${applicationName}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索 ${applicationName}"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋 ${applicationName}"
+          }
+        }
+      }
+    },
+    "Find text in ${applicationName}" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text in ${applicationName} finden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find text in ${applicationName}"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar texto en ${applicationName}"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trouver du texte dans ${applicationName}"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}内のテキストを検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}에서 텍스트 찾기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encontrar texto no ${applicationName}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Найти текст в ${applicationName}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 ${applicationName} 中查找文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 ${applicationName} 中尋找文字"
+          }
+        }
+      }
+    },
+    "Get recent text from ${applicationName}" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuellen Text aus ${applicationName} abrufen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get recent text from ${applicationName}"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener texto reciente de ${applicationName}"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtenir le texte récent de ${applicationName}"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}から最近のテキストを取得"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}에서 최근 텍스트 가져오기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obter texto recente do ${applicationName}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Получить недавний текст из ${applicationName}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 ${applicationName} 获取最近的文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 ${applicationName} 取得最近的文字"
+          }
+        }
+      }
+    },
+    "Get recent clips from ${applicationName}" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelle Clips aus ${applicationName} abrufen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get recent clips from ${applicationName}"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener clips recientes de ${applicationName}"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtenir les clips récents de ${applicationName}"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}から最近のクリップを取得"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "${applicationName}에서 최근 클립 가져오기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obter clipes recentes do ${applicationName}"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Получить недавние фрагменты из ${applicationName}"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 ${applicationName} 获取最近的剪辑"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 ${applicationName} 取得最近的片段"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/iOSApp/Resources/Localizable.xcstrings
+++ b/Sources/iOSApp/Resources/Localizable.xcstrings
@@ -3791,7 +3791,1095 @@
           }
         }
       }
-    }
+    },
+      "Save Text to ClipKitty" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Text in ClipKitty speichern"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Save Text to ClipKitty"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Guardar texto en ClipKitty"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Enregistrer le texte dans ClipKitty"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "テキストをClipKittyに保存"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "텍스트를 ClipKitty에 저장"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Salvar texto no ClipKitty"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Сохранить текст в ClipKitty"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "将文本保存到 ClipKitty"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "將文字儲存到 ClipKitty"
+                  }
+              }
+          }
+      },
+      "Save text into ClipKitty's clipboard history." : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Text im ClipKitty-Zwischenablageverlauf speichern."
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Save text into ClipKitty's clipboard history."
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Guarda texto en el historial del portapapeles de ClipKitty."
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Enregistrez le texte dans l’historique du presse-papiers de ClipKitty."
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "テキストをClipKittyのクリップボード履歴に保存します。"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "텍스트를 ClipKitty 클립보드 기록에 저장합니다."
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Salve texto no histórico da área de transferência do ClipKitty."
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Сохранить текст в истории буфера обмена ClipKitty."
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "将文本保存到 ClipKitty 的剪贴板历史记录中。"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "將文字儲存到 ClipKitty 的剪貼簿記錄中。"
+                  }
+              }
+          }
+      },
+      "Save Clipboard to ClipKitty" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Zwischenablage in ClipKitty speichern"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Save Clipboard to ClipKitty"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Guardar portapapeles en ClipKitty"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Enregistrer le presse-papiers dans ClipKitty"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "クリップボードをClipKittyに保存"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "클립보드를 ClipKitty에 저장"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Salvar área de transferência no ClipKitty"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Сохранить буфер обмена в ClipKitty"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "将剪贴板保存到 ClipKitty"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "將剪貼簿儲存到 ClipKitty"
+                  }
+              }
+          }
+      },
+      "Save the current text or image clipboard item into ClipKitty." : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Aktuellen Text- oder Bildinhalt der Zwischenablage in ClipKitty speichern."
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Save the current text or image clipboard item into ClipKitty."
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Guarda en ClipKitty el texto o la imagen actual del portapapeles."
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Enregistrez le texte ou l’image actuelle du presse-papiers dans ClipKitty."
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "現在のクリップボードのテキストまたは画像をClipKittyに保存します。"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "현재 클립보드의 텍스트 또는 이미지를 ClipKitty에 저장합니다."
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Salve no ClipKitty o texto ou a imagem atual da área de transferência."
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Сохранить текущий текст или изображение из буфера обмена в ClipKitty."
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "将当前剪贴板中的文本或图像保存到 ClipKitty。"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "將目前剪貼簿中的文字或影像儲存到 ClipKitty。"
+                  }
+              }
+          }
+      },
+      "Search ClipKitty Text" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKitty-Text durchsuchen"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Search ClipKitty Text"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Buscar texto en ClipKitty"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Rechercher du texte dans ClipKitty"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKittyのテキストを検索"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKitty 텍스트 검색"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Pesquisar texto no ClipKitty"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Искать текст в ClipKitty"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "搜索 ClipKitty 文本"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "搜尋 ClipKitty 文字"
+                  }
+              }
+          }
+      },
+      "Search ClipKitty's text clipboard history." : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Den Textverlauf der ClipKitty-Zwischenablage durchsuchen."
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Search ClipKitty's text clipboard history."
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Busca en el historial de texto del portapapeles de ClipKitty."
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Recherchez dans l’historique du presse-papiers texte de ClipKitty."
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKittyのテキストクリップボード履歴を検索します。"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKitty의 텍스트 클립보드 기록을 검색합니다."
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Pesquise no histórico de texto da área de transferência do ClipKitty."
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Искать в текстовой истории буфера обмена ClipKitty."
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "搜索 ClipKitty 的文本剪贴板历史记录。"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "搜尋 ClipKitty 的文字剪貼簿記錄。"
+                  }
+              }
+          }
+      },
+      "Get Recent ClipKitty Text" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Aktuellen ClipKitty-Text abrufen"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Get Recent ClipKitty Text"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Obtener texto reciente de ClipKitty"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Obtenir le texte récent de ClipKitty"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "最近のClipKittyテキストを取得"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "최근 ClipKitty 텍스트 가져오기"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Obter texto recente do ClipKitty"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Получить недавний текст ClipKitty"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "获取最近的 ClipKitty 文本"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "取得最近的 ClipKitty 文字"
+                  }
+              }
+          }
+      },
+      "Get recent text clips from ClipKitty." : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Aktuelle Textclips aus ClipKitty abrufen."
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Get recent text clips from ClipKitty."
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Obtén clips de texto recientes de ClipKitty."
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Obtenez les clips de texte récents de ClipKitty."
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKittyから最近のテキストクリップを取得します。"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKitty에서 최근 텍스트 클립을 가져옵니다."
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Obtenha clipes de texto recentes do ClipKitty."
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Получить недавние текстовые фрагменты из ClipKitty."
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "从 ClipKitty 获取最近的文本剪辑。"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "從 ClipKitty 取得最近的文字片段。"
+                  }
+              }
+          }
+      },
+      "Query" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Suchbegriff"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Query"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Consulta"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Requête"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "検索語句"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "쿼리"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Consulta"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Запрос"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "查询"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "查詢"
+                  }
+              }
+          }
+      },
+      "Maximum Results" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Maximale Ergebnisse"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Maximum Results"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Resultados máximos"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Nombre maximal de résultats"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "最大結果数"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "최대 결과 수"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Máximo de resultados"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Максимум результатов"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "最大结果数"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "最大結果數"
+                  }
+              }
+          }
+      },
+      "Save Text" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Text speichern"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Save Text"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Guardar texto"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Enregistrer le texte"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "テキストを保存"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "텍스트 저장"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Salvar texto"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Сохранить текст"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "保存文本"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "儲存文字"
+                  }
+              }
+          }
+      },
+      "Save Clipboard" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Zwischenablage speichern"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Save Clipboard"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Guardar portapapeles"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Enregistrer le presse-papiers"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "クリップボードを保存"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "클립보드 저장"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Salvar área de transferência"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Сохранить буфер обмена"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "保存剪贴板"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "儲存剪貼簿"
+                  }
+              }
+          }
+      },
+      "Search Text" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Text suchen"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Search Text"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Buscar texto"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Rechercher le texte"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "テキストを検索"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "텍스트 검색"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Pesquisar texto"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Искать текст"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "搜索文本"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "搜尋文字"
+                  }
+              }
+          }
+      },
+      "Recent Text" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Aktueller Text"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Recent Text"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Texto reciente"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Texte récent"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "最近のテキスト"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "최근 텍스트"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Texto recente"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Недавний текст"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "最近文本"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "最近文字"
+                  }
+              }
+          }
+      },
+      "Saved to ClipKitty." : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "In ClipKitty gespeichert."
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Saved to ClipKitty."
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Guardado en ClipKitty."
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Enregistré dans ClipKitty."
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKittyに保存しました。"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "ClipKitty에 저장됨."
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Salvo no ClipKitty."
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Сохранено в ClipKitty."
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "已保存到 ClipKitty。"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "已儲存到 ClipKitty。"
+                  }
+              }
+          }
+      },
+      "Already in ClipKitty." : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Bereits in ClipKitty."
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Already in ClipKitty."
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Ya está en ClipKitty."
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Déjà dans ClipKitty."
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "すでにClipKittyにあります。"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "이미 ClipKitty에 있습니다."
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Já está no ClipKitty."
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Уже в ClipKitty."
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "已在 ClipKitty 中。"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "已在 ClipKitty 中。"
+                  }
+              }
+          }
+      },
+      "Already in ClipKitty" : {
+          "localizations" : {
+              "de" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Bereits in ClipKitty"
+                  }
+              },
+              "en" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Already in ClipKitty"
+                  }
+              },
+              "es" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Ya está en ClipKitty"
+                  }
+              },
+              "fr" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Déjà dans ClipKitty"
+                  }
+              },
+              "ja" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "すでにClipKittyにあります"
+                  }
+              },
+              "ko" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "이미 ClipKitty에 있습니다"
+                  }
+              },
+              "pt-BR" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Já está no ClipKitty"
+                  }
+              },
+              "ru" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "Уже в ClipKitty"
+                  }
+              },
+              "zh-Hans" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "已在 ClipKitty 中"
+                  }
+              },
+              "zh-Hant" : {
+                  "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "已在 ClipKitty 中"
+                  }
+              }
+          }
+      }
   },
   "version" : "1.0"
 }

--- a/Sources/iOSSmokeTest/iOSSmokeTest.swift
+++ b/Sources/iOSSmokeTest/iOSSmokeTest.swift
@@ -11,6 +11,7 @@
 import ClipKittyAppleServices
 import ClipKittyRust
 import ClipKittyShared
+import ClipKittyShortcuts
 import SwiftUI
 
 @main

--- a/Tests/UnitTests/ClipKittyShortcutIntentTests.swift
+++ b/Tests/UnitTests/ClipKittyShortcutIntentTests.swift
@@ -1,0 +1,189 @@
+import AppIntents
+@testable import ClipKittyShortcuts
+import XCTest
+
+final class ClipKittyShortcutIntentTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clipkitty-shortcut-intents-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+        super.tearDown()
+    }
+
+    func testSaveTextIntentPersistsProvidedText() async throws {
+        let service = makeService()
+        let intent = SaveTextToClipKittyIntent()
+        intent.text = "saved through intent"
+
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        XCTAssertEqual(result.value, "saved through intent")
+        let recent = try await service.fetchRecentText(limit: 1)
+        XCTAssertEqual(recent, ["saved through intent"])
+    }
+
+    func testSaveTextIntentRejectsEmptyText() async {
+        let service = makeService()
+        let intent = SaveTextToClipKittyIntent()
+        intent.text = " \n\t "
+
+        await assertThrowsShortcutError(.emptyText) {
+            _ = try await withShortcutService(service) {
+                try await intent.perform()
+            }
+        }
+    }
+
+    func testSaveClipboardIntentPersistsReadableTextClipboard() async throws {
+        let service = makeService(pasteboardRead: .content(.text("clipboard through intent")))
+        let intent = SaveClipboardToClipKittyIntent()
+
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        XCTAssertFalse(result.value?.isEmpty ?? true)
+        let recent = try await service.fetchRecentText(limit: 1)
+        XCTAssertEqual(recent, ["clipboard through intent"])
+    }
+
+    func testSaveClipboardIntentReportsEmptyClipboard() async {
+        let service = makeService(pasteboardRead: .empty)
+        let intent = SaveClipboardToClipKittyIntent()
+
+        await assertThrowsShortcutError(.emptyClipboard) {
+            _ = try await withShortcutService(service) {
+                try await intent.perform()
+            }
+        }
+    }
+
+    func testSearchTextIntentReturnsMatchingValues() async throws {
+        let service = makeService()
+        _ = try await service.saveText("intent alpha")
+        _ = try await service.saveText("intent beta")
+        _ = try await service.saveText("outside query")
+
+        let intent = SearchClipKittyTextIntent()
+        intent.query = "intent"
+        intent.limit = 2
+
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        XCTAssertEqual(result.value?.count, 2)
+        XCTAssertTrue(result.value?.contains("intent alpha") ?? false)
+        XCTAssertTrue(result.value?.contains("intent beta") ?? false)
+    }
+
+    func testGetRecentTextIntentReturnsNewestText() async throws {
+        let service = makeService()
+        _ = try await service.saveText("older intent clip")
+        try await Task.sleep(nanoseconds: 10_000_000)
+        _ = try await service.saveText("newer intent clip")
+
+        let intent = GetRecentClipKittyTextIntent()
+        intent.limit = 1
+
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        XCTAssertEqual(result.value, ["newer intent clip"])
+    }
+
+    func testCopyLatestTextIntentReturnsAndWritesNewestText() async throws {
+        let recorder = RecordedPasteboard()
+        let service = makeService(pasteboardRecorder: recorder)
+        _ = try await service.saveText("older copy intent clip")
+        try await Task.sleep(nanoseconds: 10_000_000)
+        _ = try await service.saveText("newer copy intent clip")
+
+        let intent = CopyLatestClipKittyTextIntent()
+        let result = try await withShortcutService(service) {
+            try await intent.perform()
+        }
+
+        let writtenValues = await recorder.values()
+        XCTAssertEqual(result.value, "newer copy intent clip")
+        XCTAssertEqual(writtenValues, ["newer copy intent clip"])
+    }
+
+    func testCopyLatestTextIntentReportsEmptyDatabase() async {
+        let service = makeService()
+        let intent = CopyLatestClipKittyTextIntent()
+
+        await assertThrowsShortcutError(.noTextClips) {
+            _ = try await withShortcutService(service) {
+                try await intent.perform()
+            }
+        }
+    }
+
+    private func makeService(
+        pasteboardRead: ShortcutPasteboardRead = .empty,
+        pasteboardRecorder: RecordedPasteboard = RecordedPasteboard()
+    ) -> ClipKittyShortcutService {
+        ClipKittyShortcutService(
+            databasePath: dbPath(),
+            pasteboardClient: ShortcutPasteboardClient(
+                read: { pasteboardRead },
+                writeText: { text in
+                    await pasteboardRecorder.record(text)
+                }
+            )
+        )
+    }
+
+    private func withShortcutService<T>(
+        _ service: ClipKittyShortcutService,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        try await ClipKittyShortcutRuntime.$serviceFactory.withValue({ service }) {
+            try await operation()
+        }
+    }
+
+    private func assertThrowsShortcutError<T>(
+        _ expectedError: ClipKittyShortcutError,
+        operation: () async throws -> T
+    ) async {
+        do {
+            _ = try await operation()
+            XCTFail("Expected \(expectedError) to throw")
+        } catch let error as ClipKittyShortcutError {
+            XCTAssertEqual(error, expectedError)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    private func dbPath() -> String {
+        tempDir.appendingPathComponent("clipboard.sqlite").path
+    }
+}
+
+private actor RecordedPasteboard {
+    private var writtenValues: [String] = []
+
+    func record(_ value: String) {
+        writtenValues.append(value)
+    }
+
+    func values() -> [String] {
+        writtenValues
+    }
+}

--- a/Tests/UnitTests/ClipKittyShortcutIntentTests.swift
+++ b/Tests/UnitTests/ClipKittyShortcutIntentTests.swift
@@ -107,46 +107,13 @@ final class ClipKittyShortcutIntentTests: XCTestCase {
         XCTAssertEqual(result.value, ["newer intent clip"])
     }
 
-    func testCopyLatestTextIntentReturnsAndWritesNewestText() async throws {
-        let recorder = RecordedPasteboard()
-        let service = makeService(pasteboardRecorder: recorder)
-        _ = try await service.saveText("older copy intent clip")
-        try await Task.sleep(nanoseconds: 10_000_000)
-        _ = try await service.saveText("newer copy intent clip")
-
-        let intent = CopyLatestClipKittyTextIntent()
-        let result = try await withShortcutService(service) {
-            try await intent.perform()
-        }
-
-        requireStringValueWithDialog(result)
-        let writtenValues = await recorder.values()
-        XCTAssertEqual(result.value, "newer copy intent clip")
-        XCTAssertEqual(writtenValues, ["newer copy intent clip"])
-    }
-
-    func testCopyLatestTextIntentReportsEmptyDatabase() async {
-        let service = makeService()
-        let intent = CopyLatestClipKittyTextIntent()
-
-        await assertThrowsShortcutError(.noTextClips) {
-            _ = try await withShortcutService(service) {
-                try await intent.perform()
-            }
-        }
-    }
-
     private func makeService(
-        pasteboardRead: ShortcutPasteboardRead = .empty,
-        pasteboardRecorder: RecordedPasteboard = RecordedPasteboard()
+        pasteboardRead: ShortcutPasteboardRead = .empty
     ) -> ClipKittyShortcutService {
         ClipKittyShortcutService(
             databasePath: dbPath(),
             pasteboardClient: ShortcutPasteboardClient(
-                read: { pasteboardRead },
-                writeText: { text in
-                    await pasteboardRecorder.record(text)
-                }
+                read: { pasteboardRead }
             )
         )
     }
@@ -182,15 +149,3 @@ final class ClipKittyShortcutIntentTests: XCTestCase {
 private func requireStringValueWithDialog(
     _ result: some IntentResult & ReturnsValue<String> & ProvidesDialog
 ) {}
-
-private actor RecordedPasteboard {
-    private var writtenValues: [String] = []
-
-    func record(_ value: String) {
-        writtenValues.append(value)
-    }
-
-    func values() -> [String] {
-        writtenValues
-    }
-}

--- a/Tests/UnitTests/ClipKittyShortcutIntentTests.swift
+++ b/Tests/UnitTests/ClipKittyShortcutIntentTests.swift
@@ -29,6 +29,7 @@ final class ClipKittyShortcutIntentTests: XCTestCase {
             try await intent.perform()
         }
 
+        requireStringValueWithDialog(result)
         XCTAssertEqual(result.value, "saved through intent")
         let recent = try await service.fetchRecentText(limit: 1)
         XCTAssertEqual(recent, ["saved through intent"])
@@ -54,6 +55,7 @@ final class ClipKittyShortcutIntentTests: XCTestCase {
             try await intent.perform()
         }
 
+        requireStringValueWithDialog(result)
         XCTAssertFalse(result.value?.isEmpty ?? true)
         let recent = try await service.fetchRecentText(limit: 1)
         XCTAssertEqual(recent, ["clipboard through intent"])
@@ -117,6 +119,7 @@ final class ClipKittyShortcutIntentTests: XCTestCase {
             try await intent.perform()
         }
 
+        requireStringValueWithDialog(result)
         let writtenValues = await recorder.values()
         XCTAssertEqual(result.value, "newer copy intent clip")
         XCTAssertEqual(writtenValues, ["newer copy intent clip"])
@@ -175,6 +178,10 @@ final class ClipKittyShortcutIntentTests: XCTestCase {
         tempDir.appendingPathComponent("clipboard.sqlite").path
     }
 }
+
+private func requireStringValueWithDialog(
+    _ result: some IntentResult & ReturnsValue<String> & ProvidesDialog
+) {}
 
 private actor RecordedPasteboard {
     private var writtenValues: [String] = []

--- a/Tests/UnitTests/ClipKittyShortcutServiceTests.swift
+++ b/Tests/UnitTests/ClipKittyShortcutServiceTests.swift
@@ -1,3 +1,5 @@
+import ClipKittyRust
+import ClipKittyShared
 @testable import ClipKittyShortcuts
 import XCTest
 
@@ -70,6 +72,23 @@ final class ClipKittyShortcutServiceTests: XCTestCase {
 
         let values = try await service.searchText(query: "shortcut", limit: 2)
         XCTAssertEqual(values.count, 2)
+    }
+
+    func testUsesProvidedRepositoryInsteadOfOpeningSecondStore() async throws {
+        let rustStore = try ClipKittyRust.ClipboardStore(dbPath: dbPath())
+        let repository = ClipboardRepository(store: rustStore)
+        let service = ClipKittyShortcutService(repositoryProvider: {
+            .ready(repository)
+        })
+
+        _ = await repository.saveText(
+            text: "existing app repository",
+            sourceApp: "Test",
+            sourceAppBundleId: nil
+        )
+
+        let values = try await service.searchText(query: "existing", limit: 1)
+        XCTAssertEqual(values, ["existing app repository"])
     }
 
     private func dbPath() -> String {

--- a/Tests/UnitTests/ClipKittyShortcutServiceTests.swift
+++ b/Tests/UnitTests/ClipKittyShortcutServiceTests.swift
@@ -1,0 +1,78 @@
+@testable import ClipKittyShortcuts
+import XCTest
+
+final class ClipKittyShortcutServiceTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clipkitty-shortcuts-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+        super.tearDown()
+    }
+
+    func testSaveTextAndFetchRecentText() async throws {
+        let service = ClipKittyShortcutService(databasePath: dbPath())
+
+        let saved = try await service.saveText("hello from shortcuts")
+        switch saved {
+        case let .inserted(id):
+            XCTAssertFalse(id.isEmpty)
+        case .duplicate:
+            XCTFail("First save should insert a new clip")
+        }
+
+        let values = try await service.fetchRecentText(limit: 3)
+        XCTAssertEqual(values.first, "hello from shortcuts")
+    }
+
+    func testDuplicateSaveIsExplicitState() async throws {
+        let service = ClipKittyShortcutService(databasePath: dbPath())
+
+        _ = try await service.saveText("same clip")
+        let savedAgain = try await service.saveText("same clip")
+
+        switch savedAgain {
+        case .inserted:
+            XCTFail("Duplicate save should not report a new clip")
+        case .duplicate:
+            break
+        }
+    }
+
+    func testSaveTextRejectsEmptyInput() async {
+        let service = ClipKittyShortcutService(databasePath: dbPath())
+
+        do {
+            _ = try await service.saveText(" \n\t ")
+            XCTFail("Expected empty text to throw")
+        } catch ClipKittyShortcutError.emptyText {
+            return
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testSearchTextHonorsLimit() async throws {
+        let service = ClipKittyShortcutService(databasePath: dbPath())
+
+        _ = try await service.saveText("shortcut alpha")
+        _ = try await service.saveText("shortcut beta")
+        _ = try await service.saveText("shortcut gamma")
+
+        let values = try await service.searchText(query: "shortcut", limit: 2)
+        XCTAssertEqual(values.count, 2)
+    }
+
+    private func dbPath() -> String {
+        tempDir.appendingPathComponent("clipboard.sqlite").path
+    }
+}

--- a/tools/xtask/src/cmd/marketing.rs
+++ b/tools/xtask/src/cmd/marketing.rs
@@ -33,6 +33,7 @@ const SCREENSHOT_DB_FILE: &str = "/tmp/clipkitty_screenshot_db.txt";
 const IOS_SCREENSHOT_LOCALE_FILE: &str = "/tmp/clipkitty_ios_screenshot_locale.txt";
 const IOS_SCREENSHOT_DB_FILE: &str = "/tmp/clipkitty_ios_screenshot_db.txt";
 const IOS_SCREENSHOT_DEVICE_FILE: &str = "/tmp/clipkitty_ios_screenshot_device.txt";
+const SCREENSHOT_LOCALES_ENV: &str = "CLIPKITTY_SCREENSHOT_LOCALES";
 const VIDEO_RESULT_BUNDLE: &str = "/tmp/clipkitty_video_result.xcresult";
 const VIDEO_ATTACHMENTS_DIR: &str = "/tmp/xcresult-attachments";
 const VIDEO_BOUNDS_FILE: &str = "/tmp/clipkitty_window_bounds.txt";
@@ -96,6 +97,44 @@ impl MarketingLocale {
             Self::PtBr => "pt-BR",
             Self::Ru => "ru",
         }
+    }
+
+    fn parse(code: &str) -> Option<Self> {
+        match code {
+            "en" => Some(Self::En),
+            "es" => Some(Self::Es),
+            "zh-Hans" => Some(Self::ZhHans),
+            "zh-Hant" => Some(Self::ZhHant),
+            "ja" => Some(Self::Ja),
+            "ko" => Some(Self::Ko),
+            "fr" => Some(Self::Fr),
+            "de" => Some(Self::De),
+            "pt-BR" => Some(Self::PtBr),
+            "ru" => Some(Self::Ru),
+            _ => None,
+        }
+    }
+
+    fn selected_from_env() -> Result<Vec<Self>> {
+        let Ok(raw) = env::var(SCREENSHOT_LOCALES_ENV) else {
+            return Ok(Self::ALL.to_vec());
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Ok(Self::ALL.to_vec());
+        }
+
+        let mut locales = Vec::new();
+        for token in trimmed.split(',') {
+            let code = token.trim();
+            let Some(locale) = Self::parse(code) else {
+                return Err(anyhow!(
+                    "{SCREENSHOT_LOCALES_ENV} contains unsupported locale `{code}`"
+                ));
+            };
+            locales.push(locale);
+        }
+        Ok(locales)
     }
 }
 
@@ -263,7 +302,7 @@ fn run_screenshot_plan(
     }
     let temp_files = TempSelectionFiles::new(&temp_paths);
 
-    for locale in MarketingLocale::ALL {
+    for locale in MarketingLocale::selected_from_env()? {
         let locale_code = locale.as_code();
         reporter.info(&format!(
             "Capturing {:?} screenshots for {locale_code}...",
@@ -1200,9 +1239,54 @@ fn tool_exists(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::copy_base_database_without_images;
+    use super::{copy_base_database_without_images, MarketingLocale, SCREENSHOT_LOCALES_ENV};
     use camino::Utf8PathBuf;
     use rusqlite::{params, Connection};
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn selected_screenshot_locales_default_to_full_set() {
+        let _guard = env_lock().lock().expect("env lock");
+        std::env::remove_var(SCREENSHOT_LOCALES_ENV);
+
+        assert_eq!(
+            MarketingLocale::selected_from_env().expect("selected locales"),
+            MarketingLocale::ALL.to_vec()
+        );
+    }
+
+    #[test]
+    fn selected_screenshot_locales_parse_comma_list() {
+        let _guard = env_lock().lock().expect("env lock");
+        std::env::set_var(SCREENSHOT_LOCALES_ENV, "en, fr,pt-BR");
+
+        assert_eq!(
+            MarketingLocale::selected_from_env().expect("selected locales"),
+            vec![
+                MarketingLocale::En,
+                MarketingLocale::Fr,
+                MarketingLocale::PtBr
+            ]
+        );
+        std::env::remove_var(SCREENSHOT_LOCALES_ENV);
+    }
+
+    #[test]
+    fn selected_screenshot_locales_reject_unknown_locale() {
+        let _guard = env_lock().lock().expect("env lock");
+        std::env::set_var(SCREENSHOT_LOCALES_ENV, "en,it");
+
+        let error = MarketingLocale::selected_from_env().expect_err("unknown locale");
+        assert!(error
+            .to_string()
+            .contains("CLIPKITTY_SCREENSHOT_LOCALES contains unsupported locale `it`"));
+        std::env::remove_var(SCREENSHOT_LOCALES_ENV);
+    }
 
     #[test]
     fn copied_localized_database_drops_inherited_images() {

--- a/tools/xtask/src/cmd/marketing.rs
+++ b/tools/xtask/src/cmd/marketing.rs
@@ -368,6 +368,14 @@ fn run_screenshot_xcodebuild(
         .arg(plan.scheme)
         .arg("-destination")
         .arg(plan.destination)
+        .args([
+            "-destination-timeout",
+            "120",
+            "-test-timeouts-enabled",
+            "YES",
+            "-maximum-test-execution-time-allowance",
+            "300",
+        ])
         .arg("-derivedDataPath")
         .arg(repo.join(plan.derived_data).as_std_path())
         .arg("-only-testing")


### PR DESCRIPTION
## Summary
- add a cross-platform ClipKittyShortcuts App Intents target for macOS and iOS
- expose Shortcuts actions for saving text/clipboard content, searching, getting recent clips, and copying the latest text clip
- route App Intents through the already-open app repository so Shortcuts does not try to open a second Tantivy writer
- add intent-level and repository-lock regression tests

## Root Cause / Fix
Shortcuts initially opened a separate ClipboardStore for each intent invocation. When the app was already running, that could collide with the live Tantivy index writer and fail with `LockBusy`. The runtime now installs an app-scoped repository provider after bootstrap and the Shortcut service uses that repository when available, with the standalone database path kept as a fallback for tests and early-launch cases.

## Validation
- `tuist generate --no-open`
- focused shortcut tests: 13 passed
- macOS app Debug build passed
- ClipKittyShortcuts iOS simulator build passed with AppIntents metadata extraction
- ClipKittyShortcuts iOS device build passed with AppIntents metadata extraction

## Notes
The full iOS app build still requires generated iOS Rust artifacts (`Sources/ClipKittyRust/ios-simulator/libpurr.a`) in this worktree; without them it fails at link, after Swift compilation.