### PR TITLE
Fix iOS crash during sync startup and browser state updates

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -424,7 +424,7 @@ enum IOSBuildVariant: CaseIterable {
 // MARK: - Shared Scheme Components
 
 /// Rust pre-build action shared across all macOS app schemes.
-/// Detects purr/ changes via git tree hash and rebuilds bindings when needed.
+/// Detects Rust bridge input changes and rebuilds bindings when needed.
 ///
 /// When CLIPKITTY_SKIP_RUST_PREBUILD=1 is set, the script is a no-op: this is
 /// the contract with the Nix flake, which supplies Rust bridge artifacts into
@@ -436,11 +436,24 @@ if [ "${CLIPKITTY_SKIP_RUST_PREBUILD:-0}" = "1" ]; then
     exit 0
 fi
 
-# Use git tree hash to detect purr/ changes (fast, handles branches/rebases)
+# Hash the actual Rust bridge inputs, including uncommitted edits. Using only
+# HEAD:purr can leave Xcode linked against a stale libpurr.a during local test
+# runs, and purr-sync changes matter because the app builds purr with sync on.
 cd "$PROJECT_DIR"
 MARKER=".make/rust-tree-hash"
 LIB="Sources/ClipKittyRust/libpurr.a"
-CURRENT_HASH=$(git rev-parse HEAD:purr 2>/dev/null || echo "unknown")
+HASH_INPUTS="Cargo.toml Cargo.lock purr purr-sync"
+CURRENT_HASH=$(
+    {
+        git ls-files -s -- $HASH_INPUTS
+        git diff --binary -- $HASH_INPUTS
+        git diff --cached --binary -- $HASH_INPUTS
+        git ls-files --others --exclude-standard -- $HASH_INPUTS | while IFS= read -r path; do
+            printf 'untracked %s\\n' "$path"
+            git hash-object "$path"
+        done
+    } | shasum -a 256 | awk '{print $1}'
+)
 STORED_HASH=$(cat "$MARKER" 2>/dev/null || echo "none")
 
 if [ -f "$LIB" ] && [ "$CURRENT_HASH" = "$STORED_HASH" ]; then

--- a/Sources/AppleServices/SyncEngine.swift
+++ b/Sources/AppleServices/SyncEngine.swift
@@ -273,6 +273,7 @@
         public func stop() {
             coordinatorTask?.cancel()
             coordinatorTask = nil
+            signalWake()
             removeAccountChangeObserver()
             engineState = .idle(maintenanceState())
             logger.info("SyncEngine stopped")

--- a/Sources/AppleServices/SyncEngine.swift
+++ b/Sources/AppleServices/SyncEngine.swift
@@ -10,6 +10,7 @@
         public var events: [CKRecord]
         public var snapshots: [CKRecord]
         public var newToken: CKServerChangeToken?
+        public var moreComing: Bool
         public var tokenExpired: Bool
         public var fetchError: Error?
 
@@ -17,12 +18,14 @@
             events: [CKRecord] = [],
             snapshots: [CKRecord] = [],
             newToken: CKServerChangeToken? = nil,
+            moreComing: Bool = false,
             tokenExpired: Bool = false,
             fetchError: Error? = nil
         ) {
             self.events = events
             self.snapshots = snapshots
             self.newToken = newToken
+            self.moreComing = moreComing
             self.tokenExpired = tokenExpired
             self.fetchError = fetchError
         }
@@ -73,10 +76,6 @@
             savePolicy: CKModifyRecordsOperation.RecordSavePolicy
         ) async -> SyncRecordSaveResult
         func deleteRecords(_ recordIDs: [CKRecord.ID]) async -> SyncRecordDeleteResult
-        func fetchAllRecords(
-            ofType recordType: String,
-            in zoneID: CKRecordZone.ID
-        ) async throws -> [CKRecord]
     }
 
     /// Orchestrates iCloud sync via CloudKit using the Rust event-sourced core.
@@ -193,6 +192,12 @@
         private struct MaintenanceState {
             var lastCompactionDate: Date?
             var lastCloudCleanupDate: Date?
+        }
+
+        private struct FullResyncCloudRecords {
+            var events: [CKRecord]
+            var snapshots: [CKRecord]
+            var finalChangeToken: CKServerChangeToken?
         }
 
         // MARK: - Init
@@ -1372,6 +1377,7 @@
                 containerIdentifier: String
             )
             case unresolvedFullResyncTailEvents(count: UInt64)
