### PR TITLE
Allow 3-character infix matches and narrow short-query fuzzy recall

### DIFF
--- a/purr/src/indexer.rs
+++ b/purr/src/indexer.rs
@@ -1397,10 +1397,10 @@ impl Indexer {
 
         let mut clauses = Vec::new();
         for (i, word) in words.iter().enumerate() {
-            let len = word.chars().count();
-            if len < 3 {
+            if !crate::ranking::query_allows_fuzzy_recall(word) {
                 continue;
             }
+            let len = word.chars().count();
             let distance = crate::ranking::max_edit_distance(len);
             if distance == 0 {
                 continue;

--- a/purr/src/ranking.rs
+++ b/purr/src/ranking.rs
@@ -1697,11 +1697,17 @@ mod tests {
             dwm("tha", "the", PrefixMatch::Disabled),
             WordMatchKind::None
         );
-        // Numeric and mixed tokens do not use fuzzy matching.
+        // Numeric tokens do not use fuzzy matching.
         assert_eq!(
             dwm("997", "979", PrefixMatch::Disabled),
             WordMatchKind::None
         );
+        // Alphanumeric identifier-ish tokens can still use fuzzy matching.
+        assert_eq!(
+            dwm("sha256", "sha265", PrefixMatch::Disabled),
+            WordMatchKind::Fuzzy(1)
+        );
+        // But short alphanumeric substitutions are still too noisy.
         assert_eq!(
             dwm("a1c", "abc", PrefixMatch::Disabled),
             WordMatchKind::None

--- a/purr/src/ranking.rs
+++ b/purr/src/ranking.rs
@@ -24,8 +24,9 @@ pub use self::matching::edit_distance_bounded;
 #[cfg(test)]
 use self::matching::subsequence_match;
 pub(crate) use self::matching::{
-    does_word_match, does_word_match_fast, does_word_match_fast_raw, max_edit_distance,
-    prefix_match_for_query_word, PrefixMatch, WordMatchKind,
+    classify_fuzzy_edit, does_word_match, does_word_match_fast, does_word_match_fast_raw,
+    max_edit_distance, prefix_match_for_query_word, query_allows_fuzzy_recall, FuzzyEditKind,
+    PrefixMatch, WordMatchKind,
 };
 use self::policy::{compute_quality_detail, compute_quality_tier, compute_recency_bucket};
 #[cfg(test)]
@@ -1210,100 +1211,13 @@ fn classify_fast_match_candidate(
 }
 
 fn classify_fuzzy_typo(query: &str, target: &str, dist: u8) -> TypoClass {
-    if is_adjacent_transposition(query, target) {
-        return TypoClass::CommonTransposition;
+    match classify_fuzzy_edit(query, target, dist) {
+        FuzzyEditKind::CommonTransposition => TypoClass::CommonTransposition,
+        FuzzyEditKind::RepeatedCharEdit => TypoClass::RepeatedCharEdit,
+        FuzzyEditKind::InsertionOrDeletion => TypoClass::InsertionOrDeletion,
+        FuzzyEditKind::Substitution => TypoClass::Substitution,
+        FuzzyEditKind::MultiEdit => TypoClass::MultiEdit,
     }
-
-    if dist == 1 {
-        if let Some(is_repeated_char) = classify_single_insert_delete(query, target) {
-            return if is_repeated_char {
-                TypoClass::RepeatedCharEdit
-            } else {
-                TypoClass::InsertionOrDeletion
-            };
-        }
-        return TypoClass::Substitution;
-    }
-
-    TypoClass::MultiEdit
-}
-
-fn is_adjacent_transposition(a: &str, b: &str) -> bool {
-    let a_chars: Vec<char> = a.chars().collect();
-    let b_chars: Vec<char> = b.chars().collect();
-    if a_chars.len() != b_chars.len() || a_chars.len() < 2 {
-        return false;
-    }
-
-    let mut first_diff = None;
-    for i in 0..a_chars.len() {
-        if a_chars[i] != b_chars[i] {
-            first_diff = Some(i);
-            break;
-        }
-    }
-    let Some(i) = first_diff else {
-        return false;
-    };
-    if i + 1 >= a_chars.len() {
-        return false;
-    }
-
-    if a_chars[i] != b_chars[i + 1] || a_chars[i + 1] != b_chars[i] {
-        return false;
-    }
-
-    for j in (i + 2)..a_chars.len() {
-        if a_chars[j] != b_chars[j] {
-            return false;
-        }
-    }
-
-    true
-}
-
-/// Returns whether the edit is a repeated-char insertion/deletion when the strings
-/// differ by a single inserted or deleted character. `None` means it is not a
-/// one-char insertion/deletion relationship.
-fn classify_single_insert_delete(shorter: &str, longer: &str) -> Option<bool> {
-    let shorter_chars: Vec<char> = shorter.chars().collect();
-    let longer_chars: Vec<char> = longer.chars().collect();
-    let (shorter_chars, longer_chars) = if shorter_chars.len() <= longer_chars.len() {
-        (shorter_chars, longer_chars)
-    } else {
-        (longer_chars, shorter_chars)
-    };
-
-    if longer_chars.len() != shorter_chars.len() + 1 {
-        return None;
-    }
-
-    let mut si = 0usize;
-    let mut li = 0usize;
-    let mut skipped_idx = None;
-
-    while si < shorter_chars.len() && li < longer_chars.len() {
-        if shorter_chars[si] == longer_chars[li] {
-            si += 1;
-            li += 1;
-            continue;
-        }
-
-        if skipped_idx.is_some() {
-            return None;
-        }
-
-        skipped_idx = Some(li);
-        li += 1;
-    }
-
-    let skipped_idx = skipped_idx.unwrap_or(longer_chars.len() - 1);
-    let skipped_char = longer_chars[skipped_idx];
-    let repeated_prev = skipped_idx > 0 && longer_chars[skipped_idx - 1] == skipped_char;
-    let repeated_next =
-        skipped_idx + 1 < longer_chars.len() && longer_chars[skipped_idx + 1] == skipped_char;
-
-    Some(repeated_prev || repeated_next)
 }
 
 /// Compute proximity score from matched word positions.
@@ -1743,6 +1657,10 @@ mod tests {
             dwm("auth", "oauth", PrefixMatch::Disabled),
             WordMatchKind::InfixSubstring
         );
+        assert_eq!(
+            dwm("997", "911396997", PrefixMatch::Disabled),
+            WordMatchKind::InfixSubstring
+        );
     }
 
     #[test]
@@ -1770,10 +1688,23 @@ mod tests {
             dwm("adn", "and", PrefixMatch::Disabled),
             WordMatchKind::Fuzzy(1)
         );
-        // Short word substitution — also matches (same edit distance)
+        assert_eq!(
+            dwm("tst", "test", PrefixMatch::Disabled),
+            WordMatchKind::Fuzzy(1)
+        );
+        // Short substitutions are too noisy to treat as common typos.
         assert_eq!(
             dwm("tha", "the", PrefixMatch::Disabled),
-            WordMatchKind::Fuzzy(1)
+            WordMatchKind::None
+        );
+        // Numeric and mixed tokens do not use fuzzy matching.
+        assert_eq!(
+            dwm("997", "979", PrefixMatch::Disabled),
+            WordMatchKind::None
+        );
+        assert_eq!(
+            dwm("a1c", "abc", PrefixMatch::Disabled),
+            WordMatchKind::None
         );
         // First-char mismatch penalty prevents false positives
         assert_eq!(

--- a/purr/src/ranking/matching.rs
+++ b/purr/src/ranking/matching.rs
@@ -223,7 +223,7 @@ pub(super) fn subsequence_match(query: &str, target: &str) -> Option<u8> {
 
 /// Maximum allowed edit distance based on word length (Milli's graduation).
 /// 1-2 char words get no fuzzy tolerance. 3+ chars can enter the fuzzy path,
-/// with additional short-token and alphabetic-word gating below.
+/// with additional short-token and wordlike-token gating below.
 pub(crate) fn max_edit_distance(word_len: usize) -> u8 {
     if word_len < 3 {
         0
@@ -235,11 +235,15 @@ pub(crate) fn max_edit_distance(word_len: usize) -> u8 {
 }
 
 pub(crate) fn query_allows_fuzzy_recall(query_word: &str) -> bool {
-    query_word.chars().count() >= 3 && query_word.chars().all(char::is_alphabetic)
+    query_word.chars().count() >= 3 && is_wordlike_fuzzy_token(query_word)
 }
 
 fn token_allows_fuzzy_match(token: &str) -> bool {
-    token.chars().all(char::is_alphabetic)
+    is_wordlike_fuzzy_token(token)
+}
+
+fn is_wordlike_fuzzy_token(token: &str) -> bool {
+    token.chars().any(char::is_alphabetic) && token.chars().all(char::is_alphanumeric)
 }
 
 fn allows_short_fuzzy_match(query: &str, target: &str, dist: u8) -> bool {

--- a/purr/src/ranking/matching.rs
+++ b/purr/src/ranking/matching.rs
@@ -14,6 +14,15 @@ pub(crate) enum WordMatchKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FuzzyEditKind {
+    CommonTransposition,
+    RepeatedCharEdit,
+    InsertionOrDeletion,
+    Substitution,
+    MultiEdit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PrefixMatch {
     Disabled,
     Enabled { min_query_chars: usize },
@@ -55,7 +64,7 @@ pub(crate) fn does_word_match(
     let max_typo = max_edit_distance(qw_lower.chars().count());
     if max_typo > 0 {
         if let Some(dist) = edit_distance_bounded(qw_lower, dw_lower, max_typo) {
-            if dist > 0 {
+            if dist > 0 && allows_fuzzy_match(qw_lower, dw_lower, dist) {
                 return WordMatchKind::Fuzzy(dist);
             }
         }
@@ -129,7 +138,7 @@ fn matches_prefix(qw_lower: &str, dw_lower: &str, prefix_match: PrefixMatch) -> 
 fn classify_contained_match(qw_lower: &str, dw_lower: &str, dw_raw: &str) -> Option<WordMatchKind> {
     let query_chars: Vec<char> = qw_lower.chars().collect();
     let doc_lower_chars: Vec<char> = dw_lower.chars().collect();
-    if query_chars.len() < 4 || query_chars.len() >= doc_lower_chars.len() {
+    if query_chars.len() < 3 || query_chars.len() >= doc_lower_chars.len() {
         return None;
     }
 
@@ -213,7 +222,8 @@ pub(super) fn subsequence_match(query: &str, target: &str) -> Option<u8> {
 }
 
 /// Maximum allowed edit distance based on word length (Milli's graduation).
-/// 1-2 char words get no fuzzy tolerance. 3+ chars allow 1 edit (catches transpositions).
+/// 1-2 char words get no fuzzy tolerance. 3+ chars can enter the fuzzy path,
+/// with additional short-token and alphabetic-word gating below.
 pub(crate) fn max_edit_distance(word_len: usize) -> u8 {
     if word_len < 3 {
         0
@@ -222,6 +232,132 @@ pub(crate) fn max_edit_distance(word_len: usize) -> u8 {
     } else {
         2
     }
+}
+
+pub(crate) fn query_allows_fuzzy_recall(query_word: &str) -> bool {
+    query_word.chars().count() >= 3 && query_word.chars().all(char::is_alphabetic)
+}
+
+fn token_allows_fuzzy_match(token: &str) -> bool {
+    token.chars().all(char::is_alphabetic)
+}
+
+fn allows_short_fuzzy_match(query: &str, target: &str, dist: u8) -> bool {
+    match classify_fuzzy_edit(query, target, dist) {
+        FuzzyEditKind::CommonTransposition
+        | FuzzyEditKind::RepeatedCharEdit
+        | FuzzyEditKind::InsertionOrDeletion => true,
+        FuzzyEditKind::Substitution | FuzzyEditKind::MultiEdit => false,
+    }
+}
+
+fn allows_fuzzy_match(query: &str, target: &str, dist: u8) -> bool {
+    if !query_allows_fuzzy_recall(query) || !token_allows_fuzzy_match(target) {
+        return false;
+    }
+
+    if query.chars().count() == 3 {
+        return allows_short_fuzzy_match(query, target, dist);
+    }
+
+    true
+}
+
+pub(crate) fn classify_fuzzy_edit(query: &str, target: &str, dist: u8) -> FuzzyEditKind {
+    if is_adjacent_transposition(query, target) {
+        return FuzzyEditKind::CommonTransposition;
+    }
+
+    if dist == 1 {
+        if let Some(is_repeated_char) = classify_single_insert_delete(query, target) {
+            return if is_repeated_char {
+                FuzzyEditKind::RepeatedCharEdit
+            } else {
+                FuzzyEditKind::InsertionOrDeletion
+            };
+        }
+        return FuzzyEditKind::Substitution;
+    }
+
+    FuzzyEditKind::MultiEdit
+}
+
+fn is_adjacent_transposition(a: &str, b: &str) -> bool {
+    let a_chars: Vec<char> = a.chars().collect();
+    let b_chars: Vec<char> = b.chars().collect();
+    if a_chars.len() != b_chars.len() || a_chars.len() < 2 {
+        return false;
+    }
+
+    let mut first_diff = None;
+    for i in 0..a_chars.len() {
+        if a_chars[i] != b_chars[i] {
+            first_diff = Some(i);
+            break;
+        }
+    }
+    let Some(i) = first_diff else {
+        return false;
+    };
+    if i + 1 >= a_chars.len() {
+        return false;
+    }
+
+    if a_chars[i] != b_chars[i + 1] || a_chars[i + 1] != b_chars[i] {
+        return false;
+    }
+
+    for j in (i + 2)..a_chars.len() {
+        if a_chars[j] != b_chars[j] {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Returns whether the edit is a repeated-char insertion/deletion when the strings
+/// differ by a single inserted or deleted character. `None` means it is not a
+/// one-char insertion/deletion relationship.
+fn classify_single_insert_delete(shorter: &str, longer: &str) -> Option<bool> {
+    let shorter_chars: Vec<char> = shorter.chars().collect();
+    let longer_chars: Vec<char> = longer.chars().collect();
+    let (shorter_chars, longer_chars) = if shorter_chars.len() <= longer_chars.len() {
+        (shorter_chars, longer_chars)
+    } else {
+        (longer_chars, shorter_chars)
+    };
+
+    if longer_chars.len() != shorter_chars.len() + 1 {
+        return None;
+    }
+
+    let mut si = 0usize;
+    let mut li = 0usize;
+    let mut skipped_idx = None;
+
+    while si < shorter_chars.len() && li < longer_chars.len() {
+        if shorter_chars[si] == longer_chars[li] {
+            si += 1;
+            li += 1;
+            continue;
+        }
+
+        if skipped_idx.is_some() {
+            return None;
+        }
+
+        skipped_idx = Some(li);
+        li += 1;
+    }
+
+    let skipped_idx = skipped_idx.unwrap_or(longer_chars.len() - 1);
+    let skipped_char = longer_chars[skipped_idx];
+    let repeated_prev = skipped_idx > 0 && longer_chars[skipped_idx - 1] == skipped_char;
+    let repeated_next =
+        skipped_idx + 1 < longer_chars.len() && longer_chars[skipped_idx + 1] == skipped_char;
+
+    Some(repeated_prev || repeated_next)
 }
 
 /// Damerau-Levenshtein edit distance (optimal string alignment) with threshold pruning.

--- a/purr/tests/preview_video_search.rs
+++ b/purr/tests/preview_video_search.rs
@@ -189,12 +189,30 @@ async fn ranking_word_start_beats_mid_word() {
 
     let contents = search_contents(&store, "url").await;
 
-    // "url" exact/prefix-matches "urlParser", and fuzzy-matches "curl" (edit distance 1).
-    // urlParser should rank first (exact > fuzzy).
+    // "url" exact/prefix-matches "urlParser", and infix-matches "curl".
+    // urlParser should rank first (prefix > infix).
     assert!(!contents.is_empty(), "Should find urlParser");
     assert!(
         contents[0].contains("urlParser"),
         "Word-start 'urlParser' should rank first, got: {:?}",
+        contents
+    );
+}
+
+#[tokio::test]
+async fn ranking_three_char_infix_beats_short_numeric_noise() {
+    let (store, _temp) = create_ranking_test_store(vec![
+        "911396997",             // exact 3-char infix, oldest
+        "99% 370mg",             // formerly a noisy short numeric fuzzy candidate
+        "1,979 1,936 9,999,999", // formerly another noisy numeric candidate
+    ]);
+
+    let contents = search_contents(&store, "997").await;
+
+    assert!(!contents.is_empty(), "Should find the exact numeric infix");
+    assert!(
+        contents[0].contains("911396997"),
+        "Exact 3-char infix should rank first, got: {:?}",
         contents
     );
 }


### PR DESCRIPTION
## Summary
- Allow 3-character contained matches so queries like `997` can match `911396997` as a real infix.
- Restrict fuzzy recall to alphabetic query tokens and keep 3-character fuzzy limited to common typo shapes like transposition, insertion/deletion, and repeated-character edits.
- Add regression coverage for the numeric infix case and tighten existing ranking expectations.

## Testing
- `cargo test -p purr --lib`
- Targeted search/ranking tests for the new `997` regression and nearby typo cases
- Full `cargo test -p purr` was also exercised, with two pre-existing sync compaction failures still unrelated to this change