### PR TITLE
Fix main release CI flakiness

### DIFF
--- a/distribution/demo-data/src/video_localized.rs
+++ b/distribution/demo-data/src/video_localized.rs
@@ -2860,10 +2860,10 @@ pub const VIDEO_ITEMS_PT_BR: &[DemoItem] = &[
 // ============================================================================
 
 const VIDEO_SCENES_RU: LocalizedVideoScenes = LocalizedVideoScenes {
-    welcome_query: "добро пожаловать clipkitty",
-    find_forever_query: "скопировал найдёшь когда угодно",
-    multiline_query: "многострочный предпросмотр",
-    secure_private_query: "приватность открытый исходный код",
+    welcome_query: "clipkitty",
+    find_forever_query: "найдёшь",
+    multiline_query: "предпросмотр",
+    secure_private_query: "приватность",
     fast_query: "быстро",
 };
 

--- a/tools/xtask/src/cmd/release.rs
+++ b/tools/xtask/src/cmd/release.rs
@@ -1042,7 +1042,7 @@ fn upload_screenshots(
     Ok(())
 }
 
-/// Poll the screenshot set for up to ~30s, returning `Ok(())` once it has
+/// Poll the screenshot set for up to ~3m, returning `Ok(())` once it has
 /// `expected` screenshots and all of them are `COMPLETE`. Returns
 /// `Err(reason)` if the deadline passes without that state being reached.
 ///
@@ -1058,7 +1058,7 @@ fn wait_for_screenshot_set_ready(
     asc_env: &[(&str, &str)],
     reporter: &Reporter,
 ) -> Result<std::result::Result<(), String>> {
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + Duration::from_secs(180);
     loop {
         let screenshots =
             list_screenshot_set(repo, localization_id, device_type, asc_env, reporter)?;


### PR DESCRIPTION
## Summary
- shorten Russian intro-video search queries to avoid excessive localized typing time in CI
- wait longer for App Store Connect screenshot uploads to become visible/complete

## Verification
- cargo test -p xtask
- cargo test -p demo-data
- cargo test -p purr --test preview_video_search
- make check
