### PR TITLE
Refresh search index on item reuse

### DIFF
--- a/purr/src/save_service.rs
+++ b/purr/src/save_service.rs
@@ -45,6 +45,14 @@ pub(crate) enum ReindexOutcome {
     IndexFailed,
 }
 
+/// Outcome of touching an item timestamp.
+pub(crate) enum TouchOutcome {
+    /// The database timestamp and search index timestamp were both updated.
+    Indexed { timestamp_unix: i64 },
+    /// The database timestamp was updated, but the search index is now stale.
+    IndexFailed { timestamp_unix: i64 },
+}
+
 /// Resolved link metadata fields after normalization.
 #[allow(dead_code)]
 pub(crate) struct ResolvedLinkMetadata {
@@ -275,10 +283,25 @@ pub(crate) fn update_text_item(
     Ok(ReindexOutcome::Indexed)
 }
 
-pub(crate) fn update_timestamp(db: &Database, item_id: i64) -> Result<i64, ClipKittyError> {
+pub(crate) fn update_timestamp(
+    db: &Database,
+    indexer: &Indexer,
+    item_id: i64,
+) -> Result<TouchOutcome, ClipKittyError> {
     let now = Utc::now();
     db.update_timestamp(item_id, now)?;
-    Ok(now.timestamp())
+    let timestamp_unix = now.timestamp();
+
+    if let Some(item) = get_stored_item(db, item_id)? {
+        let index_result = indexer
+            .add_document(&item.item_id, &index_text(&item), timestamp_unix)
+            .and_then(|_| indexer.commit());
+        if index_result.is_err() {
+            return Ok(TouchOutcome::IndexFailed { timestamp_unix });
+        }
+    }
+
+    Ok(TouchOutcome::Indexed { timestamp_unix })
 }
 
 pub(crate) fn add_tag(db: &Database, item_id: i64, tag: ItemTag) -> Result<(), ClipKittyError> {

--- a/purr/src/store.rs
+++ b/purr/src/store.rs
@@ -545,7 +545,15 @@ impl ClipboardStoreApi for ClipboardStore {
     fn update_timestamp(&self, item_id: String) -> Result<(), ClipKittyError> {
         let row_id = self.require_row_id(&item_id)?;
         #[allow(unused_variables)]
-        let timestamp_unix = save_service::update_timestamp(&self.db, row_id)?;
+        let timestamp_unix = match save_service::update_timestamp(&self.db, &self.indexer, row_id)?
+        {
+            save_service::TouchOutcome::Indexed { timestamp_unix } => timestamp_unix,
+            save_service::TouchOutcome::IndexFailed { timestamp_unix } => {
+                #[cfg(feature = "sync")]
+                let _ = self.sync_emitter.set_index_dirty();
+                timestamp_unix
+            }
+        };
 
         #[cfg(feature = "sync")]
         self.sync_emitter
@@ -1337,6 +1345,23 @@ impl SearchOperation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::StoredItem;
+
+    fn insert_indexed_text_with_timestamp(
+        store: &ClipboardStore,
+        content: &str,
+        timestamp_unix: i64,
+    ) -> StoredItem {
+        let mut item = StoredItem::new_text(content.to_string(), None, None);
+        item.timestamp_unix = timestamp_unix;
+        let row_id = store.db.insert_item(&item).unwrap();
+        item.id = Some(row_id);
+        store
+            .indexer
+            .add_document(&item.item_id, item.content.text_content(), timestamp_unix)
+            .unwrap();
+        item
+    }
 
     #[test]
     fn test_round_trip_save_and_fetch() {
@@ -1356,5 +1381,34 @@ mod tests {
 
         let dup = store.save_text("hello world".into(), None, None).unwrap();
         assert!(dup.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_timestamp_refreshes_search_ranking_timestamp() {
+        let store = ClipboardStore::new_in_memory().unwrap();
+        let now = chrono::Utc::now().timestamp();
+        let first = insert_indexed_text_with_timestamp(&store, "this is a test 1", now - 10);
+        let second = insert_indexed_text_with_timestamp(&store, "this is a test 2", now - 5);
+        store.indexer.commit().unwrap();
+
+        let initial = store
+            .search(
+                "this is a test".to_string(),
+                ListPresentationProfile::CompactRow,
+            )
+            .await
+            .unwrap();
+        assert_eq!(initial.matches[0].item_metadata.item_id, second.item_id);
+
+        store.update_timestamp(first.item_id.clone()).unwrap();
+
+        let after_touch = store
+            .search(
+                "this is a test".to_string(),
+                ListPresentationProfile::CompactRow,
+            )
+            .await
+            .unwrap();
+        assert_eq!(after_touch.matches[0].item_metadata.item_id, first.item_id);
     }
 }


### PR DESCRIPTION
## What changed

- Refresh the Tantivy search document when an item is reused through `update_timestamp`, keeping search ranking timestamps aligned with SQLite display metadata.
- Preserve the existing behavior where the timestamp update succeeds even if reindexing fails, and mark the sync index dirty in that failure case.
- Add a library regression test for the reported flow: two matching entries, reuse the older one, then search and expect the reused item first.

## Root cause

`ClipboardStore::update_timestamp` updated SQLite only. Search results hydrate their displayed timestamp from SQLite, but trigram ranking uses the timestamp stored in the Tantivy index, so reused entries could display a newer timestamp while still sorting by their older indexed timestamp.

Fixes #387.

## Validation

- `rustfmt --edition 2021 --check purr/src/save_service.rs purr/src/store.rs`
- `git diff --check`
- `make check`
- `cargo test --manifest-path purr/Cargo.toml update_timestamp_refreshes_search_ranking_timestamp --lib`
- `cargo test --manifest-path purr/Cargo.toml --lib --locked`
- `nix develop --no-update-lock-file --experimental-features 'nix-command flakes' .#default --command cargo deny check`