### PR TITLE
Improve App Store copy

### DIFF
--- a/distribution/metadata/en-US/description.txt
+++ b/distribution/metadata/en-US/description.txt
@@ -1,12 +1,12 @@
-ClipKitty remembers everything you copy, so you can find it again in seconds.
+ClipKitty keeps everything you copy within instant reach.
 
-Text, code, links, colors, images, files; all in one fast, searchable history.
+Simple enough for daily pastebacks, fast enough for long histories.
 
 UNLIMITED HISTORY
 No small cap. No short expiration. ClipKitty keeps your copied items for as long as you want them.
 
 SEARCH THAT FORGIVES TYPOS
-Type what you remember. ClipKitty finds the right item even when your query is incomplete or misspelled.
+Type what you remember. ClipKitty finds the right item as you type, even when your query is incomplete or misspelled.
 
 SEE BEFORE YOU PASTE
 Preview full text, code, images, and colors in place. No guessing from cut-off snippets.

--- a/distribution/metadata/en-US/promotional_text.txt
+++ b/distribution/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Every copy, remembered. Unlimited history, search that forgives typos, full previews, and optional iCloud sync. Private by default and open source.
+Unlimited clipboard history that stays fast and simple: instant typo-friendly search, full previews, optional iCloud sync, private by default and open source.


### PR DESCRIPTION
## What changed

Surgical English App Store metadata refresh only:

- Keeps the existing subtitle unchanged: `Never Lose What You Copied.`
- Tightens promotional text around the same feature set while foregrounding fast/simple positioning.
- Changes the description opener from `find it again in seconds` to an instant-recall promise.
- Replaces the repeated item-type list near the top with a concise simple/fast positioning line.
- Updates the search line to say results are found `as you type`.

## Why

This keeps the existing structure and most existing copy, while addressing the weaker wording and sharpening the fast-but-simple positioning. It also avoids repeating item types in both the opener and the preview section. The subtitle is intentionally left alone.

## Validation

- Checked App Store-style field lengths:
  - name: 28/30
  - subtitle: 27/30
  - promotional text: 158/170
  - description: 937/4000
  - keywords: 88/100
- Ran `git diff --check`.

Diff scope: 2 files, 4 insertions, 4 deletions.