### PR TITLE
Fix README icon source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClipKitty
 
-<img src="https://raw.githubusercontent.com/jul-sh/clipkitty/gh-pages/icon.png" alt="ClipKitty icon" width="60">
+<img src="https://raw.githubusercontent.com/jul-sh/clipkitty/main/Sources/MacApp/Assets.xcassets/AppIcon.appiconset/AppIcon.png" alt="ClipKitty icon" width="60">
 
 **Copy it once. Find it forever.**
 


### PR DESCRIPTION
## Summary

- Update the README icon image to use the committed app icon on `main`.
- Stop relying on `gh-pages/icon.png` for the repository README header icon.

## Why

`gh-pages/icon.png` can lag behind the current app icon generated and committed on `main`, so the README continued to show the old icon even after the app icon was refreshed.

## Impact

The README header now renders the current checked-in ClipKitty app icon. The public-site marketing screenshot links are unchanged.

## Validation

- `git diff --check`
- Commit hook: README/App Store feature-copy alignment
- Confirmed the new raw URL SHA-256 matches `origin/main:Sources/MacApp/Assets.xcassets/AppIcon.appiconset/AppIcon.png`