### PR TITLE
Align image previews to the top left in preview panes

### DIFF
--- a/Sources/MacApp/Browser/BrowserPreviewPane.swift
+++ b/Sources/MacApp/Browser/BrowserPreviewPane.swift
@@ -374,13 +374,16 @@ private struct ImagePreviewView: View {
         // preview.
         GeometryReader { geo in
             ScrollView(.vertical, showsIndicators: true) {
-                VStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 8) {
                     if let image {
                         Image(nsImage: image)
                             .resizable()
                             .aspectRatio(contentMode: .fit)
-                            .frame(maxWidth: .infinity)
-                            .frame(maxHeight: max(geo.size.height - 32, 120))
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: max(geo.size.height - 32, 120),
+                                alignment: .topLeading
+                            )
                     } else {
                         ProgressView()
                             .frame(maxWidth: .infinity, minHeight: 120)
@@ -400,7 +403,7 @@ private struct ImagePreviewView: View {
                     }
                 }
                 .padding(16)
-                .frame(minHeight: geo.size.height - 32, alignment: .top)
+                .frame(maxWidth: .infinity, minHeight: geo.size.height - 32, alignment: .topLeading)
             }
         }
         .task(id: itemId) {

--- a/Sources/MacApp/Browser/BrowserRenderingSupport.swift
+++ b/Sources/MacApp/Browser/BrowserRenderingSupport.swift
@@ -245,17 +245,19 @@ struct FilePreviewView: View {
         VStack(spacing: 0) {
             previewHeader(file: file)
             Divider()
-            ZStack {
+            ZStack(alignment: .topLeading) {
                 Color.black.opacity(0.04)
                 if let nsImage = NSImage(data: previewData) {
                     Image(nsImage: nsImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                         .padding(16)
                 } else {
                     fileList
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Sources/iOSApp/Views/PreviewScreen.swift
+++ b/Sources/iOSApp/Views/PreviewScreen.swift
@@ -271,7 +271,7 @@ struct PreviewScreen: View {
     // MARK: - Image Content
 
     private func imageContent(data: Data, description: String, highlights: [Utf16HighlightRange]) -> some View {
-        VStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 8) {
             DecodedImageView(
                 namespace: "preview-image",
                 itemId: itemId,
@@ -280,7 +280,7 @@ struct PreviewScreen: View {
                 ProgressView()
                     .frame(maxWidth: .infinity, minHeight: 180)
             }
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             if !description.isEmpty {
                 if highlights.isEmpty {


### PR DESCRIPTION
## Summary
- Align macOS file image previews to the top-left instead of centering them
- Keep the regular macOS image preview anchored to the top-left while preserving fit scaling
- Match the iOS image detail preview layout so image content starts from the top-left like text

## Testing
- Not run (not requested)