+            case incompleteFullResyncMissingContinuationToken
 
             var errorDescription: String? {
                 switch self {
@@ -1385,37 +1391,69 @@
                     Full iCloud resync left \(count) event(s) waiting for missing history. \
                     Sync will retry instead of claiming success.
                     """
+                case .incompleteFullResyncMissingContinuationToken:
+                    return """
+                    Full iCloud resync received a paginated CloudKit response without a \
+                    continuation token. Sync will retry instead of claiming success.
+                    """
                 }
             }
         }
 
-        private func fetchAllCloudRecords(ofType recordType: String) async throws -> [CKRecord] {
-            do {
-                return try await cloud.fetchAllRecords(
-                    ofType: recordType,
-                    in: recordZone.zoneID
-                )
-            } catch {
-                if Self.isMissingRecordTypeError(error, recordType: recordType) {
-                    throw SyncEngineSchemaError.missingCloudKitRecordType(
-                        recordType: recordType,
-                        containerIdentifier: Self.cloudKitContainerIdentifier
-                    )
+        private func fetchAllCloudRecordsForFullResync() async throws -> FullResyncCloudRecords {
+            var allEvents: [CKRecord] = []
+            var allSnapshots: [CKRecord] = []
+            var changeToken: CKServerChangeToken?
+            var finalChangeToken: CKServerChangeToken?
+
+            repeat {
+                let changes = await cloud.fetchZoneChanges(in: recordZone.zoneID, since: changeToken)
+                if changes.tokenExpired {
+                    throw CKError(.changeTokenExpired)
                 }
-                throw error
+                if let fetchError = changes.fetchError {
+                    throw fetchError
+                }
+
+                allEvents.append(contentsOf: changes.events)
+                allSnapshots.append(contentsOf: changes.snapshots)
+                finalChangeToken = changes.newToken
+
+                guard changes.moreComing else {
+                    break
+                }
+                guard let nextToken = changes.newToken else {
+                    throw SyncEngineSchemaError.incompleteFullResyncMissingContinuationToken
+                }
+                changeToken = nextToken
+            } while true
+
+            return FullResyncCloudRecords(
+                events: allEvents,
+                snapshots: allSnapshots,
+                finalChangeToken: finalChangeToken
+            )
+        }
+
+        private func updateZoneChangeTokenAfterFullResync(_ changeToken: CKServerChangeToken?) throws {
+            if let changeToken {
+                let tokenData = try NSKeyedArchiver.archivedData(
+                    withRootObject: changeToken,
+                    requiringSecureCoding: true
+                )
+                try store.updateZoneChangeToken(deviceId: deviceId, token: tokenData)
+            } else {
+                try store.updateZoneChangeToken(deviceId: deviceId, token: nil)
             }
         }
 
         private func performFullResync() async throws {
             logger.info("Starting full resync")
-            // 1. Fetch all snapshots (checkpoints) from CloudKit.
-            let allSnapshots = try await fetchAllCloudRecords(ofType: Self.itemSnapshotRecordType)
+            // 1. Fetch the complete custom-zone change feed from CloudKit.
+            let cloudRecords = try await fetchAllCloudRecordsForFullResync()
 
-            // 2. Fetch all events (tail) from CloudKit.
-            let allEvents = try await fetchAllCloudRecords(ofType: Self.itemEventRecordType)
-
-            // 3. Convert to FFI records.
-            let snapshotRecords = try allSnapshots.map { record in
+            // 2. Convert to FFI records.
+            let snapshotRecords = try cloudRecords.snapshots.map { record in
                 try SyncSnapshotRecord(
                     itemId: record.recordID.recordName,
                     snapshotRevision: UInt64(record["snapshotRevision"] as? Int64 ?? 0),
@@ -1425,7 +1463,7 @@
                 )
             }
 
-            let eventRecords: [SyncEventRecord] = try allEvents.map { record in
+            let eventRecords: [SyncEventRecord] = try cloudRecords.events.map { record in
                 try SyncEventRecord(
                     eventId: record.recordID.recordName,
                     itemId: record["itemId"] as? String ?? "",
@@ -1437,7 +1475,7 @@
                 )
             }
 
-            // 4. Pass BOTH checkpoints and tail events to Rust.
+            // 3. Pass BOTH checkpoints and tail events to Rust.
             let result = try store.fullResyncWithTail(
                 snapshotRecords: snapshotRecords,
                 tailEventRecords: eventRecords
@@ -1457,14 +1495,15 @@
                 )
             }
 
-            // 5. Rebuild Tantivy index.
+            // 4. Rebuild Tantivy index.
             try store.rebuildIndex()
             try store.clearIndexDirtyFlag()
 
-            // 6. Clear token (start fresh).
-            try store.updateZoneChangeToken(deviceId: deviceId, token: nil)
+            // 5. Save the fresh zone token from the full feed so the next cycle
+            // resumes incrementally instead of replaying the whole zone again.
+            try updateZoneChangeTokenAfterFullResync(cloudRecords.finalChangeToken)
 
-            // 7. Notify UI.
+            // 6. Notify UI.
             onContentChanged?()
         }
     }
@@ -1530,8 +1569,9 @@
 
                 operation.recordZoneFetchResultBlock = { _, fetchResult in
                     switch fetchResult {
-                    case let .success((token, _, _)):
+                    case let .success((token, _, moreComing)):
                         result.newToken = token
+                        result.moreComing = moreComing
                     case let .failure(error):
                         let nsError = error as NSError
                         if nsError.code == CKError.changeTokenExpired.rawValue {
@@ -1624,48 +1664,6 @@
                 }
 
                 self.database.add(operation)
-            }
-        }
-
-        func fetchAllRecords(
-            ofType recordType: String,
-            in zoneID: CKRecordZone.ID
-        ) async throws -> [CKRecord] {
-            var records: [CKRecord] = []
-            var cursor: CKQueryOperation.Cursor?
-
-            let query = CKQuery(recordType: recordType, predicate: NSPredicate(value: true))
-            let (results, queryCursor) = try await database.records(
-                matching: query,
-                inZoneWith: zoneID,
-                resultsLimit: CKQueryOperation.maximumResults
-            )
-            try collectQueryResults(results, into: &records)
-            cursor = queryCursor
-
-            while let activeCursor = cursor {
-                let (moreResults, nextCursor) = try await database.records(
-                    continuingMatchFrom: activeCursor,
-                    resultsLimit: CKQueryOperation.maximumResults
-                )
-                try collectQueryResults(moreResults, into: &records)
-                cursor = nextCursor
-            }
-
-            return records
-        }
-
-        private func collectQueryResults(
-            _ results: [(CKRecord.ID, Result<CKRecord, Error>)],
-            into records: inout [CKRecord]
-        ) throws {
-            for (_, result) in results {
-                switch result {
-                case let .success(record):
-                    records.append(record)
-                case let .failure(error):
-                    throw error
-                }
             }
         }
     }

--- a/Sources/Shared/BrowserViewModel.swift
+++ b/Sources/Shared/BrowserViewModel.swift
@@ -203,32 +203,9 @@ public final class BrowserViewModel {
     }
 
     public func handleDisplayReset(initialSearchQuery: String, contentRevision: Int = 0) {
-        searchExecution.cancel()
-        previewTask?.cancel()
-        previewTask = nil
-        #if ENABLE_LINK_PREVIEWS
-            metadataTask?.cancel()
-            metadataTask = nil
-        #endif
-        matchedExcerptTasks.values.forEach { $0.cancel() }
-        matchedExcerptTasks.removeAll()
-        pendingMatchedExcerptItemIds.removeAll()
-        prefetchTask?.cancel()
-        prefetchTask = nil
-        previewSpinnerTask?.cancel()
-        previewSpinnerTask = nil
-        pendingDeleteTask?.cancel()
-        pendingDeleteTask = nil
-        pendingTagSettleTask?.cancel()
-        pendingTagSettleTask = nil
-        queryGeneration += 1
-        previewGeneration += 1
-        #if ENABLE_LINK_PREVIEWS
-            metadataGeneration += 1
-        #endif
+        cancelInFlightWork()
         latestKnownContentRevision = contentRevision
         lastLoadedContentRevision = nil
-        hidePreviewSpinner()
         hasUserNavigated = false
         prefetchCache.removeAll()
         previewPayloadsByItemId.removeAll()
@@ -243,6 +220,15 @@ public final class BrowserViewModel {
         // instead of flashing the empty state while the new results are loading.
         hasAppliedInitialSearch = false
         startInitialSearch(initialSearchQuery: initialSearchQuery, targetContentRevision: contentRevision)
+    }
+
+    public func prepareForSuspension() {
+        cancelInFlightWork()
+        dismissSnackbarNotification()
+        overlayState = .none
+        mutationState = .idle
+        editSession = .inactive
+        hasUserNavigated = false
     }
 
     public func handleContentRevisionChange(_ contentRevision: Int, isPanelVisible: Bool) {
@@ -669,6 +655,33 @@ public final class BrowserViewModel {
             return
         }
         submitSearch(request: contentState.request, targetContentRevision: latestKnownContentRevision)
+    }
+
+    private func cancelInFlightWork() {
+        searchExecution.cancel()
+        previewTask?.cancel()
+        previewTask = nil
+        #if ENABLE_LINK_PREVIEWS
+            metadataTask?.cancel()
+            metadataTask = nil
+        #endif
+        matchedExcerptTasks.values.forEach { $0.cancel() }
+        matchedExcerptTasks.removeAll()
+        pendingMatchedExcerptItemIds.removeAll()
+        prefetchTask?.cancel()
+        prefetchTask = nil
+        previewSpinnerTask?.cancel()
+        previewSpinnerTask = nil
+        pendingDeleteTask?.cancel()
+        pendingDeleteTask = nil
+        pendingTagSettleTask?.cancel()
+        pendingTagSettleTask = nil
+        queryGeneration += 1
+        previewGeneration += 1
+        #if ENABLE_LINK_PREVIEWS
+            metadataGeneration += 1
+        #endif
+        hidePreviewSpinner()
     }
 
     private func startInitialSearch(initialSearchQuery: String, targetContentRevision: Int) {

--- a/Sources/iOSApp/App/AppContainer.swift
+++ b/Sources/iOSApp/App/AppContainer.swift
@@ -4,7 +4,7 @@ import ClipKittyShared
 import ClipKittyShortcuts
 import Foundation
 
-/// Owns all app-scoped services. Created once at launch.
+/// Owns all app-scoped services for the current foreground session.
 @MainActor
 @Observable
 final class AppContainer {
@@ -115,6 +115,10 @@ final class AppContainer {
 
     func shortcutRepositoryAvailability() -> ClipKittyShortcutRepositoryAvailability {
         .ready(repository)
+    }
+
+    func prepareForSuspension() {
+        store.prepareForSuspend()
     }
 
 }

--- a/Sources/iOSApp/ClipKittyiOSApp.swift
+++ b/Sources/iOSApp/ClipKittyiOSApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 enum AppLaunchState {
     case launching
     case ready(AppContainer, AppState)
+    case suspended
     case failed(String)
 }
 
@@ -72,12 +73,11 @@ final class AppState {
         withAnimation(.bouncy) {
             toast = ToastState(message: message, action: action)
         }
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(message.duration))
-            if toast.message == message {
-                withAnimation(.bouncy) {
-                    toast = .init()
-                }
+            guard let self, self.toast.message == message else { return }
+            withAnimation(.bouncy) {
+                self.toast = .init()
             }
         }
     }
@@ -91,6 +91,11 @@ final class AppState {
         let added = await processPendingShareItems()
         if added > 0 { refreshFeed() }
         await autoAddFromClipboard()
+    }
+
+    func prepareForSuspension() {
+        viewModel.prepareForSuspension()
+        toast = .init()
     }
 
     func processPendingShareItems() async -> Int {
@@ -260,17 +265,28 @@ struct ClipKittyiOSApp: App {
 
     var body: some Scene {
         WindowGroup {
-            switch launchState {
-            case .launching:
-                ProgressView("Loading ClipKitty...")
-                    .onAppear { performBootstrap() }
+            content
+                .onChange(of: scenePhase) { _, newPhase in
+                    handleScenePhaseChange(newPhase)
+                }
+        }
+    }
 
-            case let .ready(container, appState):
-                rootView(container: container, appState: appState)
+    @ViewBuilder
+    private var content: some View {
+        switch launchState {
+        case .launching:
+            ProgressView("Loading ClipKitty...")
+                .onAppear { performBootstrap() }
 
-            case let .failed(message):
-                bootstrapFailureView(message: message)
-            }
+        case let .ready(container, appState):
+            rootView(container: container, appState: appState)
+
+        case .suspended:
+            ProgressView("Loading ClipKitty...")
+
+        case let .failed(message):
+            bootstrapFailureView(message: message)
         }
     }
 
@@ -288,19 +304,11 @@ struct ClipKittyiOSApp: App {
             .task {
                 await appState.ingestPendingAndClipboard()
             }
-            .onChange(of: scenePhase) { _, newPhase in
-                if newPhase == .active {
-                    Task { await appState.ingestPendingAndClipboard() }
-                }
-            }
 
         #if ENABLE_ICLOUD_SYNC
             if let coordinator = syncCoordinator {
                 base
                     .environment(coordinator)
-                    .onChange(of: scenePhase) { _, newPhase in
-                        coordinator.handleScenePhaseChange(newPhase)
-                    }
             } else {
                 base
             }
@@ -313,8 +321,11 @@ struct ClipKittyiOSApp: App {
         let customPath = ProcessInfo.processInfo.environment["CLIPKITTY_SCREENSHOT_DB"]
         switch AppContainer.bootstrap(databasePath: customPath) {
         case let .success(container):
-            ClipKittyShortcutRuntime.useRepositoryProvider {
-                container.shortcutRepositoryAvailability()
+            ClipKittyShortcutRuntime.useRepositoryProvider { [weak container] in
+                guard let container else {
+                    return .unavailable("ClipKitty is suspended.")
+                }
+                return container.shortcutRepositoryAvailability()
             }
             let appState = AppState(container: container)
             #if ENABLE_ICLOUD_SYNC
@@ -336,6 +347,55 @@ struct ClipKittyiOSApp: App {
         case let .failure(error):
             launchState = .failed(error.localizedDescription)
         }
+    }
+
+    private func handleScenePhaseChange(_ phase: ScenePhase) {
+        switch phase {
+        case .active:
+            handleForegroundActivation()
+        case .inactive:
+            #if ENABLE_ICLOUD_SYNC
+                syncCoordinator?.handleScenePhaseChange(.inactive)
+            #endif
+        case .background:
+            prepareForSuspension()
+        @unknown default:
+            break
+        }
+    }
+
+    private func handleForegroundActivation() {
+        switch launchState {
+        case .suspended:
+            performBootstrap()
+        case let .ready(_, appState):
+            #if ENABLE_ICLOUD_SYNC
+                syncCoordinator?.handleScenePhaseChange(.active)
+            #endif
+            Task {
+                await appState.ingestPendingAndClipboard()
+            }
+        case .launching, .failed:
+            break
+        }
+    }
+
+    private func prepareForSuspension() {
+        #if ENABLE_ICLOUD_SYNC
+            syncCoordinator?.handleScenePhaseChange(.background)
+            syncCoordinator = nil
+        #endif
+
+        guard case let .ready(container, appState) = launchState else {
+            if case .launching = launchState {
+                launchState = .suspended
+            }
+            return
+        }
+
+        appState.prepareForSuspension()
+        container.prepareForSuspension()
+        launchState = .suspended
     }
 
     private func bootstrapFailureView(message: String) -> some View {

--- a/Tests/UnitTests/BrowserViewModelTests.swift
+++ b/Tests/UnitTests/BrowserViewModelTests.swift
@@ -44,6 +44,34 @@ final class BrowserViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedItemId, "2")
     }
 
+    func testPrepareForSuspensionCancelsSearchWithoutStartingReplacement() async {
+        let client = MockBrowserStoreClient()
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {}
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        XCTAssertEqual(client.startedSearchRequests.count, 1)
+
+        viewModel.prepareForSuspension()
+        await flushMainActor()
+
+        client.resumeSearch(with: BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "late")],
+            firstPreviewPayload: nil,
+            totalCount: 1
+        ))
+        await flushMainActor()
+
+        XCTAssertTrue(viewModel.itemIds.isEmpty)
+        XCTAssertEqual(client.startedSearchRequests.count, 1)
+    }
+
     func testStalePreviewCompletionDoesNotOverwriteNewerSelection() async {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(

--- a/Tests/UnitTests/SyncEngineTests.swift
+++ b/Tests/UnitTests/SyncEngineTests.swift
@@ -385,6 +385,42 @@ final class SyncEngineTests: XCTestCase {
         XCTAssertEqual(transport.zoneChangeRequestHadToken, [false, false])
     }
 
+    func testCoordinatorFullResyncPreservesLocalItemWithoutDeleteProof() async throws {
+        let store = try makeStore()
+        let defaults = makeDefaults()
+        let transport = FakeCloudTransport()
+        let deviceId = "survivor-device"
+        let localId = try store.saveText(
+            text: "local survivor",
+            sourceApp: nil,
+            sourceAppBundleId: nil
+        )
+
+        var expiredResult = SyncZoneChangeResult()
+        expiredResult.tokenExpired = true
+        transport.zoneChangeResults = [expiredResult, SyncZoneChangeResult()]
+
+        let engine = makeEngine(
+            store: store,
+            transport: transport,
+            defaults: defaults,
+            deviceId: deviceId
+        )
+
+        await engine.runCoordinatorCycle()
+
+        assertSynced(engine.status)
+        let items = try store.fetchByIds(itemIds: [localId])
+        XCTAssertEqual(items.count, 1)
+        guard case let .text(value) = items[0].content else {
+            return XCTFail("Expected text item to survive full resync")
+        }
+        XCTAssertEqual(value, "local survivor")
+        XCTAssertTrue(try store.pendingLocalEvents().isEmpty)
+        XCTAssertEqual(try store.pendingSnapshotRecords().map(\.itemId), [localId])
+        XCTAssertEqual(transport.zoneChangeRequestHadToken, [false, false])
+    }
+
     func testCoordinatorFailsOnUnreadableCloudAsset() async throws {
         let store = try makeStore()
         let defaults = makeDefaults()

--- a/Tests/UnitTests/SyncEngineTests.swift
+++ b/Tests/UnitTests/SyncEngineTests.swift
@@ -47,7 +47,6 @@ final class SyncEngineTests: XCTestCase {
         var saveSubscriptionHandler: ((CKDatabaseSubscription) throws -> Void)?
         var saveRecordsHandler: (([CKRecord], CKModifyRecordsOperation.RecordSavePolicy) -> SyncRecordSaveResult)?
         var deleteRecordsHandler: (([CKRecord.ID]) -> SyncRecordDeleteResult)?
-        var fetchAllRecordsHandler: ((String, CKRecordZone.ID) throws -> [CKRecord])?
         var onSaveSubscription: (() -> Void)?
 
         private(set) var ensureZoneAttempts = 0
@@ -55,7 +54,7 @@ final class SyncEngineTests: XCTestCase {
         private(set) var subscriptionSaveAttempts = 0
         private(set) var savedSubscriptionIDs: [String] = []
         private(set) var savePolicies: [CKModifyRecordsOperation.RecordSavePolicy] = []
-        private(set) var queriedRecordTypes: [String] = []
+        private(set) var zoneChangeRequestHadToken: [Bool] = []
 
         func accountStatus() async throws -> CKAccountStatus {
             try accountStatusResult.get()
@@ -76,8 +75,9 @@ final class SyncEngineTests: XCTestCase {
 
         func fetchZoneChanges(
             in _: CKRecordZone.ID,
-            since _: CKServerChangeToken?
+            since changeToken: CKServerChangeToken?
         ) async -> SyncZoneChangeResult {
+            zoneChangeRequestHadToken.append(changeToken != nil)
             if zoneChangeResults.isEmpty {
                 return SyncZoneChangeResult()
             }
@@ -96,14 +96,6 @@ final class SyncEngineTests: XCTestCase {
         func deleteRecords(_ recordIDs: [CKRecord.ID]) async -> SyncRecordDeleteResult {
             deleteRecordsHandler?(recordIDs)
                 ?? SyncRecordDeleteResult(deletedRecordIDs: recordIDs)
-        }
-
-        func fetchAllRecords(
-            ofType recordType: String,
-            in zoneID: CKRecordZone.ID
-        ) async throws -> [CKRecord] {
-            queriedRecordTypes.append(recordType)
-            return try fetchAllRecordsHandler?(recordType, zoneID) ?? []
         }
     }
 
@@ -390,7 +382,7 @@ final class SyncEngineTests: XCTestCase {
         await engine.runCoordinatorCycle()
 
         assertSynced(engine.status)
-        XCTAssertEqual(transport.queriedRecordTypes, ["ItemSnapshot", "ItemEvent"])
+        XCTAssertEqual(transport.zoneChangeRequestHadToken, [false, false])
     }
 
     func testCoordinatorFailsOnUnreadableCloudAsset() async throws {
@@ -682,31 +674,22 @@ final class SyncEngineTests: XCTestCase {
         let strippedAggregate = try bundleBase64Fields(from: sourceSnapshot.aggregateData)
         defer { try? FileManager.default.removeItem(at: strippedAggregate.assetURL) }
 
-        transport.fetchAllRecordsHandler = { recordType, zoneID in
-            switch recordType {
-            case "ItemSnapshot":
-                let record = CKRecord(
-                    recordType: "ItemSnapshot",
-                    recordID: CKRecord.ID(recordName: sourceSnapshot.itemId, zoneID: zoneID)
-                )
-                record["snapshotRevision"] = Int64(sourceSnapshot.snapshotRevision) as CKRecordValue
-                record["schemaVersion"] = Int64(sourceSnapshot.schemaVersion) as CKRecordValue
-                record["coversThroughEvent"] = sourceSnapshot.coversThroughEvent as CKRecordValue?
-                record["aggregateData"] = strippedAggregate.strippedJSON as CKRecordValue
-                record["blobBundleAsset"] = CKAsset(fileURL: strippedAggregate.assetURL)
-                return [record]
+        let zoneID = CKRecordZone(zoneName: "ClipKittySync").zoneID
+        let record = CKRecord(
+            recordType: "ItemSnapshot",
+            recordID: CKRecord.ID(recordName: sourceSnapshot.itemId, zoneID: zoneID)
+        )
+        record["snapshotRevision"] = Int64(sourceSnapshot.snapshotRevision) as CKRecordValue
+        record["schemaVersion"] = Int64(sourceSnapshot.schemaVersion) as CKRecordValue
+        record["coversThroughEvent"] = sourceSnapshot.coversThroughEvent as CKRecordValue?
+        record["aggregateData"] = strippedAggregate.strippedJSON as CKRecordValue
+        record["blobBundleAsset"] = CKAsset(fileURL: strippedAggregate.assetURL)
 
-            case "ItemEvent":
-                return []
-
-            default:
-                return []
-            }
-        }
-
-        var result = SyncZoneChangeResult()
-        result.tokenExpired = true
-        transport.zoneChangeResults = [result]
+        var expiredResult = SyncZoneChangeResult()
+        expiredResult.tokenExpired = true
+        var fullResyncResult = SyncZoneChangeResult()
+        fullResyncResult.snapshots = [record]
+        transport.zoneChangeResults = [expiredResult, fullResyncResult]
 
         let engine = makeEngine(
             store: targetStore,

--- a/purr-sync/src/types.rs
+++ b/purr-sync/src/types.rs
@@ -300,8 +300,8 @@ pub const COMPACTION_AGE_THRESHOLD_SECS: i64 = 7 * 24 * 3600;
 /// Tombstone age (seconds) after which stale events trigger compaction.
 pub const TOMBSTONE_COMPACTION_AGE_SECS: i64 = 30 * 24 * 3600;
 
-/// Retention: keep tombstone snapshots for 90 days.
-pub const TOMBSTONE_SNAPSHOT_RETENTION_SECS: i64 = 90 * 24 * 3600;
+/// Retention: keep tombstone snapshots for 2 years.
+pub const TOMBSTONE_SNAPSHOT_RETENTION_SECS: i64 = 2 * 365 * 24 * 3600;
 /// Retention: keep compacted raw events for 30 days after snapshot coverage.
 pub const COMPACTED_EVENT_RETENTION_SECS: i64 = 30 * 24 * 3600;
 

--- a/purr/src/database.rs
+++ b/purr/src/database.rs
@@ -274,6 +274,16 @@ impl Database {
         &self.pool
     }
 
+    /// Best-effort checkpoint before iOS suspends the process.
+    ///
+    /// The app closes the store immediately after this; the checkpoint just
+    /// shortens any remaining WAL work while the connections are still alive.
+    pub fn checkpoint_for_suspend(&self) -> DatabaseResult<()> {
+        let conn = self.get_conn()?;
+        conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE);")?;
+        Ok(())
+    }
+
     /// Set up the database schema (normalized: items + child tables)
     fn setup_schema(&self) -> DatabaseResult<()> {
         let conn = self.get_conn()?;

--- a/purr/src/store.rs
+++ b/purr/src/store.rs
@@ -251,6 +251,14 @@ impl ClipboardStore {
         self.rebuild_index_contents()
     }
 
+    pub fn prepare_for_suspend(&self) {
+        if let Some(token) = self.active_search_token.lock().take() {
+            token.cancel();
+        }
+        let _ = self.indexer.commit();
+        let _ = self.db.checkpoint_for_suspend();
+    }
+
     pub fn start_search(
         &self,
         query: String,

--- a/purr/src/store.rs
+++ b/purr/src/store.rs
@@ -8,7 +8,7 @@ use crate::interface::{
     SearchOutcome, SearchResult, StoreBootstrapPlan,
 };
 #[cfg(feature = "sync")]
-use crate::sync_bridge::{RealSyncEmitter, SyncEmitter};
+use crate::sync_bridge::{snapshot_from_stored_item_with_bookmark, RealSyncEmitter, SyncEmitter};
 use crate::{match_presentation, save_service, search_service};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
@@ -775,6 +775,68 @@ impl ClipboardStore {
             fallback_local_item_id,
         )
     }
+
+    fn local_snapshots_for_full_resync(
+        &self,
+    ) -> Result<Vec<purr_sync::snapshot::ItemSnapshot>, ClipKittyError> {
+        use purr_sync::snapshot::ItemSnapshot;
+        use purr_sync::store::SyncStore;
+        use purr_sync::types::{ItemAggregate, LiveItemState, VersionVector, SYNC_SCHEMA_VERSION};
+
+        let items = self.db.fetch_all_items()?;
+        let item_ids: Vec<String> = items.iter().map(|item| item.item_id.clone()).collect();
+        let tags_by_item_id = self.db.get_tags_for_item_ids(&item_ids)?;
+        let sync = SyncStore::new(self.db.pool());
+
+        items
+            .into_iter()
+            .map(|item| {
+                let item_id = item.item_id.clone();
+                let existing_snapshot = sync.fetch_snapshot(&item_id)?;
+                let is_bookmarked = tags_by_item_id
+                    .get(&item_id)
+                    .map(|tags| tags.contains(&ItemTag::Bookmark))
+                    .unwrap_or(false);
+
+                let mut versions = match existing_snapshot
+                    .as_ref()
+                    .map(|snapshot| &snapshot.aggregate)
+                {
+                    Some(ItemAggregate::Live(live)) => live.versions,
+                    Some(ItemAggregate::Tombstoned(_)) | None => VersionVector {
+                        content: 1,
+                        bookmark: if is_bookmarked { 1 } else { 0 },
+                        existence: 1,
+                        touch: 1,
+                        metadata: 1,
+                    },
+                };
+                if is_bookmarked && versions.bookmark == 0 {
+                    versions.bookmark = 1;
+                }
+
+                let aggregate = ItemAggregate::Live(LiveItemState {
+                    snapshot: snapshot_from_stored_item_with_bookmark(&item, is_bookmarked),
+                    versions,
+                });
+                let snapshot = ItemSnapshot {
+                    item_id: item_id.clone(),
+                    snapshot_revision: existing_snapshot
+                        .as_ref()
+                        .map(|snapshot| snapshot.snapshot_revision.max(1))
+                        .unwrap_or(1),
+                    schema_version: SYNC_SCHEMA_VERSION,
+                    covers_through_event: existing_snapshot
+                        .and_then(|snapshot| snapshot.covers_through_event),
+                    aggregate,
+                    uploaded: false,
+                    uploaded_at: None,
+                };
+
+                Ok(snapshot)
+            })
+            .collect()
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -894,7 +956,7 @@ impl ClipboardStore {
                 record.schema_version,
                 record.covers_through_event.clone(),
                 &record.aggregate_data,
-                false,
+                true,
                 None,
             )
             .map_err(|e| ClipKittyError::InvalidInput(e))?;
@@ -1053,7 +1115,7 @@ impl ClipboardStore {
             record.schema_version,
             record.covers_through_event,
             &record.aggregate_data,
-            false,
+            true,
             None,
         )
         .map_err(|e| ClipKittyError::InvalidInput(e))?;
@@ -1084,44 +1146,14 @@ impl ClipboardStore {
     }
 
     /// Perform a full resync from the provided snapshots.
-    /// Clears all sync state, rebuilds from snapshots, and materializes
-    /// live items into the local items table + Tantivy index.
+    /// Reconciles CloudKit's explicit live/tombstoned states with local items.
     pub fn full_resync(
         &self,
         snapshot_records: Vec<crate::interface::SyncSnapshotRecord>,
     ) -> Result<u64, ClipKittyError> {
-        use purr_sync::replay;
-        use purr_sync::snapshot::ItemSnapshot;
-
-        let snapshots: Vec<ItemSnapshot> = snapshot_records
-            .into_iter()
-            .map(|r| {
-                ItemSnapshot::from_stored(
-                    r.item_id,
-                    r.snapshot_revision,
-                    r.schema_version,
-                    r.covers_through_event,
-                    &r.aggregate_data,
-                    false,
-                    None,
-                )
-                .map_err(|e| ClipKittyError::InvalidInput(e))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let applied = replay::full_resync_from_snapshots(self.db.pool(), &snapshots)?;
-
-        self.db.clear_all()?;
-        self.indexer.clear()?;
-
-        // Materialize all snapshots into the read model.
-        for snapshot in &snapshots {
-            let _ =
-                self.materialize_aggregate(&snapshot.item_id, &snapshot.aggregate, true, None)?;
-        }
-        let _ = self.indexer.commit();
-
-        Ok(applied as u64)
+        Ok(self
+            .full_resync_with_tail(snapshot_records, Vec::new())?
+            .checkpoints_applied)
     }
 
     /// Perform a full resync from checkpoints and tail events.
@@ -1137,8 +1169,11 @@ impl ClipboardStore {
         use purr_sync::replay;
         use purr_sync::snapshot::ItemSnapshot;
         use purr_sync::store::SyncStore;
+        use std::collections::HashSet;
 
-        let snapshots: Vec<ItemSnapshot> = snapshot_records
+        let local_snapshots_before_resync = self.local_snapshots_for_full_resync()?;
+
+        let remote_snapshots: Vec<ItemSnapshot> = snapshot_records
             .into_iter()
             .map(|r| {
                 ItemSnapshot::from_stored(
@@ -1147,12 +1182,30 @@ impl ClipboardStore {
                     r.schema_version,
                     r.covers_through_event,
                     &r.aggregate_data,
-                    false,
+                    true,
                     None,
                 )
                 .map_err(|e| ClipKittyError::InvalidInput(e))
             })
             .collect::<Result<Vec<_>, _>>()?;
+        let remote_item_ids: HashSet<String> = remote_snapshots
+            .iter()
+            .map(|snapshot| snapshot.item_id.clone())
+            .collect();
+        let mut local_base_snapshots: Vec<ItemSnapshot> = local_snapshots_before_resync
+            .into_iter()
+            .filter(|snapshot| !remote_item_ids.contains(&snapshot.item_id))
+            .map(|mut snapshot| {
+                // Local bases are not CloudKit checkpoints. They exist so tail
+                // events with explicit item IDs can apply, while plain absence
+                // from CloudKit still cannot delete local data.
+                snapshot.covers_through_event = None;
+                snapshot
+            })
+            .collect();
+        let local_base_count = local_base_snapshots.len();
+        let mut resync_snapshots = remote_snapshots;
+        resync_snapshots.append(&mut local_base_snapshots);
 
         let tail_events: Vec<ItemEvent> = tail_event_records
             .into_iter()
@@ -1170,12 +1223,11 @@ impl ClipboardStore {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let result = replay::full_resync(self.db.pool(), &snapshots, &tail_events)?;
+        let mut result = replay::full_resync(self.db.pool(), &resync_snapshots, &tail_events)?;
+        result.checkpoints_applied = result.checkpoints_applied.saturating_sub(local_base_count);
 
-        self.db.clear_all()?;
-        self.indexer.clear()?;
-
-        // Materialize all live snapshots into the read model.
+        // CloudKit only deletes local data via explicit tombstone snapshots/events.
+        // Absence from the full feed means "missing remote proof", not "deleted".
         let sync = SyncStore::new(self.db.pool());
         let all_snapshots = sync.fetch_all_snapshots()?;
         for snapshot in &all_snapshots {

--- a/purr/src/sync_bridge.rs
+++ b/purr/src/sync_bridge.rs
@@ -26,6 +26,15 @@ use r2d2_sqlite::SqliteConnectionManager;
 
 /// Build an ItemSnapshotData from a StoredItem for sync transport.
 pub(crate) fn snapshot_from_stored_item(item: &StoredItem) -> ItemSnapshotData {
+    snapshot_from_stored_item_with_bookmark(item, false)
+}
+
+/// Build an ItemSnapshotData from a StoredItem, carrying bookmark state when the
+/// caller is reconstructing a full local aggregate rather than an insert event.
+pub(crate) fn snapshot_from_stored_item_with_bookmark(
+    item: &StoredItem,
+    is_bookmarked: bool,
+) -> ItemSnapshotData {
     let type_specific = match &item.content {
         ClipboardContent::Text { value } => TypeSpecificData::Text {
             value: value.clone(),
@@ -88,7 +97,7 @@ pub(crate) fn snapshot_from_stored_item(item: &StoredItem) -> ItemSnapshotData {
         source_app: item.source_app.clone(),
         source_app_bundle_id: item.source_app_bundle_id.clone(),
         timestamp_unix: item.timestamp_unix,
-        is_bookmarked: false,
+        is_bookmarked,
         thumbnail_base64: item.thumbnail.as_ref().map(|d| base64_encode(d)),
         color_rgba: item.color_rgba,
         type_specific,

--- a/purr/tests/sync_tests.rs
+++ b/purr/tests/sync_tests.rs
@@ -18,6 +18,7 @@ use purr_sync::types::{
 };
 
 use purr::database::Database;
+use purr::interface::ItemTag;
 use purr::ClipboardStore;
 use purr::ClipboardStoreApi;
 use tempfile::TempDir;
@@ -108,6 +109,28 @@ fn tombstone_aggregate(content_type: &str, versions: VersionVector) -> ItemAggre
         versions,
         content_type: content_type.to_string(),
     })
+}
+
+fn snapshot_record(snapshot: &ItemSnapshot) -> purr::interface::SyncSnapshotRecord {
+    purr::interface::SyncSnapshotRecord {
+        item_id: snapshot.item_id.clone(),
+        snapshot_revision: snapshot.snapshot_revision,
+        schema_version: snapshot.schema_version,
+        covers_through_event: snapshot.covers_through_event.clone(),
+        aggregate_data: snapshot.aggregate_data(),
+    }
+}
+
+fn event_record(event: &ItemEvent) -> purr::interface::SyncEventRecord {
+    purr::interface::SyncEventRecord {
+        event_id: event.event_id.clone(),
+        item_id: event.item_id.clone(),
+        origin_device_id: event.origin_device_id.clone(),
+        schema_version: event.schema_version,
+        recorded_at: event.recorded_at,
+        payload_type: event.payload_type(),
+        payload_data: event.payload_data(),
+    }
 }
 
 fn default_versions() -> VersionVector {
@@ -1107,15 +1130,17 @@ mod compaction_tests {
 
     fn seed_item_with_events(db: &Database, global_id: &str, n_events: usize) {
         let sync = SyncStore::new(db.pool());
+        let recorded_at_base = chrono::Utc::now().timestamp();
 
         // Create the item.
-        let create_event = ItemEvent::new_local(
+        let mut create_event = ItemEvent::new_local(
             global_id.to_string(),
             "device-A",
             ItemEventPayload::ItemCreated {
                 snapshot: text_snapshot("compaction test"),
             },
         );
+        create_event.recorded_at = recorded_at_base;
         sync.append_local_event(&create_event).unwrap();
 
         let agg = ItemAggregate::Live(LiveItemState {
@@ -1134,7 +1159,7 @@ mod compaction_tests {
 
         // Add touch events.
         for i in 0..n_events {
-            let touch_event = ItemEvent::new_local(
+            let mut touch_event = ItemEvent::new_local(
                 global_id.to_string(),
                 "device-A",
                 ItemEventPayload::ItemTouched {
@@ -1142,6 +1167,7 @@ mod compaction_tests {
                     base_touch_version: 1 + (i as u64),
                 },
             );
+            touch_event.recorded_at = recorded_at_base + 1 + i as i64;
             sync.append_local_event(&touch_event).unwrap();
         }
     }
@@ -2395,37 +2421,121 @@ mod replay_audit_tests {
     }
 
     #[test]
-    fn full_resync_with_tail_replaces_stale_local_rows() {
+    fn full_resync_with_tail_preserves_local_survivors_without_delete_proof() {
         let (store, dir) = test_store();
 
-        let stale_id = store
-            .save_text("stale local row".to_string(), None, None)
+        let local_id = store
+            .save_text("local survivor".to_string(), None, None)
             .unwrap();
-        assert!(!stale_id.is_empty());
+        store.add_tag(local_id.clone(), ItemTag::Bookmark).unwrap();
+        assert!(!local_id.is_empty());
 
         let aggregate = ItemAggregate::Live(LiveItemState {
             snapshot: text_snapshot("remote truth"),
             versions: default_versions(),
         });
         let snapshot = ItemSnapshot::initial("remote-item".to_string(), aggregate);
-        let record = purr::interface::SyncSnapshotRecord {
-            item_id: snapshot.item_id.clone(),
-            snapshot_revision: snapshot.snapshot_revision,
-            schema_version: snapshot.schema_version,
-            covers_through_event: snapshot.covers_through_event.clone(),
-            aggregate_data: snapshot.aggregate_data(),
-        };
+        let record = snapshot_record(&snapshot);
 
         let result = store.full_resync_with_tail(vec![record], vec![]).unwrap();
         assert_eq!(result.checkpoints_applied, 1);
         assert_eq!(result.tail_events_applied, 0);
 
         let db = store_db(&dir);
-        assert!(db.fetch_items_by_item_ids(&[stale_id]).unwrap().is_empty());
+        assert_eq!(
+            db.fetch_items_by_item_ids(&[local_id.clone()])
+                .unwrap()
+                .len(),
+            1
+        );
 
         let all_items = db.fetch_all_items().unwrap();
-        assert_eq!(all_items.len(), 1);
-        assert_eq!(all_items[0].text_content(), "remote truth");
+        assert_eq!(all_items.len(), 2);
+        assert!(all_items
+            .iter()
+            .any(|item| item.item_id == local_id && item.text_content() == "local survivor"));
+        assert!(all_items
+            .iter()
+            .any(|item| item.item_id == "remote-item" && item.text_content() == "remote truth"));
+
+        let pending_snapshots = store.pending_snapshot_records().unwrap();
+        assert_eq!(pending_snapshots.len(), 1);
+        assert_eq!(pending_snapshots[0].item_id, local_id);
+        let aggregate: ItemAggregate =
+            serde_json::from_str(&pending_snapshots[0].aggregate_data).unwrap();
+        match aggregate {
+            ItemAggregate::Live(live) => {
+                assert!(live.snapshot.is_bookmarked);
+                assert_eq!(live.versions.bookmark, 1);
+            }
+            other => panic!("expected survivor live snapshot, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn full_resync_with_tail_deletes_local_rows_with_tombstone_proof() {
+        let (store, dir) = test_store();
+
+        let local_id = store
+            .save_text("delete only with proof".to_string(), None, None)
+            .unwrap();
+        let mut versions = default_versions();
+        versions.existence = 2;
+        let tombstone = ItemSnapshot::compacted(
+            local_id.clone(),
+            1,
+            "delete-proof-event".to_string(),
+            tombstone_aggregate("text", versions),
+        );
+
+        let result = store
+            .full_resync_with_tail(vec![snapshot_record(&tombstone)], vec![])
+            .unwrap();
+        assert_eq!(result.checkpoints_applied, 1);
+
+        let db = store_db(&dir);
+        assert!(db
+            .fetch_items_by_item_ids(&[local_id.clone()])
+            .unwrap()
+            .is_empty());
+
+        let sync = SyncStore::new(db.pool());
+        let projection = sync.fetch_projection(&local_id).unwrap().unwrap();
+        assert_projection_tombstoned(&projection);
+        assert!(store.pending_snapshot_records().unwrap().is_empty());
+    }
+
+    #[test]
+    fn full_resync_with_tail_deletes_local_rows_with_tail_delete_proof() {
+        let (store, dir) = test_store();
+
+        let local_id = store
+            .save_text("delete from tail event".to_string(), None, None)
+            .unwrap();
+        let deleted = ItemEvent::new_local(
+            local_id.clone(),
+            "device-A",
+            ItemEventPayload::ItemDeleted {
+                base_existence_version: 1,
+            },
+        );
+
+        let result = store
+            .full_resync_with_tail(vec![], vec![event_record(&deleted)])
+            .unwrap();
+        assert_eq!(result.checkpoints_applied, 0);
+        assert_eq!(result.tail_events_applied, 1);
+        assert_eq!(result.tail_events_deferred, 0);
+
+        let db = store_db(&dir);
+        assert!(db
+            .fetch_items_by_item_ids(&[local_id.clone()])
+            .unwrap()
+            .is_empty());
+
+        let sync = SyncStore::new(db.pool());
+        let projection = sync.fetch_projection(&local_id).unwrap().unwrap();
+        assert_projection_tombstoned(&projection);
     }
 
     #[test]
@@ -2590,6 +2700,10 @@ mod replay_audit_tests {
         };
 
         assert!(store.apply_remote_snapshot(make_record()).unwrap());
+        assert!(
+            store.pending_snapshot_records().unwrap().is_empty(),
+            "snapshots fetched from CloudKit should not be echoed back as pending uploads"
+        );
 
         let db = store_db(&dir);
         let row_id = db.fetch_all_items().unwrap()[0].id.unwrap();


### PR DESCRIPTION
## Summary
- Stabilize the iOS app startup path by tightening app container and browser view model state handling.
- Harden sync engine and bridge logic so unexpected sync states no longer propagate into the UI.
- Align shared Rust and Swift types across the sync boundary to keep database, store, and bridge behavior consistent.
- Add and update unit coverage for browser and sync flows to protect the crash fix.

## Testing
- Updated unit tests for `BrowserViewModel` and `SyncEngine`.
- Added/updated Rust sync tests for the bridge, store, and database flow.
- Not run (not requested).