### PR TITLE
Add font preference setting

### DIFF
--- a/Sources/MacApp/AppFont.swift
+++ b/Sources/MacApp/AppFont.swift
@@ -1,0 +1,35 @@
+import ClipKittyMacPlatform
+import SwiftUI
+
+extension AppSettings {
+    func appFont(size: CGFloat, weight: Font.Weight? = nil) -> Font {
+        let font: Font = switch fontPreference {
+        case .iosevkaCharon:
+            .custom(FontManager.sansSerifName(for: .iosevkaCharon), size: size)
+        case .system:
+            .system(size: size)
+        }
+        return font.withWeight(weight)
+    }
+
+    func previewFont(size: CGFloat, weight: Font.Weight? = nil) -> Font {
+        let font: Font = switch fontPreference {
+        case .iosevkaCharon:
+            .custom(FontManager.monoName(for: .iosevkaCharon), size: size)
+        case .system:
+            .system(size: size, design: .monospaced)
+        }
+        return font.withWeight(weight)
+    }
+
+    var previewFontName: String {
+        FontManager.monoName(for: fontPreference)
+    }
+}
+
+private extension Font {
+    func withWeight(_ weight: Font.Weight?) -> Font {
+        guard let weight else { return self }
+        return self.weight(weight)
+    }
+}

