### PR TITLE
align feature copy checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ guard-%:
 shell: ## Drop into the pinned Nix dev shell.
 	@$(NIX_DEVELOP) bash
 
-check: ## Verify repository invariants (pins + pinned actions).
+check: ## Verify repository invariants (pins, pinned actions, copy alignment).
 	@$(XTASK) check
 
 workspace: ## Materialize the generated Xcode workspace/project.

--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@ ClipKitty is built around a simple idea: your clipboard can remember more withou
 
 ## Features
 
-- **Deep clipboard history**  
-  Keep far more than the last few things you copied.
+- **Everything stays within reach**
+  Keep a deep history of text, links, images, files, code, and colors without turning your clipboard into another thing to manage.
 
-- **Fast, forgiving search**  
-  Find clips by typing what you remember, even if your query is partial or misspelled.
+- **Search what you remember**
+  Type a few words, fragments, or even a typo. ClipKitty helps you find the right item fast, even when your search is incomplete or misspelled.
 
-- **Live previews**  
-  See full text, code, images, colors, links, and files before you paste.
+- **Preview before you paste**
+  See full text, code, images, colors, links, and files before using them. No guessing from tiny cut-off snippets.
 
-- **Natural keyboard flow**  
-  Press **⌥Space**, type to search, move with **↑ / ↓**, and press **Return** to paste.
+- **Move fast from the keyboard**
+  Press **⌥Space**, search by typing, move with **↑ / ↓**, and press **Return** to paste.
 
-- **Optional iCloud Sync**  
-  Sync your history across your Mac, iPhone, and iPad when you choose.
+- **Sync only when you want it**
+  Use optional iCloud Sync to keep your history in step across Mac, iPhone, and iPad. It is off by default and uses your private iCloud account, with no ClipKitty-run server in the path.
 
-- **Private by default**  
-  No accounts. No telemetry. No third-party servers. Your clipboard history stays on-device unless you enable iCloud Sync.
+- **Private by default**
+  No accounts. No telemetry. No third-party servers. Your clipboard history stays on-device unless you enable iCloud Sync; even then, it uses Apple's private CloudKit database without developer access to your clips.
 
-- **Open source and attested**  
-  ClipKitty publishes build attestations so you can [verify](VERIFY.md) that the app was built from the public source.
+- **Open source and attested**
+  ClipKitty is open source and publishes build attestations so you can [verify](VERIFY.md) the app was built from the public source.
 
 ## Installation
 

--- a/distribution/metadata/en-US/description.txt
+++ b/distribution/metadata/en-US/description.txt
@@ -1,23 +1,24 @@
-ClipKitty is a calm, powerful clipboard manager for everything you copy.
-
-Copy text, links, images, and colors without worrying about what gets overwritten. ClipKitty keeps your clipboard history close, searchable, and easy to use; so you can stay in flow and find things when you need them.
-
 Copy it once. Find it forever.
 
+ClipKitty is built around a simple idea: your clipboard can remember more without asking more from you.
+
 Everything stays within reach
-Keep a deep history of everything you've copied; without turning it into another thing to manage.
+Keep a deep history of text, links, images, files, code, and colors without turning your clipboard into another thing to manage.
 
 Search what you remember
-Type a few words, fragments, or even a typo. ClipKitty helps you find the right item quickly, even when your search is incomplete.
+Type a few words, fragments, or even a typo. ClipKitty helps you find the right item fast, even when your search is incomplete or misspelled.
 
 Preview before you paste
-See full text, code, images, and colors before using them. No guessing from tiny cut-off snippets.
+See full text, code, images, colors, links, and files before using them. No guessing from tiny cut-off snippets.
 
 Move fast from the keyboard
-Open ClipKitty with Option-Space, search by typing, move with the arrow keys, and press Return to paste.
+Press ⌥Space, search by typing, move with ↑ / ↓, and press Return to paste.
 
 Sync only when you want it
-Use optional iCloud sync to keep your clipboard history in step across Mac, iPhone, and iPad. It is off by default.
+Use optional iCloud Sync to keep your history in step across Mac, iPhone, and iPad. It is off by default and uses your private iCloud account, with no ClipKitty-run server in the path.
 
 Private by default
-ClipKitty works on-device with no telemetry, no accounts, and no third-party servers. Optional sync stays in your private iCloud container. The app is open source and publicly auditable.
+No accounts. No telemetry. No third-party servers. Your clipboard history stays on-device unless you enable iCloud Sync; even then, it uses Apple's private CloudKit database without developer access to your clips.
+
+Open source and attested
+ClipKitty is open source and publishes build attestations so you can verify the app was built from the public source.

