### PR TITLE
[codex] Add preview font appearance setting

### DIFF
--- a/Sources/MacApp/AppFont.swift
+++ b/Sources/MacApp/AppFont.swift
@@ -1,8 +1,22 @@
 import ClipKittyMacPlatform
 import SwiftUI
 
+enum AppFontMetrics {
+    private static let systemScale: CGFloat = 0.94
+
+    static func size(_ size: CGFloat, for preference: AppFontPreference) -> CGFloat {
+        switch preference {
+        case .iosevkaCharon:
+            return size
+        case .system:
+            return size * systemScale
+        }
+    }
+}
+
 extension AppSettings {
     func appFont(size: CGFloat, weight: Font.Weight? = nil) -> Font {
+        let size = AppFontMetrics.size(size, for: fontPreference)
         let font: Font = switch fontPreference {
         case .iosevkaCharon:
             .custom(FontManager.sansSerifName(for: .iosevkaCharon), size: size)
@@ -13,17 +27,37 @@ extension AppSettings {
     }
 
     func previewFont(size: CGFloat, weight: Font.Weight? = nil) -> Font {
-        let font: Font = switch fontPreference {
-        case .iosevkaCharon:
-            .custom(FontManager.monoName(for: .iosevkaCharon), size: size)
-        case .system:
-            .system(size: size, design: .monospaced)
+        let size = previewFontSize(size)
+        let font: Font = switch previewFontPreference {
+        case .coding:
+            switch fontPreference {
+            case .iosevkaCharon:
+                .custom(FontManager.monoName(for: .iosevkaCharon), size: size)
+            case .system:
+                .system(size: size, design: .monospaced)
+            }
+        case .proportional:
+            switch fontPreference {
+            case .iosevkaCharon:
+                .custom(FontManager.sansSerifName(for: .iosevkaCharon), size: size)
+            case .system:
+                .system(size: size)
+            }
         }
         return font.withWeight(weight)
     }
 
+    func previewFontSize(_ size: CGFloat) -> CGFloat {
+        AppFontMetrics.size(size, for: fontPreference)
+    }
+
     var previewFontName: String {
-        FontManager.monoName(for: fontPreference)
+        switch previewFontPreference {
+        case .coding:
+            return FontManager.monoName(for: fontPreference)
+        case .proportional:
+            return FontManager.sansSerifName(for: fontPreference)
+        }
     }
 }
 

--- a/Sources/MacApp/Browser/BrowserPreviewPane.swift
+++ b/Sources/MacApp/Browser/BrowserPreviewPane.swift
@@ -87,7 +87,7 @@ struct BrowserPreviewPane: View {
             TextPreviewView(
                 itemId: item.itemMetadata.itemId,
                 fontName: settings.previewFontName,
-                fontSize: settings.scaled(15),
+                fontSize: settings.previewFontSize(settings.scaled(15)),
                 highlights: decoration?.highlights ?? [],
                 initialScrollHighlightIndex: decoration?.initialScrollHighlightIndex,
                 scrollBehavior: {

--- a/Sources/MacApp/Browser/BrowserRenderingSupport.swift
+++ b/Sources/MacApp/Browser/BrowserRenderingSupport.swift
@@ -328,7 +328,7 @@ struct FilePreviewView: View {
             TextPreviewView(
                 itemId: previewId,
                 fontName: settings.previewFontName,
-                fontSize: 12,
+                fontSize: settings.previewFontSize(12),
                 highlights: highlights,
                 scrollBehavior: .autoScroll,
                 interaction: .readOnly
@@ -823,16 +823,22 @@ struct TextPreviewView: NSViewRepresentable {
         let textChanged = itemChanged ? true : textView.string != (TextPreviewView.textCache[itemId] ?? "")
         let highlightsChanged = coordinator.lastHighlights != highlights
         let contentWidthChanged = abs(coordinator.lastContentWidth - containerWidth) > 0.5
+        let fontChanged = coordinator.lastFontName != fontName
+        let fontSizeChanged = abs(coordinator.lastFontSize - fontSize) > 0.01
         let gainedHighlights = !highlights.isEmpty && coordinator.lastHighlights.isEmpty
 
-        guard itemChanged || textChanged || highlightsChanged || contentWidthChanged else { return }
+        guard itemChanged || textChanged || highlightsChanged || contentWidthChanged || fontChanged || fontSizeChanged else {
+            return
+        }
         coordinator.lastContentWidth = containerWidth
-        if itemChanged || textChanged || contentWidthChanged || gainedHighlights {
+        coordinator.lastFontName = fontName
+        coordinator.lastFontSize = fontSize
+        if itemChanged || textChanged || contentWidthChanged || fontChanged || fontSizeChanged || gainedHighlights {
             coordinator.needsGeometrySync = true
         }
 
         let scaledSize: CGFloat
-        if itemChanged || textChanged || contentWidthChanged {
+        if itemChanged || textChanged || contentWidthChanged || fontChanged || fontSizeChanged {
             scaledSize = scaledFontSize(containerWidth: containerWidth)
             coordinator.lastScaledFontSize = scaledSize
         } else {
@@ -863,14 +869,18 @@ struct TextPreviewView: NSViewRepresentable {
 
         let previousMatchRanges = coordinator.currentMatchRanges
         let tlm = textView.textLayoutManager
-        if let tlm, itemChanged || textChanged || highlightsChanged, !previousMatchRanges.isEmpty {
+        if let tlm,
+           itemChanged || textChanged || highlightsChanged || fontChanged || fontSizeChanged,
+           !previousMatchRanges.isEmpty
+        {
             clearHighlightRenderingAttributes(matchRanges: previousMatchRanges, from: tlm)
         }
 
         // Reset the text view's attributed content when the highlight set changes for the
         // same item. This reuses the same preview view but gives TextKit a clean baseline
         // for the new overlay, which is much lighter than a full item reset.
-        let shouldUpdateText = itemChanged || (!coordinator.isEditing && (textChanged || highlightsChanged))
+        let shouldUpdateText = itemChanged ||
+            (!coordinator.isEditing && (textChanged || highlightsChanged || fontChanged || fontSizeChanged))
         if shouldUpdateText {
             let text = TextPreviewView.textCache[itemId] ?? ""
             // Text content changed — replace storage attributes (font, color, paragraph style only).
@@ -894,7 +904,7 @@ struct TextPreviewView: NSViewRepresentable {
             }
         }
 
-        if itemChanged || textChanged || highlightsChanged {
+        if itemChanged || textChanged || highlightsChanged || fontChanged || fontSizeChanged {
             // Convert highlights to NSTextRanges for the layout manager
             let newMatchRanges = resolveTextRanges(highlights: highlights, text: text, layoutManager: tlm)
 
@@ -1264,6 +1274,8 @@ struct TextPreviewView: NSViewRepresentable {
         var currentMatchRanges: [MatchRange] = []
         var scrollGeneration: Int = 0
         var lastContentWidth: CGFloat = 0
+        var lastFontName: String?
+        var lastFontSize: CGFloat = 0
         var lastScaledFontSize: CGFloat?
         var lastUsageBounds: CGRect = .zero
         var needsGeometrySync: Bool = false
@@ -1906,11 +1918,12 @@ struct HighlightedTextView: View, Equatable {
     }
 
     private var font: Font {
+        let size = AppFontMetrics.size(15 * textScale, for: fontPreference)
         switch fontPreference {
         case .iosevkaCharon:
-            return .custom(FontManager.sansSerifName(for: .iosevkaCharon), size: 15 * textScale)
+            return .custom(FontManager.sansSerifName(for: .iosevkaCharon), size: size)
         case .system:
-            return .system(size: 15 * textScale)
+            return .system(size: size)
         }
     }
 

--- a/Sources/MacApp/Resources/Localizable.xcstrings
+++ b/Sources/MacApp/Resources/Localizable.xcstrings
@@ -368,6 +368,21 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "字體" } }
       }
     },
+    "Preview Font": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Preview Font" } }
+      }
+    },
+    "Coding": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Coding" } }
+      }
+    },
+    "Proportional": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Proportional" } }
+      }
+    },
     "Iosevka Charon": {
       "localizations": {
         "de": { "stringUnit": { "state": "translated", "value": "Iosevka Charon" } },

--- a/Sources/MacApp/Settings.swift
+++ b/Sources/MacApp/Settings.swift
@@ -174,6 +174,10 @@ final class AppSettings: ObservableObject {
         didSet { save() }
     }
 
+    @Published var previewFontPreference: PreviewFontPreference {
+        didSet { save() }
+    }
+
     // MARK: - Privacy Settings
 
     /// Whether to ignore confidential/sensitive content (passwords from password managers)
@@ -238,6 +242,7 @@ final class AppSettings: ObservableObject {
     private let maxDbSizeKey = "maxDatabaseSizeGB"
     private let launchAtLoginKey = "launchAtLogin"
     private let fontPreferenceKey = "fontPreference"
+    private let previewFontPreferenceKey = "previewFontPreference"
     #if ENABLE_SYNTHETIC_PASTE
         private let autoPasteKey = "autoPasteEnabled"
     #endif
@@ -293,6 +298,8 @@ final class AppSettings: ObservableObject {
         launchAtLoginEnabled = defaults.bool(forKey: launchAtLoginKey)
         fontPreference = defaults.string(forKey: fontPreferenceKey)
             .flatMap(AppFontPreference.init(rawValue:)) ?? .iosevkaCharon
+        previewFontPreference = defaults.string(forKey: previewFontPreferenceKey)
+            .flatMap(PreviewFontPreference.init(rawValue:)) ?? .coding
         #if ENABLE_SYNTHETIC_PASTE
             autoPasteEnabled = defaults.object(forKey: autoPasteKey) as? Bool ?? false
         #endif
@@ -398,6 +405,7 @@ final class AppSettings: ObservableObject {
         defaults.set(maxDatabaseSizeGB, forKey: maxDbSizeKey)
         defaults.set(launchAtLoginEnabled, forKey: launchAtLoginKey)
         defaults.set(fontPreference.rawValue, forKey: fontPreferenceKey)
+        defaults.set(previewFontPreference.rawValue, forKey: previewFontPreferenceKey)
         #if ENABLE_SYNTHETIC_PASTE
             defaults.set(autoPasteEnabled, forKey: autoPasteKey)
         #endif

--- a/Sources/MacApp/Settings/GeneralSettingsView.swift
+++ b/Sources/MacApp/Settings/GeneralSettingsView.swift
@@ -94,6 +94,14 @@ struct GeneralSettingsView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+
+                Picker(String(localized: "Preview Font"), selection: $settings.previewFontPreference) {
+                    ForEach(PreviewFontPreference.allCases) { preference in
+                        Text(previewFontPreferenceLabel(preference))
+                            .tag(preference)
+                    }
+                }
+                .pickerStyle(.segmented)
             }
 
             #if ENABLE_ICLOUD_SYNC
@@ -369,6 +377,15 @@ struct GeneralSettingsView: View {
             return String(localized: "Iosevka Charon")
         case .system:
             return String(localized: "System")
+        }
+    }
+
+    private func previewFontPreferenceLabel(_ preference: PreviewFontPreference) -> String {
+        switch preference {
+        case .coding:
+            return String(localized: "Coding")
+        case .proportional:
+            return String(localized: "Proportional")
         }
     }
 

--- a/Sources/MacPlatform/FontManager.swift
+++ b/Sources/MacPlatform/FontManager.swift
@@ -11,6 +11,15 @@ public enum AppFontPreference: String, CaseIterable, Identifiable {
     }
 }
 
+public enum PreviewFontPreference: String, CaseIterable, Identifiable {
+    case coding
+    case proportional
+
+    public var id: String {
+        rawValue
+    }
+}
+
 public enum FontManager {
     /// Preferred custom fonts with system fallbacks.
     /// Use PostScript names so registered fonts resolve reliably.


### PR DESCRIPTION
## Summary
- Add an Appearance setting for preview font style with `Coding` and `Proportional` enum cases.
- Keep the default preview style as `Coding` / monospace.
- Apply the preview font choice to the main editable preview, link URL preview text, and file text previews.
- Render System fonts slightly smaller than Iosevka Charon across the Mac app font helpers and row preview text.

## Notes
- The preview renderer now tracks font name and font size changes so changing the setting updates the currently displayed preview without selecting a different item.

## Validation
- Started `xcodebuild build -workspace ClipKitty.xcworkspace -scheme ClipKitty -configuration Debug -destination 'platform=macOS,arch=arm64'`.
- Stopped the build before completion at user request to create this PR early.
- Commit hook reported SwiftLint was not available locally and skipped linting.