--- a/Sources/MacApp/Browser/BrowserPreviewPane.swift
+++ b/Sources/MacApp/Browser/BrowserPreviewPane.swift
@@ -10,6 +10,7 @@ struct BrowserPreviewPane: View {
     let focusSearchField: () -> Void
     let focusTarget: FocusState<BrowserView.FocusTarget?>.Binding
 
+    @ObservedObject private var settings = AppSettings.shared
     private let isUITestPreviewDebugEnabled = CommandLine.arguments.contains("--use-simulated-db")
 
     var body: some View {
@@ -42,7 +43,7 @@ struct BrowserPreviewPane: View {
                     emptyState
                 } else {
                     Text("No item selected")
-                        .font(.custom(FontManager.sansSerif, size: 16))
+                        .font(settings.appFont(size: 16))
                         .foregroundStyle(.secondary)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
@@ -56,9 +57,7 @@ struct BrowserPreviewPane: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.largeTitle)
                 .foregroundStyle(.secondary)
-            Text(message)
-                .font(.custom(FontManager.sansSerif, size: 15))
-                .foregroundStyle(.secondary)
+            BrowserPreviewErrorText(message: message)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -87,8 +86,8 @@ struct BrowserPreviewPane: View {
             let _ = { TextPreviewView.textCache[item.itemMetadata.itemId] = previewText }()
             TextPreviewView(
                 itemId: item.itemMetadata.itemId,
-                fontName: FontManager.mono,
-                fontSize: AppSettings.shared.scaled(15),
+                fontName: settings.previewFontName,
+                fontSize: settings.scaled(15),
                 highlights: decoration?.highlights ?? [],
                 initialScrollHighlightIndex: decoration?.initialScrollHighlightIndex,
                 scrollBehavior: {
@@ -161,13 +160,13 @@ struct BrowserPreviewPane: View {
 
                     if highlights.isEmpty {
                         Text(url)
-                            .font(.custom(FontManager.mono, size: 12))
+                            .font(settings.previewFont(size: 12))
                             .foregroundStyle(.secondary)
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     } else {
                         Text(HighlightStyler.attributedText(url, highlights: highlights))
-                            .font(.custom(FontManager.mono, size: 12))
+                            .font(settings.previewFont(size: 12))
                             .foregroundStyle(.secondary)
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -346,7 +345,7 @@ struct BrowserPreviewPane: View {
                 .font(.largeTitle)
                 .foregroundStyle(.tertiary)
             Text(emptyStateMessage)
-                .font(.custom(FontManager.sansSerif, size: 15))
+                .font(settings.appFont(size: 15))
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -360,6 +359,17 @@ struct BrowserPreviewPane: View {
             return String(localized: "No clipboard history")
         }
         return String(localized: "No results")
+    }
+}
+
+private struct BrowserPreviewErrorText: View {
+    @ObservedObject private var settings = AppSettings.shared
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(settings.appFont(size: 15))
+            .foregroundStyle(.secondary)
     }
 }
 

--- a/Sources/MacApp/Browser/BrowserRenderingSupport.swift
+++ b/Sources/MacApp/Browser/BrowserRenderingSupport.swift
@@ -233,6 +233,8 @@ struct FilePreviewView: View {
     let files: [FileEntry]
     var searchQuery: String = ""
 
+    @ObservedObject private var settings = AppSettings.shared
+
     /// Query words for highlighting (lowercased, non-empty)
     private var queryWords: [String] {
         searchQuery.lowercased()
@@ -325,7 +327,7 @@ struct FilePreviewView: View {
             Divider()
             TextPreviewView(
                 itemId: previewId,
-                fontName: FontManager.mono,
+                fontName: settings.previewFontName,
                 fontSize: 12,
                 highlights: highlights,
                 scrollBehavior: .autoScroll,
@@ -337,7 +339,7 @@ struct FilePreviewView: View {
             case .truncated:
                 Divider()
                 Text("Preview truncated")
-                    .font(.custom(FontManager.sansSerif, size: 11))
+                    .font(settings.appFont(size: 11))
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 16)
@@ -1554,12 +1556,16 @@ struct ItemRow: View {
     let onContextMenuShow: () -> Void
     let onContextMenuHide: () -> Void
 
+    @ObservedObject private var settings = AppSettings.shared
+
     private var accentSelected: Bool {
         isSelected && hasUserNavigated && !hasPendingEdit
     }
 
     /// Height for exactly 1 line of text, scaled with text size setting
-    private var rowHeight: CGFloat { AppSettings.shared.scaled(32) }
+    private var rowHeight: CGFloat {
+        settings.scaled(32)
+    }
 
     // MARK: - Display Text (Simplified - SwiftUI handles truncation)
 
@@ -1590,6 +1596,15 @@ struct ItemRow: View {
         }
     }
 
+    private var lineNumberFont: Font {
+        switch settings.fontPreference {
+        case .iosevkaCharon:
+            return settings.previewFont(size: 13)
+        case .system:
+            return settings.appFont(size: 13)
+        }
+    }
+
     var body: some View {
         // 1. Wrap the content inside a Button
         Button(action: onTap) {
@@ -1599,8 +1614,8 @@ struct ItemRow: View {
                     if hasPendingEdit {
                         // Show pencil emoji when item has pending edit
                         Text("✏️")
-                            .font(.system(size: AppSettings.shared.scaled(24)))
-                            .frame(width: AppSettings.shared.scaled(32), height: AppSettings.shared.scaled(32))
+                            .font(.system(size: settings.scaled(24)))
+                            .frame(width: settings.scaled(32), height: settings.scaled(32))
                     } else {
                         ZStack(alignment: .bottomTrailing) {
                             // Main icon: image thumbnail, browser icon for links, color swatch, or SF symbol
@@ -1625,7 +1640,7 @@ struct ItemRow: View {
                                         .resizable()
                                 }
                             }
-                            .frame(width: AppSettings.shared.scaled(32), height: AppSettings.shared.scaled(32))
+                            .frame(width: settings.scaled(32), height: settings.scaled(32))
                             .clipShape(RoundedRectangle(cornerRadius: 4))
 
                             // Badge: Bookmark icon for bookmarked items, otherwise source app icon
@@ -1650,13 +1665,13 @@ struct ItemRow: View {
                         }
                     }
                 }
-                .frame(width: AppSettings.shared.scaled(38), height: AppSettings.shared.scaled(38))
+                .frame(width: settings.scaled(38), height: settings.scaled(38))
                 .allowsHitTesting(false)
 
                 // Line number (shown in search mode when line > 1)
                 if let lineNumber = displayExcerpt.lineNumber, lineNumber > 1 {
                     Text("L\(lineNumber):")
-                        .font(.custom(FontManager.mono, size: 13))
+                        .font(lineNumberFont)
                         .foregroundColor(accentSelected ? .white.opacity(0.7) : .secondary)
                         .lineLimit(1)
                         .fixedSize()
@@ -1669,7 +1684,8 @@ struct ItemRow: View {
                         text: displayExcerpt.text,
                         highlights: displayExcerpt.highlights,
                         accentSelected: accentSelected,
-                        textScale: AppSettings.shared.textScale
+                        textScale: settings.textScale,
+                        fontPreference: settings.fontPreference
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .allowsHitTesting(false)
@@ -1883,13 +1899,19 @@ struct HighlightedTextView: View, Equatable {
     let highlights: [Utf16HighlightRange]
     let accentSelected: Bool
     let textScale: CGFloat
+    let fontPreference: AppFontPreference
 
     private var textColor: Color {
         accentSelected ? .white : .primary
     }
 
     private var font: Font {
-        .custom(FontManager.sansSerif, size: 15 * textScale)
+        switch fontPreference {
+        case .iosevkaCharon:
+            return .custom(FontManager.sansSerifName(for: .iosevkaCharon), size: 15 * textScale)
+        case .system:
+            return .system(size: 15 * textScale)
+        }
     }
 
     var body: some View {

--- a/Sources/MacApp/Browser/BrowserSearchBar.swift
+++ b/Sources/MacApp/Browser/BrowserSearchBar.swift
@@ -28,11 +28,11 @@ struct BrowserSearchBar<FilterPopoverContent: View>: View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(.secondary)
-                .font(.custom(FontManager.sansSerif, size: settings.scaled(17)).weight(.medium))
+                .font(settings.appFont(size: settings.scaled(17), weight: .medium))
 
             TextField("Clipboard History Search", text: $searchText)
                 .textFieldStyle(.plain)
-                .font(.custom(FontManager.sansSerif, size: settings.scaled(17)))
+                .font(settings.appFont(size: settings.scaled(17)))
                 .tint(.primary)
                 .focused(focusTarget, equals: .search)
                 .id(colorScheme)

--- a/Sources/MacApp/Browser/BrowserView.swift
+++ b/Sources/MacApp/Browser/BrowserView.swift
@@ -9,6 +9,7 @@ struct BrowserView: View {
     @Bindable var viewModel: BrowserViewModel
     let displayVersion: Int
 
+    @ObservedObject private var settings = AppSettings.shared
     @State private var commandKeyEventMonitor: Any?
     @FocusState private var focusTarget: FocusTarget?
 
@@ -129,7 +130,7 @@ struct BrowserView: View {
                     displayVersion: displayVersion,
                     focusSearchField: focusSearchField
                 )
-                .frame(width: AppSettings.shared.scaled(324))
+                .frame(width: settings.scaled(324))
 
                 Divider()
 
@@ -276,14 +277,14 @@ struct BrowserView: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.yellow)
             Text(message)
-                .font(.custom(FontManager.sansSerif, size: 13))
+                .font(settings.appFont(size: 13))
                 .lineLimit(2)
                 .foregroundStyle(.primary)
             Button(String(localized: "Dismiss")) {
                 viewModel.dismissMutationFailure()
             }
             .buttonStyle(.plain)
-            .font(.custom(FontManager.sansSerif, size: 13).weight(.semibold))
+            .font(settings.appFont(size: 13, weight: .semibold))
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)

--- a/Sources/MacApp/Resources/Localizable.xcstrings
+++ b/Sources/MacApp/Resources/Localizable.xcstrings
@@ -340,6 +340,62 @@
         }
       }
     },
+    "Appearance": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Erscheinungsbild" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Appearance" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Apariencia" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Apparence" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "外観" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "모양" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Aparência" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Внешний вид" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "外观" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "外觀" } }
+      }
+    },
+    "Font": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Schrift" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Font" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Fuente" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Police" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "フォント" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "글꼴" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Fonte" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Шрифт" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "字体" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "字體" } }
+      }
+    },
+    "Iosevka Charon": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } }
+      }
+    },
+    "System": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "System" } },
+        "en": { "stringUnit": { "state": "translated", "value": "System" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Sistema" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Système" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "システム" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "시스템" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Sistema" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Системный" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "系统" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "系統" } }
+      }
+    },
     "Are you sure you want to delete all clipboard history? This cannot be undone.": {
       "extractionState": "stale",
       "localizations": {

--- a/Sources/MacApp/Settings.swift
+++ b/Sources/MacApp/Settings.swift
@@ -73,7 +73,7 @@ enum PasteMode {
             case .downloading: try container.encode(Tag.downloading, forKey: .tag)
             case .installing: try container.encode(Tag.installing, forKey: .tag)
             case .available: try container.encode(Tag.available, forKey: .tag)
-            case .checkFailed(let message):
+            case let .checkFailed(message):
                 try container.encode(Tag.checkFailed, forKey: .tag)
                 try container.encode(message, forKey: .errorMessage)
             }
@@ -149,9 +149,11 @@ final class AppSettings: ObservableObject {
         @Published var lastUpdateCheckDate: Date? {
             didSet { save() }
         }
+
         @Published var lastUpdateCheckResult: UpdateCheckState = .idle {
             didSet { save() }
         }
+
         @Published var autoInstallUpdates: Bool {
             didSet { save() }
         }
@@ -165,6 +167,10 @@ final class AppSettings: ObservableObject {
     let imageCompressionQuality: Double
 
     @Published var launchAtLoginEnabled: Bool {
+        didSet { save() }
+    }
+
+    @Published var fontPreference: AppFontPreference {
         didSet { save() }
     }
 
@@ -231,6 +237,7 @@ final class AppSettings: ObservableObject {
     private let deleteHotKeyKey = "deleteHotKey"
     private let maxDbSizeKey = "maxDatabaseSizeGB"
     private let launchAtLoginKey = "launchAtLogin"
+    private let fontPreferenceKey = "fontPreference"
     #if ENABLE_SYNTHETIC_PASTE
         private let autoPasteKey = "autoPasteEnabled"
     #endif
@@ -284,6 +291,8 @@ final class AppSettings: ObservableObject {
         }
 
         launchAtLoginEnabled = defaults.bool(forKey: launchAtLoginKey)
+        fontPreference = defaults.string(forKey: fontPreferenceKey)
+            .flatMap(AppFontPreference.init(rawValue:)) ?? .iosevkaCharon
         #if ENABLE_SYNTHETIC_PASTE
             autoPasteEnabled = defaults.object(forKey: autoPasteKey) as? Bool ?? false
         #endif
@@ -366,13 +375,13 @@ final class AppSettings: ObservableObject {
              "UICTContentSizeCategoryM", "UICTContentSizeCategoryL":
             1.0
         case "UICTContentSizeCategoryXL":
-            1.12  // 19/17
+            1.12 // 19/17
         case "UICTContentSizeCategoryXXL":
-            1.24  // 21/17
+            1.24 // 21/17
         case "UICTContentSizeCategoryXXXL":
-            1.35  // 23/17
+            1.35 // 23/17
         default:
-            1.5   // a11y M and above
+            1.5 // a11y M and above
         }
         return min(scale, 1.5)
     }
@@ -388,6 +397,7 @@ final class AppSettings: ObservableObject {
         }
         defaults.set(maxDatabaseSizeGB, forKey: maxDbSizeKey)
         defaults.set(launchAtLoginEnabled, forKey: launchAtLoginKey)
+        defaults.set(fontPreference.rawValue, forKey: fontPreferenceKey)
         #if ENABLE_SYNTHETIC_PASTE
             defaults.set(autoPasteEnabled, forKey: autoPasteKey)
         #endif

--- a/Sources/MacApp/Settings/GeneralSettingsView.swift
+++ b/Sources/MacApp/Settings/GeneralSettingsView.swift
@@ -5,8 +5,8 @@ import ClipKittyShared
 #if ENABLE_ICLOUD_SYNC
     import CloudKit
 #endif
-import SwiftUI
 import OSLog
+import SwiftUI
 
 struct GeneralSettingsView: View {
     @ObservedObject private var settings = AppSettings.shared
@@ -80,12 +80,21 @@ struct GeneralSettingsView: View {
                 }
             }
 
-
             #if ENABLE_SYNTHETIC_PASTE
                 Section(String(localized: "Paste Items")) {
                     PasteItemsSettingView()
                 }
             #endif
+
+            Section(String(localized: "Appearance")) {
+                Picker(String(localized: "Font"), selection: $settings.fontPreference) {
+                    ForEach(AppFontPreference.allCases) { preference in
+                        Text(fontPreferenceLabel(preference))
+                            .tag(preference)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
 
             #if ENABLE_ICLOUD_SYNC
                 Section(String(localized: "iCloud Sync")) {
@@ -183,7 +192,7 @@ struct GeneralSettingsView: View {
                                 }
                                 .buttonStyle(.borderedProminent)
                             }
-                        case .checkFailed(let errorMessage):
+                        case let .checkFailed(errorMessage):
                             VStack(alignment: .trailing, spacing: 6) {
                                 Label(
                                     String(localized: "Update check failed"),
@@ -354,6 +363,15 @@ struct GeneralSettingsView: View {
         String(localized: "\(settings.maxDatabaseSizeGB, specifier: "%.1f") GB")
     }
 
+    private func fontPreferenceLabel(_ preference: AppFontPreference) -> String {
+        switch preference {
+        case .iosevkaCharon:
+            return String(localized: "Iosevka Charon")
+        case .system:
+            return String(localized: "System")
+        }
+    }
+
     private func sliderValue(for gb: Double) -> Double {
         let clamped = min(max(gb, minDatabaseSizeGB), maxDatabaseSizeGB)
         let ratio = maxDatabaseSizeGB / minDatabaseSizeGB
@@ -381,7 +399,7 @@ struct GeneralSettingsView: View {
                     Image(systemName: "icloud").foregroundStyle(.secondary)
                 case .connecting:
                     ProgressView().controlSize(.small)
-                case .syncing(_):
+                case .syncing:
                     ProgressView().controlSize(.small)
                 case .synced:
                     Image(systemName: "checkmark.icloud").foregroundStyle(.green)
@@ -500,27 +518,27 @@ struct GeneralSettingsView: View {
     }
 
     #if ENABLE_BUILD_ATTESTATION_LINK
-    private func checkAttestation() async {
-        guard let hash = binaryHash else { return }
-        let rekorURL = URL(string: "https://rekor.sigstore.dev/api/v1/index/retrieve")!
+        private func checkAttestation() async {
+            guard let hash = binaryHash else { return }
+            let rekorURL = URL(string: "https://rekor.sigstore.dev/api/v1/index/retrieve")!
 
-        var request = URLRequest(url: rekorURL)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = "{\"hash\":\"sha256:\(hash)\"}".data(using: .utf8)
+            var request = URLRequest(url: rekorURL)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = "{\"hash\":\"sha256:\(hash)\"}".data(using: .utf8)
 
-        do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200
-            else { return }
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200
+                else { return }
 
-            let entries = try JSONDecoder().decode([String].self, from: data)
-            if !entries.isEmpty {
-                attestationURL = URL(string: "https://search.sigstore.dev/?hash=sha256:\(hash)")
+                let entries = try JSONDecoder().decode([String].self, from: data)
+                if !entries.isEmpty {
+                    attestationURL = URL(string: "https://search.sigstore.dev/?hash=sha256:\(hash)")
+                }
+            } catch {
+                // No attestation available
             }
-        } catch {
-            // No attestation available
         }
-    }
     #endif
 }

--- a/Sources/MacPlatform/FontManager.swift
+++ b/Sources/MacPlatform/FontManager.swift
@@ -2,21 +2,56 @@ import AppKit
 import CoreText
 import Foundation
 
+public enum AppFontPreference: String, CaseIterable, Identifiable {
+    case iosevkaCharon
+    case system
+
+    public var id: String {
+        rawValue
+    }
+}
+
 public enum FontManager {
-    // Preferred custom fonts with system fallbacks.
-    // Use PostScript names so registered fonts resolve reliably.
+    /// Preferred custom fonts with system fallbacks.
+    /// Use PostScript names so registered fonts resolve reliably.
     public static var sansSerif: String {
-        let name = "IosevkaCharon-Regular"
-        return fontAvailable(name) ? name : NSFont.systemFont(ofSize: 0).fontName
+        sansSerifName(for: .iosevkaCharon)
     }
 
     public static var mono: String {
-        let name = "IosevkaCharonMono-Regular"
-        return fontAvailable(name) ? name : NSFont.monospacedSystemFont(ofSize: 0, weight: .regular).fontName
+        monoName(for: .iosevkaCharon)
+    }
+
+    public static func sansSerifName(for preference: AppFontPreference) -> String {
+        switch preference {
+        case .iosevkaCharon:
+            let name = "IosevkaCharon-Regular"
+            return fontAvailable(name) ? name : systemSansSerifName
+        case .system:
+            return systemSansSerifName
+        }
+    }
+
+    public static func monoName(for preference: AppFontPreference) -> String {
+        switch preference {
+        case .iosevkaCharon:
+            let name = "IosevkaCharonMono-Regular"
+            return fontAvailable(name) ? name : systemMonospaceName
+        case .system:
+            return systemMonospaceName
+        }
     }
 
     private static func fontAvailable(_ name: String) -> Bool {
         NSFont(name: name, size: 12) != nil
+    }
+
+    private static var systemSansSerifName: String {
+        NSFont.systemFont(ofSize: 12).fontName
+    }
+
+    private static var systemMonospaceName: String {
+        NSFont.monospacedSystemFont(ofSize: 12, weight: .regular).fontName
     }
 
     public static func registerFonts() {


### PR DESCRIPTION
## Summary
- add a General settings Appearance picker for Iosevka Charon vs System fonts
- persist the font preference in AppSettings and resolve preview/list fonts from it
- keep preview text monospaced in System mode while using the normal system font in the list/search/other browser UI

Follow-up to #397.

## Verification
- xcodebuild -workspace ClipKitty.xcworkspace -scheme ClipKitty -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
- make check