--- a/tools/xtask/src/cmd/check.rs
+++ b/tools/xtask/src/cmd/check.rs
@@ -19,11 +19,12 @@ pub fn run(dry_run: bool, reporter: &Reporter) -> Result<()> {
     let _ = SideEffectLevel::ReadOnly;
     let repo = RepoRoot::discover(reporter)?;
     if dry_run {
-        reporter.info("[dry-run] would verify pinned inputs and pinned GitHub Actions");
+        reporter.info("[dry-run] would verify pinned inputs, pinned GitHub Actions, and product copy alignment");
         return Ok(());
     }
     check_pinned_actions(&repo, false, reporter)?;
-    check_pins(&repo, false, reporter)
+    check_pins(&repo, false, reporter)?;
+    crate::cmd::copy::check_synced(&repo, reporter)
 }
 
 const PINNED_LOCKFILES: &[&str] = &["Cargo.lock", "flake.lock"];

--- a/tools/xtask/src/cmd/copy.rs
+++ b/tools/xtask/src/cmd/copy.rs
@@ -1,0 +1,298 @@
+//! Check that README feature copy stays aligned with App Store copy.
+
+use std::fs;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+use crate::output::Reporter;
+use crate::process::Runner;
+use crate::repo::RepoRoot;
+
+const README_PATH: &str = "README.md";
+const APP_STORE_DESCRIPTION_PATH: &str = "distribution/metadata/en-US/description.txt";
+const APP_STORE_INTRO: &[&str] = &[
+    "Copy it once. Find it forever.",
+    "ClipKitty is built around a simple idea: your clipboard can remember more without asking more from you.",
+];
+const APP_STORE_BODY_EXCEPTIONS: &[&str] = &["Sync only when you want it", "Private by default"];
+
+pub(crate) fn check_synced(repo: &RepoRoot, reporter: &Reporter) -> Result<()> {
+    let readme = read_to_string(repo, README_PATH)?;
+    let app_store = read_to_string(repo, APP_STORE_DESCRIPTION_PATH)?;
+    check_alignment(&readme, &app_store)?;
+    reporter.success("README and App Store feature copy are aligned.");
+    Ok(())
+}
+
+pub(crate) fn check_staged_synced(repo: &RepoRoot, reporter: &Reporter) -> Result<()> {
+    let readme = read_index_to_string(repo, reporter, README_PATH)?;
+    let app_store = read_index_to_string(repo, reporter, APP_STORE_DESCRIPTION_PATH)?;
+    check_alignment(&readme, &app_store)?;
+    reporter.success("Staged README and App Store feature copy are aligned.");
+    Ok(())
+}
+
+fn check_alignment(readme: &str, app_store: &str) -> Result<()> {
+    let readme_features = parse_readme_features(readme)?;
+    let app_store_description = parse_app_store_description(app_store)?;
+
+    let mut errors = Vec::new();
+
+    if app_store_description.intro != APP_STORE_INTRO {
+        errors.push(format!(
+            "{APP_STORE_DESCRIPTION_PATH}: intro must be exactly:\n{}",
+            APP_STORE_INTRO.join("\n\n")
+        ));
+    }
+
+    if app_store_description.features.len() != readme_features.len() {
+        errors.push(format!(
+            "{APP_STORE_DESCRIPTION_PATH}: expected {} feature(s), found {}",
+            readme_features.len(),
+            app_store_description.features.len()
+        ));
+    }
+
+    for (index, readme_feature) in readme_features.iter().enumerate() {
+        let Some(app_store_feature) = app_store_description.features.get(index) else {
+            continue;
+        };
+        if app_store_feature.title != readme_feature.title {
+            errors.push(format!(
+                "{APP_STORE_DESCRIPTION_PATH}: feature {} title is `{}`, expected `{}`",
+                index + 1,
+                app_store_feature.title,
+                readme_feature.title
+            ));
+            continue;
+        }
+
+        if APP_STORE_BODY_EXCEPTIONS.contains(&readme_feature.title.as_str()) {
+            continue;
+        }
+
+        let expected = normalize_copy(&strip_markdown(&readme_feature.body));
+        let actual = normalize_copy(&app_store_feature.body);
+        if actual != expected {
+            errors.push(format!(
+                "{APP_STORE_DESCRIPTION_PATH}: `{}` body diverges from {README_PATH}",
+                readme_feature.title
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    for error in &errors {
+        eprintln!("{error}");
+    }
+    bail!(
+        "README/App Store feature copy drift detected. Keep titles and non-sync/privacy feature bodies aligned."
+    )
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Feature {
+    title: String,
+    body: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct AppStoreDescription {
+    intro: Vec<String>,
+    features: Vec<Feature>,
+}
+
+fn parse_readme_features(readme: &str) -> Result<Vec<Feature>> {
+    let section = markdown_section(readme, "## Features")?;
+    let mut features = Vec::new();
+
+    for block in section.split("\n\n") {
+        let block = block.trim();
+        if block.is_empty() || block.starts_with("<!--") {
+            continue;
+        }
+        let Some(rest) = block.strip_prefix("- **") else {
+            continue;
+        };
+        let Some(title_end) = rest.find("**") else {
+            return Err(anyhow!("{README_PATH}: malformed feature title `{block}`"));
+        };
+        let title = rest[..title_end].to_string();
+        let body = rest[title_end + 2..]
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if body.is_empty() {
+            return Err(anyhow!("{README_PATH}: feature `{title}` has no body"));
+        }
+        features.push(Feature { title, body });
+    }
+
+    if features.is_empty() {
+        return Err(anyhow!("{README_PATH}: no features found"));
+    }
+    Ok(features)
+}
+
+fn markdown_section<'a>(document: &'a str, heading: &str) -> Result<&'a str> {
+    let Some(start) = document.find(heading) else {
+        return Err(anyhow!("{README_PATH}: missing `{heading}` section"));
+    };
+    let content_start = start + heading.len();
+    let content_start = document[content_start..]
+        .strip_prefix("\n\n")
+        .map(|_| content_start + 2)
+        .unwrap_or(content_start);
+    let next_heading = document[content_start..]
+        .find("\n## ")
+        .map(|offset| content_start + offset)
+        .unwrap_or(document.len());
+    Ok(&document[content_start..next_heading])
+}
+
+fn parse_app_store_description(contents: &str) -> Result<AppStoreDescription> {
+    let sections: Vec<&str> = contents
+        .trim()
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|section| !section.is_empty())
+        .collect();
+
+    if sections.len() < APP_STORE_INTRO.len() {
+        return Err(anyhow!(
+            "{APP_STORE_DESCRIPTION_PATH}: description is missing intro copy"
+        ));
+    }
+
+    let intro = sections[..APP_STORE_INTRO.len()]
+        .iter()
+        .map(|section| (*section).to_string())
+        .collect();
+    let mut features = Vec::new();
+
+    for section in &sections[APP_STORE_INTRO.len()..] {
+        let mut lines = section
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty());
+        let Some(title) = lines.next() else {
+            continue;
+        };
+        let body = lines.collect::<Vec<_>>().join(" ");
+        if body.is_empty() {
+            return Err(anyhow!(
+                "{APP_STORE_DESCRIPTION_PATH}: feature `{title}` has no body"
+            ));
+        }
+        features.push(Feature {
+            title: title.to_string(),
+            body,
+        });
+    }
+
+    Ok(AppStoreDescription { intro, features })
+}
+
+fn strip_markdown(input: &str) -> String {
+    let without_bold = input.replace("**", "");
+    strip_links(&without_bold)
+}
+
+fn strip_links(input: &str) -> String {
+    let mut output = String::new();
+    let mut cursor = 0;
+    while let Some(open_bracket) = input[cursor..].find('[') {
+        let open_bracket = cursor + open_bracket;
+        let Some(close_bracket_offset) = input[open_bracket..].find(']') else {
+            break;
+        };
+        let close_bracket = open_bracket + close_bracket_offset;
+        let link_target_start = close_bracket + 1;
+        if !input[link_target_start..].starts_with('(') {
+            break;
+        }
+        let Some(close_paren_offset) = input[link_target_start + 1..].find(')') else {
+            break;
+        };
+        let close_paren = link_target_start + 1 + close_paren_offset;
+        output.push_str(&input[cursor..open_bracket]);
+        output.push_str(&input[open_bracket + 1..close_bracket]);
+        cursor = close_paren + 1;
+    }
+    output.push_str(&input[cursor..]);
+    output
+}
+
+fn normalize_copy(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn read_to_string(repo: &RepoRoot, rel: &str) -> Result<String> {
+    let path = repo.join(rel);
+    fs::read_to_string(path.as_std_path()).with_context(|| format!("reading {path}"))
+}
+
+fn read_index_to_string(repo: &RepoRoot, reporter: &Reporter, rel: &str) -> Result<String> {
+    Runner::new(reporter, "git")
+        .arg("show")
+        .arg(format!(":{rel}"))
+        .cwd(repo.as_path())
+        .output()
+        .with_context(|| format!("reading staged {rel}"))?
+        .stdout_string()
+        .with_context(|| format!("decoding staged {rel} as UTF-8"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_readme_feature_bullets() {
+        let readme = "# App\n\n## Features\n\n- **Search**  \n  Find **things** quickly.\n\n- **Open source**  \n  You can [verify](VERIFY.md) builds.\n\n## Install\n";
+
+        assert_eq!(
+            parse_readme_features(readme).unwrap(),
+            vec![
+                Feature {
+                    title: "Search".to_string(),
+                    body: "Find **things** quickly.".to_string()
+                },
+                Feature {
+                    title: "Open source".to_string(),
+                    body: "You can [verify](VERIFY.md) builds.".to_string()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn strips_markdown_for_app_store_comparison() {
+        assert_eq!(
+            strip_markdown("Press **⌥Space** and [verify](VERIFY.md)."),
+            "Press ⌥Space and verify."
+        );
+    }
+
+    #[test]
+    fn permits_sync_and_privacy_body_exceptions() {
+        let readme = "# App\n\n## Features\n\n- **Sync only when you want it**  \n  README sync copy.\n\n- **Private by default**  \n  README privacy copy.\n\n- **Search**  \n  Find clips quickly.\n\n## Install\n";
+        let app_store = "Copy it once. Find it forever.\n\nClipKitty is built around a simple idea: your clipboard can remember more without asking more from you.\n\nSync only when you want it\nApp Store sync copy.\n\nPrivate by default\nApp Store privacy copy.\n\nSearch\nFind clips quickly.\n";
+
+        check_alignment(readme, app_store).unwrap();
+    }
+
+    #[test]
+    fn rejects_non_exception_body_drift() {
+        let readme =
+            "# App\n\n## Features\n\n- **Search**  \n  Find clips quickly.\n\n## Install\n";
+        let app_store = "Copy it once. Find it forever.\n\nClipKitty is built around a simple idea: your clipboard can remember more without asking more from you.\n\nSearch\nDifferent copy.\n";
+
+        assert!(check_alignment(readme, app_store).is_err());
+    }
+}

--- a/tools/xtask/src/cmd/env.rs
+++ b/tools/xtask/src/cmd/env.rs
@@ -144,9 +144,14 @@ pub(crate) fn run_pre_commit_command(
     reporter: &Reporter,
 ) -> Result<()> {
     if dry_run {
-        reporter.info("[dry-run] would run the pre-commit formatting/lint/localization checks");
+        reporter.info(
+            "[dry-run] would run the pre-commit copy-alignment/formatting/lint/localization checks",
+        );
         return Ok(());
     }
+
+    reporter.info("Checking staged README/App Store feature copy alignment...");
+    crate::cmd::copy::check_staged_synced(repo, reporter)?;
 
     let staged_swift_files = staged_swift_files(repo, reporter)?;
     if staged_swift_files.is_empty() {

--- a/tools/xtask/src/cmd/mod.rs
+++ b/tools/xtask/src/cmd/mod.rs
@@ -8,6 +8,7 @@ use crate::output::Reporter;
 pub mod app;
 pub mod build;
 pub mod check;
+pub mod copy;
 pub mod env;
 pub mod marketing;
 pub mod perf;

--- a/tools/xtask/tests/cli.rs
+++ b/tools/xtask/tests/cli.rs
@@ -170,6 +170,7 @@ fn verbose_and_dry_run_flags_propagate() {
 fn rejects_internalized_legacy_commands() {
     for argv in [
         ["clipkitty", "check", "pins"].as_slice(),
+        ["clipkitty", "copy", "sync"].as_slice(),
         ["clipkitty", "build", "generate"].as_slice(),
         ["clipkitty", "build", "app", "Release"].as_slice(),
         ["clipkitty", "sign", "app", "Hardened"].as_slice(),


### PR DESCRIPTION
## Summary

- Collapse the English App Store description intro to the requested two-paragraph positioning copy.
- Prefer README feature copy for the App Store feature list, stripping Markdown formatting where needed.
- Keep App Store-specific sync/privacy copy allowed to differ from README wording.
- Remove the public copy-generation CLI and enforce README/App Store feature alignment through `make check` and the staged pre-commit hook.

## Validation

- `cargo test -p xtask`
- `cargo run --quiet -p xtask -- check`
- `cargo run --quiet -p xtask -- __internal pre-commit`
- `cargo run --quiet -p xtask -- copy sync` fails as an unrecognized command
- staged-index drift probe fails when non-exempt App Store copy diverges from README
- `git diff --check`

Note: the xtask commands still emit the existing unused enum variant warnings in `tools/xtask/src/cmd/marketing.rs`.