### PR TITLE
Add robust iOS background sync

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -838,7 +838,7 @@ let project = Project(
                 "ITSAppUsesNonExemptEncryption": false,
                 "LSApplicationCategoryType": "public.app-category.utilities",
                 "NSHumanReadableCopyright": "Copyright © 2025 ClipKitty. All rights reserved.",
-                "UIBackgroundModes": ["remote-notification"],
+                "UIBackgroundModes": ["fetch", "remote-notification"],
                 "UILaunchScreen": ["UIColorName": ""],
                 // Tuist's default iOS Info.plist declares UIRequiredDevice
                 // capabilities = [armv7]. This is an arm64-only iOS 26 app, so

--- a/Project.swift
+++ b/Project.swift
@@ -838,7 +838,11 @@ let project = Project(
                 "ITSAppUsesNonExemptEncryption": false,
                 "LSApplicationCategoryType": "public.app-category.utilities",
                 "NSHumanReadableCopyright": "Copyright © 2025 ClipKitty. All rights reserved.",
-                "UIBackgroundModes": ["fetch", "remote-notification"],
+                "BGTaskSchedulerPermittedIdentifiers": [
+                    "com.eviljuliette.clipkitty.sync.refresh",
+                    "com.eviljuliette.clipkitty.sync.processing",
+                ],
+                "UIBackgroundModes": ["fetch", "processing", "remote-notification"],
                 "UILaunchScreen": ["UIColorName": ""],
                 // Tuist's default iOS Info.plist declares UIRequiredDevice
                 // capabilities = [armv7]. This is an arm64-only iOS 26 app, so

--- a/Sources/AppleServices/SyncEngine.swift
+++ b/Sources/AppleServices/SyncEngine.swift
@@ -148,6 +148,7 @@
         private nonisolated static let blobBundleFieldName = "blobBundleAsset"
         /// Age threshold for CloudKit event cleanup (30 days).
         private nonisolated static let cloudCleanupAgeDays: UInt32 = 30
+        private nonisolated static let indexMaintenanceBatchLimit: UInt32 = 64
 
         @ObservationIgnored
         private let logger = Logger(subsystem: "com.clipkitty", category: "SyncEngine")
@@ -201,6 +202,11 @@
             case nothingToUpload
             case retryableFailure(reason: String)
             case permanentFailure(reason: String)
+        }
+
+        private enum IndexMaintenancePass {
+            case notNeeded
+            case needed(SyncIndexActivity)
         }
 
         /// Structured outcome of uploading snapshots to CloudKit.
@@ -288,7 +294,7 @@
                 case let .rebuildingIndex(indexActivity):
                     switch indexActivity {
                     case .localMaintenance:
-                        return String(localized: "Rebuilding index…")
+                        return String(localized: "Indexing…")
                     case .downloadedContent:
                         return String(localized: "Indexing iCloud…")
                     }
@@ -721,6 +727,29 @@
             }.value
         }
 
+        private func processQueuedIndexWork(activity: SyncIndexActivity) async {
+            markSyncing(.rebuildingIndex(activity))
+            do {
+                let outcome = try await performStoreOperation { store in
+                    try store.processIndexQueue(maxItems: Self.indexMaintenanceBatchLimit)
+                }
+                logIndexMaintenanceOutcome(outcome)
+            } catch {
+                logger.error("Queued index maintenance failed: \(error.localizedDescription)")
+            }
+        }
+
+        private func logIndexMaintenanceOutcome(_ outcome: IndexMaintenanceOutcome) {
+            switch outcome {
+            case let .completed(processed):
+                logger.info("Queued index maintenance completed after \(processed) items")
+            case let .moreRemaining(processed, remaining):
+                logger.info(
+                    "Queued index maintenance processed \(processed) items; \(remaining) remain"
+                )
+            }
+        }
+
         /// Single serial coordinator cycle: fetch → apply → compact → upload → cleanup.
         public func runCoordinatorCycle() async {
             do {
@@ -761,12 +790,8 @@
                 }
 
                 if deviceState.indexDirty {
-                    logger.info("Index dirty, rebuilding")
-                    markSyncing(.rebuildingIndex(.localMaintenance))
-                    try await performStoreOperation { store in
-                        try store.rebuildIndex()
-                        try store.clearIndexDirtyFlag()
-                    }
+                    logger.info("Index dirty, processing queued index work")
+                    await processQueuedIndexWork(activity: .localMaintenance)
                 }
 
                 // ── Phase 1: Fetch remote changes ──
@@ -807,6 +832,7 @@
                 }
 
                 // ── Phase 4: Token advancement (conditional on success) ──
+                let indexMaintenancePass: IndexMaintenancePass
                 switch batchOutcome {
                 case let .applied(eventsApplied, snapshotsApplied):
                     if let newToken = changes.newToken {
@@ -820,12 +846,18 @@
                     }
                     if eventsApplied > 0 || snapshotsApplied > 0 {
                         onContentChanged?()
+                        indexMaintenancePass = .needed(.downloadedContent(incrementalDownload))
+                    } else {
+                        indexMaintenancePass = .notNeeded
                     }
 
                 case let .partialFailure(appliedCount, _, _):
                     // Do NOT advance token — retry on next cycle.
                     if appliedCount > 0 {
                         onContentChanged?()
+                        indexMaintenancePass = .needed(.downloadedContent(incrementalDownload))
+                    } else {
+                        indexMaintenancePass = .notNeeded
                     }
                     logger.warning("Partial batch failure, not advancing token")
 
@@ -837,6 +869,13 @@
                         state.activity = .synced(lastSync: now())
                     }
                     return
+                }
+
+                switch indexMaintenancePass {
+                case .notNeeded:
+                    break
+                case let .needed(activity):
+                    await processQueuedIndexWork(activity: activity)
                 }
 
                 // ── Phase 5: Periodic compaction ──
@@ -1736,20 +1775,23 @@
                 )
             }
 
-            // 3. Rebuild Tantivy index and save the fresh zone token from the
-            // full feed so the next cycle resumes incrementally instead of
-            // replaying the whole zone again.
-            markSyncing(.rebuildingIndex(.downloadedContent(downloadActivity)))
+            // 3. Queue derived search-index repair and save the fresh zone token
+            // from the full feed so the next cycle resumes incrementally instead
+            // of replaying the whole zone again. Search indexing is durable,
+            // bounded, and resumable; it must not gate token advancement.
             let finalChangeToken = cloudRecords.finalChangeToken
             let deviceId = self.deviceId
-            try await performStoreOperation { store in
-                try store.rebuildIndex()
-                try store.clearIndexDirtyFlag()
+            let finalTokenData = try Self.archivedZoneChangeToken(finalChangeToken)
+            let queuedItems = try await performStoreOperation { store in
+                let queuedItems = try store.enqueueFullIndexRebuild()
                 try store.updateZoneChangeToken(
                     deviceId: deviceId,
-                    token: Self.archivedZoneChangeToken(finalChangeToken)
+                    token: finalTokenData
                 )
+                return queuedItems
             }
+            logger.info("Queued full-resync index maintenance for \(queuedItems) items")
+            await processQueuedIndexWork(activity: .downloadedContent(downloadActivity))
 
             // 4. Notify UI.
             onContentChanged?()

--- a/Sources/AppleServices/SyncEngine.swift
+++ b/Sources/AppleServices/SyncEngine.swift
@@ -375,6 +375,35 @@
             signalWake()
         }
 
+        /// Run a single sync cycle for an iOS background wake.
+        ///
+        /// When the normal coordinator loop is already active, a background wake
+        /// only needs to collapse the sleep interval. Otherwise this performs
+        /// the same coordinator cycle headlessly so a silent CloudKit push can
+        /// catch up before the user opens the app.
+        public func runBackgroundSyncCycle() async -> BackgroundSyncResult {
+            guard coordinatorTask == nil else {
+                signalWake()
+                return .completed
+            }
+
+            store.setSyncDeviceId(deviceId: deviceId)
+            await runCoordinatorCycle()
+
+            switch status {
+            case .synced, .syncing:
+                return .completed
+            case .unavailable:
+                return .unavailable
+            case let .error(message):
+                return .failed(message)
+            case .temporarilyUnavailable:
+                return .failed("iCloud temporarily unavailable")
+            case .idle, .connecting:
+                return .failed("iCloud sync did not complete")
+            }
+        }
+
         /// Mark a wake as pending and resume any waiting sleeper.
         private func signalWake() {
             pendingWake = true
@@ -394,6 +423,12 @@
             case error(String)
             case temporarilyUnavailable
             case unavailable
+        }
+
+        public enum BackgroundSyncResult: Equatable, Sendable {
+            case completed
+            case unavailable
+            case failed(String)
         }
 
         public var status: SyncStatus {

--- a/Sources/AppleServices/SyncEngine.swift
+++ b/Sources/AppleServices/SyncEngine.swift
@@ -78,6 +78,52 @@
         func deleteRecords(_ recordIDs: [CKRecord.ID]) async -> SyncRecordDeleteResult
     }
 
+    private final class StoreOperationTracker: @unchecked Sendable {
+        private let lock = NSLock()
+        private var activeOperationCount = 0
+        private var drainWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func begin() {
+            lock.lock()
+            activeOperationCount += 1
+            lock.unlock()
+        }
+
+        func finish() {
+            let waiters: [CheckedContinuation<Void, Never>]
+            lock.lock()
+            activeOperationCount -= 1
+            if activeOperationCount == 0 {
+                waiters = drainWaiters
+                drainWaiters.removeAll()
+            } else {
+                waiters = []
+            }
+            lock.unlock()
+
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+
+        func waitForDrain() async {
+            await withCheckedContinuation { continuation in
+                var shouldResumeImmediately = false
+                lock.lock()
+                if activeOperationCount == 0 {
+                    shouldResumeImmediately = true
+                } else {
+                    drainWaiters.append(continuation)
+                }
+                lock.unlock()
+
+                if shouldResumeImmediately {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
     /// Orchestrates iCloud sync via CloudKit using the Rust event-sourced core.
     ///
     /// Architecture:
@@ -127,6 +173,8 @@
 
         @ObservationIgnored
         private var coordinatorTask: Task<Void, Never>?
+        @ObservationIgnored
+        private let storeOperationTracker = StoreOperationTracker()
         @ObservationIgnored
         private var accountChangeObserver: NSObjectProtocol?
         @ObservationIgnored
@@ -367,6 +415,31 @@
             removeAccountChangeObserver()
             engineState = .idle(maintenanceState())
             logger.info("SyncEngine stopped")
+        }
+
+        /// Stop the coordinator and wait until any synchronous Rust store work
+        /// has fully drained before allowing iOS to suspend the process.
+        public func prepareForSuspend() async {
+            let task = coordinatorTask
+            coordinatorTask = nil
+            task?.cancel()
+            signalWake()
+            removeAccountChangeObserver()
+            engineState = .idle(maintenanceState())
+
+            await task?.value
+            await storeOperationTracker.waitForDrain()
+
+            guard !Task.isCancelled else {
+                logger.info("SyncEngine suspend preparation cancelled before store flush")
+                return
+            }
+
+            let store = self.store
+            await Task.detached(priority: .utility) {
+                store.prepareForSuspend()
+            }.value
+            logger.info("SyncEngine prepared for suspend")
         }
 
         /// Signal the coordinator to wake up immediately (e.g. from push notification).
@@ -640,8 +713,11 @@
             _ body: @escaping @Sendable (ClipKittyRust.ClipboardStore) throws -> T
         ) async throws -> T {
             let store = self.store
+            let tracker = storeOperationTracker
+            tracker.begin()
             return try await Task.detached(priority: priority) {
-                try body(store)
+                defer { tracker.finish() }
+                return try body(store)
             }.value
         }
 

--- a/Sources/iOSApp/App/AppContainer.swift
+++ b/Sources/iOSApp/App/AppContainer.swift
@@ -3,11 +3,14 @@ import ClipKittyRust
 import ClipKittyShared
 import ClipKittyShortcuts
 import Foundation
+import os
 
 /// Owns all app-scoped services for the current foreground session.
 @MainActor
 @Observable
 final class AppContainer {
+    private static let logger = Logger(subsystem: "com.clipkitty", category: "iOSBootstrap")
+
     let store: ClipKittyRust.ClipboardStore
     let repository: ClipboardRepository
     let previewLoader: PreviewLoader
@@ -70,12 +73,38 @@ final class AppContainer {
             return .failure(.databaseOpenFailed(error.localizedDescription))
         }
 
-        if plan == .rebuildIndex {
-            do {
-                try store.rebuildIndex()
-            } catch {
-                return .failure(.databaseOpenFailed("Index rebuild failed: \(error.localizedDescription)"))
-            }
+        switch plan {
+        case .ready:
+            break
+        case .rebuildIndex:
+            #if ENABLE_ICLOUD_SYNC
+                do {
+                    switch try iOSIndexMaintenance.queueBootstrapRepairIfNeeded(
+                        plan: plan,
+                        store: store
+                    ) {
+                    case .notNeeded:
+                        break
+                    case let .queued(itemCount):
+                        logger.info("Queued bootstrap index repair for \(itemCount) items")
+                    }
+
+                    do {
+                        let outcome = try iOSIndexMaintenance.processQueuedBatch(store: store)
+                        logIndexMaintenanceOutcome(outcome, context: "bootstrap")
+                    } catch {
+                        logger.error("Bootstrap index maintenance failed: \(error.localizedDescription)")
+                    }
+                } catch {
+                    return .failure(.databaseOpenFailed("Index repair queue failed: \(error.localizedDescription)"))
+                }
+            #else
+                do {
+                    try store.rebuildIndex()
+                } catch {
+                    return .failure(.databaseOpenFailed("Index rebuild failed: \(error.localizedDescription)"))
+                }
+            #endif
         }
 
         let repository = ClipboardRepository(store: store)
@@ -120,5 +149,21 @@ final class AppContainer {
     func prepareForSuspension() {
         store.prepareForSuspend()
     }
+
+    #if ENABLE_ICLOUD_SYNC
+        private static func logIndexMaintenanceOutcome(
+            _ outcome: IndexMaintenanceOutcome,
+            context: String
+        ) {
+            switch outcome {
+            case let .completed(processed):
+                logger.info("\(context) index maintenance completed after \(processed) items")
+            case let .moreRemaining(processed, remaining):
+                logger.info(
+                    "\(context) index maintenance processed \(processed) items; \(remaining) remain"
+                )
+            }
+        }
+    #endif
 
 }

--- a/Sources/iOSApp/App/iOSIndexMaintenance.swift
+++ b/Sources/iOSApp/App/iOSIndexMaintenance.swift
@@ -1,0 +1,33 @@
+#if ENABLE_ICLOUD_SYNC
+
+    import ClipKittyRust
+
+    enum iOSIndexBootstrapRepairPlan: Equatable {
+        case notNeeded
+        case queued(itemCount: UInt64)
+    }
+
+    enum iOSIndexMaintenance {
+        static let batchLimit: UInt32 = 64
+
+        static func queueBootstrapRepairIfNeeded(
+            plan: StoreBootstrapPlan,
+            store: ClipKittyRust.ClipboardStore
+        ) throws -> iOSIndexBootstrapRepairPlan {
+            switch plan {
+            case .ready:
+                return .notNeeded
+            case .rebuildIndex:
+                let itemCount = try store.enqueueFullIndexRebuild()
+                return .queued(itemCount: itemCount)
+            }
+        }
+
+        static func processQueuedBatch(
+            store: ClipKittyRust.ClipboardStore
+        ) throws -> IndexMaintenanceOutcome {
+            try store.processIndexQueue(maxItems: batchLimit)
+        }
+    }
+
+#endif

--- a/Sources/iOSApp/App/iOSSyncCoordinator.swift
+++ b/Sources/iOSApp/App/iOSSyncCoordinator.swift
@@ -1,5 +1,6 @@
 #if ENABLE_ICLOUD_SYNC
 
+    import BackgroundTasks
     import ClipKittyAppleServices
     import ClipKittyRust
     import ClipKittyShared
@@ -44,6 +45,8 @@
         private let engineFactory: (ClipKittyRust.ClipboardStore) -> any SyncEngineProtocol
         @ObservationIgnored
         private let registerForRemoteNotifications: () -> Void
+        @ObservationIgnored
+        private let scheduleBackgroundSync: () -> Void
 
         var status: SyncEngine.SyncStatus {
             switch runtime {
@@ -66,6 +69,9 @@
                 engineFactory: { SyncEngine(store: $0) },
                 registerForRemoteNotifications: {
                     iOSRemoteNotificationBridge.shared.registerForRemoteNotifications()
+                },
+                scheduleBackgroundSync: {
+                    iOSBackgroundSyncScheduler.shared.scheduleAll()
                 }
             )
         }
@@ -75,16 +81,19 @@
             enabled: Bool,
             onContentChanged: @escaping () -> Void,
             engineFactory: @escaping (ClipKittyRust.ClipboardStore) -> any SyncEngineProtocol,
-            registerForRemoteNotifications: @escaping () -> Void = {}
+            registerForRemoteNotifications: @escaping () -> Void = {},
+            scheduleBackgroundSync: @escaping () -> Void = {}
         ) {
             self.onContentChanged = onContentChanged
             self.engineFactory = engineFactory
             self.registerForRemoteNotifications = registerForRemoteNotifications
+            self.scheduleBackgroundSync = scheduleBackgroundSync
             if enabled {
                 let engine = engineFactory(store)
                 engine.onContentChanged = onContentChanged
                 runtime = .enabled(store: store, engine: engine)
                 registerForRemoteNotifications()
+                scheduleBackgroundSync()
             } else {
                 runtime = .disabled(store: store)
             }
@@ -98,6 +107,7 @@
                 engine.onContentChanged = onContentChanged
                 runtime = .enabled(store: store, engine: engine)
                 registerForRemoteNotifications()
+                scheduleBackgroundSync()
                 engine.start()
 
             case let .enabled(store, engine):
@@ -116,6 +126,7 @@
                 case .active:
                     engine.start()
                 case .background:
+                    scheduleBackgroundSync()
                     engine.stop()
                 case .inactive:
                     break
@@ -130,6 +141,7 @@
             case .disabled:
                 break
             case let .enabled(_, engine):
+                scheduleBackgroundSync()
                 engine.start()
                 engine.handleRemoteNotification()
             }
@@ -140,6 +152,7 @@
             case .disabled:
                 break
             case let .enabled(_, engine):
+                scheduleBackgroundSync()
                 await engine.prepareForSuspend()
             }
         }
@@ -182,27 +195,65 @@
         static let shared = iOSBackgroundSyncRunner()
 
         private let logger = Logger(subsystem: "com.clipkitty", category: "SyncBackground")
-        private var inFlightSync: Task<UIBackgroundFetchResult, Never>?
+        private enum InFlightSync {
+            case none
+            case running(id: UUID, task: Task<UIBackgroundFetchResult, Never>)
+        }
+
+        private var inFlightSync: InFlightSync = .none
 
         private init() {}
 
         func performRemoteNotificationSync() async -> UIBackgroundFetchResult {
-            if let inFlightSync {
-                return await inFlightSync.value
+            await performSync(named: "ClipKitty iCloud Sync")
+        }
+
+        func performScheduledSync() async -> UIBackgroundFetchResult {
+            await performSync(named: "ClipKitty Scheduled iCloud Sync")
+        }
+
+        func cancelInFlightSync() {
+            switch inFlightSync {
+            case .none:
+                break
+            case let .running(_, task):
+                task.cancel()
+                inFlightSync = .none
+            }
+        }
+
+        private func performSync(named name: String) async -> UIBackgroundFetchResult {
+            switch inFlightSync {
+            case .none:
+                break
+            case let .running(_, task):
+                return await task.value
             }
 
+            let syncID = UUID()
             let task = Task { @MainActor in
-                await iOSBackgroundTaskRunner.run(named: "ClipKitty iCloud Sync") {
+                await iOSBackgroundTaskRunner.run(named: name) {
                     await self.runHeadlessSyncIfEnabled()
                 }
             }
-            inFlightSync = task
+            inFlightSync = .running(id: syncID, task: task)
             let result = await task.value
-            inFlightSync = nil
+            switch inFlightSync {
+            case .none:
+                break
+            case let .running(id, _) where id == syncID:
+                inFlightSync = .none
+            case .running:
+                break
+            }
             return result
         }
 
         private func runHeadlessSyncIfEnabled() async -> UIBackgroundFetchResult {
+            if Task.isCancelled {
+                return .failed
+            }
+
             guard iOSSettingsStore().syncEnabled else {
                 logger.debug("Skipping background sync because iCloud sync is disabled")
                 return .noData
@@ -215,9 +266,24 @@
                 let store = try ClipKittyRust.ClipboardStore(dbPath: dbPath)
                 defer { store.prepareForSuspend() }
 
-                if plan == .rebuildIndex {
-                    logger.info("Rebuilding index before background sync")
-                    try store.rebuildIndex()
+                switch try iOSIndexMaintenance.queueBootstrapRepairIfNeeded(
+                    plan: plan,
+                    store: store
+                ) {
+                case .notNeeded:
+                    break
+                case let .queued(itemCount):
+                    logger.info("Queued background index repair for \(itemCount) items")
+                    do {
+                        let outcome = try iOSIndexMaintenance.processQueuedBatch(store: store)
+                        logIndexMaintenanceOutcome(outcome)
+                    } catch {
+                        logger.error("Background index maintenance failed: \(error.localizedDescription)")
+                    }
+                }
+
+                if Task.isCancelled {
+                    return .failed
                 }
 
                 var contentChanged = false
@@ -241,6 +307,119 @@
             } catch {
                 logger.error("Background sync bootstrap failed: \(error.localizedDescription)")
                 return .failed
+            }
+        }
+
+        private func logIndexMaintenanceOutcome(_ outcome: IndexMaintenanceOutcome) {
+            switch outcome {
+            case let .completed(processed):
+                logger.info("Background index maintenance completed after \(processed) items")
+            case let .moreRemaining(processed, remaining):
+                logger.info(
+                    "Background index maintenance processed \(processed) items; \(remaining) remain"
+                )
+            }
+        }
+    }
+
+    enum iOSBackgroundSyncTaskKind: CaseIterable {
+        case appRefresh
+        case processing
+
+        var identifier: String {
+            switch self {
+            case .appRefresh:
+                return "com.eviljuliette.clipkitty.sync.refresh"
+            case .processing:
+                return "com.eviljuliette.clipkitty.sync.processing"
+            }
+        }
+    }
+
+    @MainActor
+    final class iOSBackgroundSyncScheduler {
+        static let shared = iOSBackgroundSyncScheduler()
+
+        private let logger = Logger(subsystem: "com.clipkitty", category: "SyncBackground")
+        private var registeredKinds: Set<iOSBackgroundSyncTaskKind> = []
+
+        private init() {}
+
+        func register() {
+            for kind in iOSBackgroundSyncTaskKind.allCases {
+                register(kind: kind)
+            }
+        }
+
+        func scheduleAll() {
+            for kind in iOSBackgroundSyncTaskKind.allCases {
+                schedule(kind: kind)
+            }
+        }
+
+        func schedule(kind: iOSBackgroundSyncTaskKind) {
+            let request: BGTaskRequest
+            switch kind {
+            case .appRefresh:
+                let refresh = BGAppRefreshTaskRequest(identifier: kind.identifier)
+                refresh.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60)
+                request = refresh
+            case .processing:
+                let processing = BGProcessingTaskRequest(identifier: kind.identifier)
+                processing.requiresNetworkConnectivity = true
+                processing.requiresExternalPower = false
+                processing.earliestBeginDate = Date(timeIntervalSinceNow: 5 * 60)
+                request = processing
+            }
+
+            do {
+                try BGTaskScheduler.shared.submit(request)
+                logger.debug("Scheduled background sync task \(kind.identifier)")
+            } catch {
+                logger.error("Failed to schedule background sync task \(kind.identifier): \(error.localizedDescription)")
+            }
+        }
+
+        private func register(kind: iOSBackgroundSyncTaskKind) {
+            guard !registeredKinds.contains(kind) else { return }
+
+            let accepted = BGTaskScheduler.shared.register(
+                forTaskWithIdentifier: kind.identifier,
+                using: nil
+            ) { task in
+                Task { @MainActor in
+                    self.handle(task: task, kind: kind)
+                }
+            }
+
+            if accepted {
+                registeredKinds.insert(kind)
+                logger.debug("Registered background sync task \(kind.identifier)")
+            } else {
+                logger.error("Failed to register background sync task \(kind.identifier)")
+            }
+        }
+
+        private func handle(task: BGTask, kind: iOSBackgroundSyncTaskKind) {
+            schedule(kind: kind)
+
+            let operation = Task { @MainActor in
+                let result = await iOSBackgroundSyncRunner.shared.performScheduledSync()
+                switch result {
+                case .newData, .noData:
+                    task.setTaskCompleted(success: true)
+                case .failed:
+                    task.setTaskCompleted(success: false)
+                @unknown default:
+                    task.setTaskCompleted(success: false)
+                }
+            }
+
+            task.expirationHandler = {
+                operation.cancel()
+                Task { @MainActor in
+                    iOSBackgroundSyncRunner.shared.cancelInFlightSync()
+                }
             }
         }
     }
@@ -269,15 +448,35 @@
         }
 
         func handleRemoteNotification() async -> UIBackgroundFetchResult {
+            iOSBackgroundSyncScheduler.shared.schedule(kind: .processing)
+
             if let coordinator {
                 let result = await coordinator.performRemoteNotificationSync()
-                return result.backgroundFetchResult
+                let fetchResult = result.backgroundFetchResult
+                switch fetchResult {
+                case .newData, .noData:
+                    iOSBackgroundSyncScheduler.shared.schedule(kind: .appRefresh)
+                case .failed:
+                    pendingRemoteNotification = true
+                    iOSBackgroundSyncScheduler.shared.schedule(kind: .processing)
+                @unknown default:
+                    pendingRemoteNotification = true
+                    iOSBackgroundSyncScheduler.shared.schedule(kind: .processing)
+                }
+                return fetchResult
             }
 
             logger.info("Handling remote sync notification with headless background sync")
             let result = await iOSBackgroundSyncRunner.shared.performRemoteNotificationSync()
-            if result == .failed {
+            switch result {
+            case .newData, .noData:
+                iOSBackgroundSyncScheduler.shared.schedule(kind: .appRefresh)
+            case .failed:
                 pendingRemoteNotification = true
+                iOSBackgroundSyncScheduler.shared.schedule(kind: .processing)
+            @unknown default:
+                pendingRemoteNotification = true
+                iOSBackgroundSyncScheduler.shared.schedule(kind: .processing)
             }
             return result
         }
@@ -291,7 +490,16 @@
         }
     }
 
+    @MainActor
     final class iOSAppDelegate: NSObject, UIApplicationDelegate {
+        func application(
+            _: UIApplication,
+            didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
+        ) -> Bool {
+            iOSBackgroundSyncScheduler.shared.register()
+            return true
+        }
+
         func application(
             _: UIApplication,
             didRegisterForRemoteNotificationsWithDeviceToken _: Data

--- a/Sources/iOSApp/App/iOSSyncCoordinator.swift
+++ b/Sources/iOSApp/App/iOSSyncCoordinator.swift
@@ -16,6 +16,7 @@
         var status: SyncEngine.SyncStatus { get }
         func start()
         func stop()
+        func prepareForSuspend() async
         func handleRemoteNotification()
         func runBackgroundSyncCycle() async -> SyncEngine.BackgroundSyncResult
     }
@@ -114,8 +115,10 @@
                 switch phase {
                 case .active:
                     engine.start()
-                case .background, .inactive:
+                case .background:
                     engine.stop()
+                case .inactive:
+                    break
                 @unknown default:
                     break
                 }
@@ -132,6 +135,15 @@
             }
         }
 
+        func prepareForSuspension() async {
+            switch runtime {
+            case .disabled:
+                break
+            case let .enabled(_, engine):
+                await engine.prepareForSuspend()
+            }
+        }
+
         func performRemoteNotificationSync() async -> SyncEngine.BackgroundSyncResult {
             switch runtime {
             case .disabled:
@@ -145,11 +157,31 @@
     // MARK: - Background Sync
 
     @MainActor
+    enum iOSBackgroundTaskRunner {
+        static func run<Result>(
+            named name: String,
+            operation: @escaping @MainActor () async -> Result
+        ) async -> Result {
+            let operationTask = Task { @MainActor in
+                await operation()
+            }
+            let backgroundTask = UIApplication.shared.beginBackgroundTask(withName: name) {
+                operationTask.cancel()
+            }
+
+            let result = await operationTask.value
+            if backgroundTask != .invalid {
+                UIApplication.shared.endBackgroundTask(backgroundTask)
+            }
+            return result
+        }
+    }
+
+    @MainActor
     final class iOSBackgroundSyncRunner {
         static let shared = iOSBackgroundSyncRunner()
 
         private let logger = Logger(subsystem: "com.clipkitty", category: "SyncBackground")
-        private let timeout: TimeInterval = 25
         private var inFlightSync: Task<UIBackgroundFetchResult, Never>?
 
         private init() {}
@@ -160,7 +192,7 @@
             }
 
             let task = Task { @MainActor in
-                await self.withTimeout {
+                await iOSBackgroundTaskRunner.run(named: "ClipKitty iCloud Sync") {
                     await self.runHeadlessSyncIfEnabled()
                 }
             }
@@ -210,42 +242,6 @@
                 logger.error("Background sync bootstrap failed: \(error.localizedDescription)")
                 return .failed
             }
-        }
-
-        private func withTimeout(
-            operation: @escaping @MainActor () async -> UIBackgroundFetchResult
-        ) async -> UIBackgroundFetchResult {
-            await withCheckedContinuation { continuation in
-                let completion = BackgroundFetchCompletion(continuation)
-                let timeout = self.timeout
-                let operationTask = Task { @MainActor in
-                    let result = await operation()
-                    completion.resume(returning: result)
-                }
-                Task {
-                    try? await Task.sleep(for: .seconds(timeout))
-                    operationTask.cancel()
-                    completion.resume(returning: .failed)
-                }
-            }
-        }
-    }
-
-    private final class BackgroundFetchCompletion: @unchecked Sendable {
-        private let lock = NSLock()
-        private var didResume = false
-        private let continuation: CheckedContinuation<UIBackgroundFetchResult, Never>
-
-        init(_ continuation: CheckedContinuation<UIBackgroundFetchResult, Never>) {
-            self.continuation = continuation
-        }
-
-        func resume(returning result: UIBackgroundFetchResult) {
-            lock.lock()
-            defer { lock.unlock() }
-            guard !didResume else { return }
-            didResume = true
-            continuation.resume(returning: result)
         }
     }
 

--- a/Sources/iOSApp/App/iOSSyncCoordinator.swift
+++ b/Sources/iOSApp/App/iOSSyncCoordinator.swift
@@ -2,6 +2,7 @@
 
     import ClipKittyAppleServices
     import ClipKittyRust
+    import ClipKittyShared
     import os
     import SwiftUI
     import UIKit
@@ -16,6 +17,7 @@
         func start()
         func stop()
         func handleRemoteNotification()
+        func runBackgroundSyncCycle() async -> SyncEngine.BackgroundSyncResult
     }
 
     extension SyncEngine: SyncEngineProtocol {}
@@ -129,6 +131,122 @@
                 engine.handleRemoteNotification()
             }
         }
+
+        func performRemoteNotificationSync() async -> SyncEngine.BackgroundSyncResult {
+            switch runtime {
+            case .disabled:
+                return .unavailable
+            case let .enabled(_, engine):
+                return await engine.runBackgroundSyncCycle()
+            }
+        }
+    }
+
+    // MARK: - Background Sync
+
+    @MainActor
+    final class iOSBackgroundSyncRunner {
+        static let shared = iOSBackgroundSyncRunner()
+
+        private let logger = Logger(subsystem: "com.clipkitty", category: "SyncBackground")
+        private let timeout: TimeInterval = 25
+        private var inFlightSync: Task<UIBackgroundFetchResult, Never>?
+
+        private init() {}
+
+        func performRemoteNotificationSync() async -> UIBackgroundFetchResult {
+            if let inFlightSync {
+                return await inFlightSync.value
+            }
+
+            let task = Task { @MainActor in
+                await self.withTimeout {
+                    await self.runHeadlessSyncIfEnabled()
+                }
+            }
+            inFlightSync = task
+            let result = await task.value
+            inFlightSync = nil
+            return result
+        }
+
+        private func runHeadlessSyncIfEnabled() async -> UIBackgroundFetchResult {
+            guard iOSSettingsStore().syncEnabled else {
+                logger.debug("Skipping background sync because iCloud sync is disabled")
+                return .noData
+            }
+
+            do {
+                DatabasePath.migrateIfNeeded()
+                let dbPath = try DatabasePath.resolve()
+                let plan = try inspectStoreBootstrap(dbPath: dbPath)
+                let store = try ClipKittyRust.ClipboardStore(dbPath: dbPath)
+                defer { store.prepareForSuspend() }
+
+                if plan == .rebuildIndex {
+                    logger.info("Rebuilding index before background sync")
+                    try store.rebuildIndex()
+                }
+
+                var contentChanged = false
+                let engine = SyncEngine(store: store)
+                engine.onContentChanged = {
+                    contentChanged = true
+                }
+
+                let result = await engine.runBackgroundSyncCycle()
+                switch result {
+                case .completed:
+                    logger.info("Background sync completed")
+                    return contentChanged ? .newData : .noData
+                case .unavailable:
+                    logger.info("Background sync skipped because iCloud is unavailable")
+                    return .noData
+                case let .failed(reason):
+                    logger.error("Background sync failed: \(reason)")
+                    return .failed
+                }
+            } catch {
+                logger.error("Background sync bootstrap failed: \(error.localizedDescription)")
+                return .failed
+            }
+        }
+
+        private func withTimeout(
+            operation: @escaping @MainActor () async -> UIBackgroundFetchResult
+        ) async -> UIBackgroundFetchResult {
+            await withCheckedContinuation { continuation in
+                let completion = BackgroundFetchCompletion(continuation)
+                let timeout = self.timeout
+                let operationTask = Task { @MainActor in
+                    let result = await operation()
+                    completion.resume(returning: result)
+                }
+                Task {
+                    try? await Task.sleep(for: .seconds(timeout))
+                    operationTask.cancel()
+                    completion.resume(returning: .failed)
+                }
+            }
+        }
+    }
+
+    private final class BackgroundFetchCompletion: @unchecked Sendable {
+        private let lock = NSLock()
+        private var didResume = false
+        private let continuation: CheckedContinuation<UIBackgroundFetchResult, Never>
+
+        init(_ continuation: CheckedContinuation<UIBackgroundFetchResult, Never>) {
+            self.continuation = continuation
+        }
+
+        func resume(returning result: UIBackgroundFetchResult) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didResume else { return }
+            didResume = true
+            continuation.resume(returning: result)
+        }
     }
 
     @MainActor
@@ -145,21 +263,27 @@
             self.coordinator = coordinator
             guard pendingRemoteNotification else { return }
             pendingRemoteNotification = false
-            coordinator.handleRemoteNotification()
+            Task {
+                _ = await coordinator.performRemoteNotificationSync()
+            }
         }
 
         func registerForRemoteNotifications() {
             UIApplication.shared.registerForRemoteNotifications()
         }
 
-        func handleRemoteNotification() -> Bool {
-            guard let coordinator else {
-                pendingRemoteNotification = true
-                logger.info("Queued remote sync notification until bootstrap completes")
-                return false
+        func handleRemoteNotification() async -> UIBackgroundFetchResult {
+            if let coordinator {
+                let result = await coordinator.performRemoteNotificationSync()
+                return result.backgroundFetchResult
             }
-            coordinator.handleRemoteNotification()
-            return true
+
+            logger.info("Handling remote sync notification with headless background sync")
+            let result = await iOSBackgroundSyncRunner.shared.performRemoteNotificationSync()
+            if result == .failed {
+                pendingRemoteNotification = true
+            }
+            return result
         }
 
         func didRegisterForRemoteNotifications() {
@@ -196,8 +320,21 @@
             fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
         ) {
             Task { @MainActor in
-                let handled = iOSRemoteNotificationBridge.shared.handleRemoteNotification()
-                completionHandler(handled ? .newData : .noData)
+                let result = await iOSRemoteNotificationBridge.shared.handleRemoteNotification()
+                completionHandler(result)
+            }
+        }
+    }
+
+    private extension SyncEngine.BackgroundSyncResult {
+        var backgroundFetchResult: UIBackgroundFetchResult {
+            switch self {
+            case .completed:
+                return .newData
+            case .unavailable:
+                return .noData
+            case .failed:
+                return .failed
             }
         }
     }

--- a/Sources/iOSApp/ClipKittyiOSApp.swift
+++ b/Sources/iOSApp/ClipKittyiOSApp.swift
@@ -6,9 +6,20 @@ import SwiftUI
 
 // MARK: - App Launch State
 
+struct AppSession {
+    let container: AppContainer
+    let appState: AppState
+}
+
+struct AppSuspensionContext {
+    let id: UUID
+    let session: AppSession
+}
+
 enum AppLaunchState {
     case launching
-    case ready(AppContainer, AppState)
+    case ready(AppSession)
+    case suspending(AppSuspensionContext)
     case suspended
     case failed(String)
 }
@@ -264,8 +275,11 @@ struct ClipKittyiOSApp: App {
             ProgressView("Loading ClipKitty...")
                 .onAppear { performBootstrap() }
 
-        case let .ready(container, appState):
-            rootView(container: container, appState: appState)
+        case let .ready(session):
+            rootView(container: session.container, appState: session.appState)
+
+        case let .suspending(context):
+            rootView(container: context.session.container, appState: context.session.appState)
 
         case .suspended:
             ProgressView("Loading ClipKitty...")
@@ -313,6 +327,7 @@ struct ClipKittyiOSApp: App {
                 return container.shortcutRepositoryAvailability()
             }
             let appState = AppState(container: container)
+            let session = AppSession(container: container, appState: appState)
             #if ENABLE_ICLOUD_SYNC
                 let coordinator = iOSSyncCoordinator(
                     store: container.store,
@@ -328,7 +343,7 @@ struct ClipKittyiOSApp: App {
                 }
             #endif
 
-            launchState = .ready(container, appState)
+            launchState = .ready(session)
         case let .failure(error):
             launchState = .failed(error.localizedDescription)
         }
@@ -353,34 +368,63 @@ struct ClipKittyiOSApp: App {
         switch launchState {
         case .suspended:
             performBootstrap()
-        case let .ready(_, appState):
+        case let .ready(session):
             #if ENABLE_ICLOUD_SYNC
                 syncCoordinator?.handleScenePhaseChange(.active)
             #endif
             Task {
-                await appState.ingestPendingAndClipboard()
+                await session.appState.ingestPendingAndClipboard()
             }
+        case .suspending:
+            break
         case .launching, .failed:
             break
         }
     }
 
     private func prepareForSuspension() {
-        #if ENABLE_ICLOUD_SYNC
-            syncCoordinator?.handleScenePhaseChange(.background)
-            syncCoordinator = nil
-        #endif
-
-        guard case let .ready(container, appState) = launchState else {
+        guard case let .ready(session) = launchState else {
             if case .launching = launchState {
                 launchState = .suspended
             }
             return
         }
 
-        appState.prepareForSuspension()
-        container.prepareForSuspension()
+        let suspensionID = UUID()
+        Task { @MainActor in
+            await finishPreparingForSuspension(session: session, suspensionID: suspensionID)
+        }
+        launchState = .suspending(
+            AppSuspensionContext(id: suspensionID, session: session)
+        )
+    }
+
+    private func finishPreparingForSuspension(
+        session: AppSession,
+        suspensionID: UUID
+    ) async {
+        #if ENABLE_ICLOUD_SYNC
+            await iOSBackgroundTaskRunner.run(named: "ClipKitty Suspend") {
+                await syncCoordinator?.prepareForSuspension()
+                session.appState.prepareForSuspension()
+                session.container.prepareForSuspension()
+            }
+            syncCoordinator = nil
+        #else
+            session.appState.prepareForSuspension()
+            session.container.prepareForSuspension()
+        #endif
+
+        guard case let .suspending(context) = launchState,
+              context.id == suspensionID
+        else {
+            return
+        }
+
         launchState = .suspended
+        if scenePhase == .active {
+            handleForegroundActivation()
+        }
     }
 
     private func bootstrapFailureView(message: String) -> some View {

--- a/Tests/UnitTests/SyncEngineDeterministicCloudE2ETests.swift
+++ b/Tests/UnitTests/SyncEngineDeterministicCloudE2ETests.swift
@@ -1,0 +1,538 @@
+@testable import ClipKitty
+@testable import ClipKittyAppleServices
+import ClipKittyRust
+import CloudKit
+import XCTest
+
+@MainActor
+final class SyncEngineDeterministicCloudE2ETests: XCTestCase {
+    private final class DeterministicCloud {
+        private struct StoredRecord {
+            let recordType: String
+            var record: CKRecord
+        }
+
+        private struct Change {
+            let sequence: Int64
+            let recordID: CKRecord.ID
+            let recordType: String
+        }
+
+        private let zoneID = CKRecordZone(zoneName: "ClipKittySync").zoneID
+        private let assetDirectory: URL
+        private var nextSequence: Int64 = 0
+        private var storedRecords: [CKRecord.ID: StoredRecord] = [:]
+        private var changes: [Change] = []
+
+        var accountStatusResult: Result<CKAccountStatus, Error> = .success(.available)
+        var nextSaveOperationError: Error?
+        var nextFetchError: Error?
+
+        init() throws {
+            assetDirectory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("clipkitty-deterministic-cloud-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: assetDirectory, withIntermediateDirectories: true)
+        }
+
+        func makeTransport() -> DeterministicCloudTransport {
+            DeterministicCloudTransport(cloud: self)
+        }
+
+        func accountStatus() throws -> CKAccountStatus {
+            try accountStatusResult.get()
+        }
+
+        func ensureZoneExists(_ zone: CKRecordZone) throws {
+            guard zone.zoneID.zoneName == zoneID.zoneName else {
+                throw NSError(
+                    domain: "DeterministicCloud",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Unexpected zone \(zone.zoneID.zoneName)"]
+                )
+            }
+        }
+
+        func saveSubscription(_: CKDatabaseSubscription) {}
+
+        func fetchChanges(
+            after cursor: Int64
+        ) -> (result: SyncZoneChangeResult, newestSequence: Int64) {
+            if let fetchError = nextFetchError {
+                nextFetchError = nil
+                return (SyncZoneChangeResult(fetchError: fetchError), cursor)
+            }
+
+            let visibleChanges = changes
+                .filter { $0.sequence > cursor }
+                .sorted { $0.sequence < $1.sequence }
+            let newestSequence = visibleChanges.last?.sequence ?? cursor
+            let records = visibleChanges.compactMap { change in
+                storedRecords[change.recordID].map { (change.recordType, cloneRecord($0.record)) }
+            }
+
+            return (
+                SyncZoneChangeResult(
+                    events: records
+                        .filter { $0.0 == "ItemEvent" }
+                        .map(\.1),
+                    snapshots: records
+                        .filter { $0.0 == "ItemSnapshot" }
+                        .map(\.1)
+                ),
+                newestSequence
+            )
+        }
+
+        func saveRecords(
+            _ records: [CKRecord],
+            savePolicy: CKModifyRecordsOperation.RecordSavePolicy
+        ) -> SyncRecordSaveResult {
+            if let nextSaveOperationError {
+                self.nextSaveOperationError = nil
+                return SyncRecordSaveResult(operationError: nextSaveOperationError)
+            }
+
+            var savedRecordIDs: [CKRecord.ID] = []
+            var perRecordErrors: [CKRecord.ID: Error] = [:]
+
+            for record in records {
+                do {
+                    switch savePolicy {
+                    case .ifServerRecordUnchanged:
+                        if storedRecords[record.recordID] != nil {
+                            perRecordErrors[record.recordID] = CKError(.serverRecordChanged)
+                            continue
+                        }
+                        try storeNewRecord(record)
+
+                    case .changedKeys:
+                        try mergeChangedKeys(from: record)
+
+                    case .allKeys:
+                        try replaceRecord(record)
+
+                    @unknown default:
+                        throw NSError(
+                            domain: "DeterministicCloud",
+                            code: 2,
+                            userInfo: [NSLocalizedDescriptionKey: "Unsupported save policy \(savePolicy)"]
+                        )
+                    }
+
+                    savedRecordIDs.append(record.recordID)
+                } catch {
+                    perRecordErrors[record.recordID] = error
+                }
+            }
+
+            return SyncRecordSaveResult(
+                savedRecordIDs: savedRecordIDs,
+                perRecordErrors: perRecordErrors
+            )
+        }
+
+        func deleteRecords(_ recordIDs: [CKRecord.ID]) -> SyncRecordDeleteResult {
+            var deletedRecordIDs: [CKRecord.ID] = []
+            var perRecordErrors: [CKRecord.ID: Error] = [:]
+
+            for recordID in recordIDs {
+                if storedRecords.removeValue(forKey: recordID) != nil {
+                    deletedRecordIDs.append(recordID)
+                } else {
+                    perRecordErrors[recordID] = CKError(.unknownItem)
+                }
+            }
+
+            return SyncRecordDeleteResult(
+                deletedRecordIDs: deletedRecordIDs,
+                perRecordErrors: perRecordErrors
+            )
+        }
+
+        func recordCount(recordType: String? = nil) -> Int {
+            storedRecords.values.filter { stored in
+                recordType.map { stored.recordType == $0 } ?? true
+            }.count
+        }
+
+        private func storeNewRecord(_ record: CKRecord) throws {
+            try replaceRecord(record)
+        }
+
+        private func replaceRecord(_ record: CKRecord) throws {
+            let copied = try cloneRecordCopyingAssets(record)
+            storedRecords[record.recordID] = StoredRecord(
+                recordType: record.recordType,
+                record: copied
+            )
+            appendChange(recordID: record.recordID, recordType: record.recordType)
+        }
+
+        private func mergeChangedKeys(from record: CKRecord) throws {
+            let merged: CKRecord
+            if let existing = storedRecords[record.recordID]?.record {
+                merged = cloneRecord(existing)
+            } else {
+                merged = CKRecord(recordType: record.recordType, recordID: record.recordID)
+            }
+
+            let changedKeys = record.changedKeys()
+            let keysToApply = changedKeys.isEmpty ? record.allKeys() : changedKeys
+
+            for key in keysToApply {
+                if let asset = record[key] as? CKAsset {
+                    merged[key] = try copyAsset(asset, recordID: record.recordID, key: key)
+                } else if let value = record[key] as? CKRecordValue {
+                    merged[key] = value
+                } else {
+                    merged[key] = nil
+                }
+            }
+
+            storedRecords[record.recordID] = StoredRecord(
+                recordType: record.recordType,
+                record: merged
+            )
+            appendChange(recordID: record.recordID, recordType: record.recordType)
+        }
+
+        private func appendChange(recordID: CKRecord.ID, recordType: String) {
+            nextSequence += 1
+            changes.append(
+                Change(
+                    sequence: nextSequence,
+                    recordID: recordID,
+                    recordType: recordType
+                )
+            )
+        }
+
+        private func cloneRecordCopyingAssets(_ record: CKRecord) throws -> CKRecord {
+            let clone = CKRecord(recordType: record.recordType, recordID: record.recordID)
+            for key in record.allKeys() {
+                if let asset = record[key] as? CKAsset {
+                    clone[key] = try copyAsset(asset, recordID: record.recordID, key: key)
+                } else if let value = record[key] as? CKRecordValue {
+                    clone[key] = value
+                }
+            }
+            return clone
+        }
+
+        private func cloneRecord(_ record: CKRecord) -> CKRecord {
+            let clone = CKRecord(recordType: record.recordType, recordID: record.recordID)
+            for key in record.allKeys() {
+                if let asset = record[key] as? CKAsset {
+                    clone[key] = asset
+                } else {
+                    clone[key] = record[key] as? CKRecordValue
+                }
+            }
+            return clone
+        }
+
+        private func copyAsset(
+            _ asset: CKAsset,
+            recordID: CKRecord.ID,
+            key: String
+        ) throws -> CKAsset {
+            guard let sourceURL = asset.fileURL else {
+                throw NSError(
+                    domain: "DeterministicCloud",
+                    code: 3,
+                    userInfo: [NSLocalizedDescriptionKey: "Asset \(key) for \(recordID.recordName) has no file URL"]
+                )
+            }
+
+            let destination = assetDirectory
+                .appendingPathComponent("\(nextSequence)-\(UUID().uuidString)-\(key).asset")
+            try FileManager.default.copyItem(at: sourceURL, to: destination)
+            return CKAsset(fileURL: destination)
+        }
+    }
+
+    private final class DeterministicCloudTransport: SyncCloudTransport {
+        private let cloud: DeterministicCloud
+        private var cursor: Int64 = 0
+        private var shouldExpireNextToken = false
+
+        init(cloud: DeterministicCloud) {
+            self.cloud = cloud
+        }
+
+        func expireTokenOnNextFetch() {
+            shouldExpireNextToken = true
+        }
+
+        func accountStatus() async throws -> CKAccountStatus {
+            try cloud.accountStatus()
+        }
+
+        func ensureZoneExists(_ zone: CKRecordZone) async throws {
+            try cloud.ensureZoneExists(zone)
+        }
+
+        func saveSubscription(_ subscription: CKDatabaseSubscription) async throws {
+            cloud.saveSubscription(subscription)
+        }
+
+        func fetchZoneChanges(
+            in _: CKRecordZone.ID,
+            since _: CKServerChangeToken?
+        ) async -> SyncZoneChangeResult {
+            if shouldExpireNextToken {
+                shouldExpireNextToken = false
+                return SyncZoneChangeResult(tokenExpired: true)
+            }
+
+            // CKServerChangeToken is opaque and not constructible in tests, so
+            // the deterministic transport owns the equivalent per-device cursor.
+            let response = cloud.fetchChanges(after: cursor)
+            cursor = response.newestSequence
+            return response.result
+        }
+
+        func saveRecords(
+            _ records: [CKRecord],
+            savePolicy: CKModifyRecordsOperation.RecordSavePolicy
+        ) async -> SyncRecordSaveResult {
+            cloud.saveRecords(records, savePolicy: savePolicy)
+        }
+
+        func deleteRecords(_ recordIDs: [CKRecord.ID]) async -> SyncRecordDeleteResult {
+            cloud.deleteRecords(recordIDs)
+        }
+    }
+
+    private func makeStore() throws -> ClipKittyRust.ClipboardStore {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("clipkitty-sync-e2e-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        return try ClipKittyRust.ClipboardStore(dbPath: tmp.appendingPathComponent("test.sqlite").path)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "SyncEngineDeterministicCloudE2ETests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeEngine(
+        store: ClipKittyRust.ClipboardStore,
+        transport: any SyncCloudTransport,
+        deviceId: String
+    ) -> SyncEngine {
+        SyncEngine(
+            store: store,
+            cloud: transport,
+            userDefaults: makeDefaults(),
+            deviceId: deviceId,
+            notificationCenter: NotificationCenter(),
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+    }
+
+    private func assertSynced(
+        _ engine: SyncEngine,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .synced = engine.status else {
+            return XCTFail("Expected synced status, got \(engine.status)", file: file, line: line)
+        }
+    }
+
+    private func assertText(
+        _ expectedText: String,
+        itemId: String,
+        in store: ClipKittyRust.ClipboardStore,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let items = try store.fetchByIds(itemIds: [itemId])
+        XCTAssertEqual(items.count, 1, file: file, line: line)
+        guard let item = items.first else { return }
+        guard case let .text(value) = item.content else {
+            return XCTFail("Expected text item, got \(item.content)", file: file, line: line)
+        }
+        XCTAssertEqual(value, expectedText, file: file, line: line)
+    }
+
+    private func assertMissing(
+        itemId: String,
+        in store: ClipKittyRust.ClipboardStore,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        XCTAssertTrue(
+            try store.fetchByIds(itemIds: [itemId]).isEmpty,
+            "Expected item \(itemId) to be absent",
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertSearchFinds(
+        _ itemId: String,
+        query: String,
+        in store: ClipKittyRust.ClipboardStore,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let result = try await store.search(query: query, presentation: .compactRow)
+        XCTAssertTrue(
+            result.matches.contains { $0.itemMetadata.itemId == itemId },
+            "Expected search for `\(query)` to find \(itemId), got \(result.matches.map(\.itemMetadata.itemId))",
+            file: file,
+            line: line
+        )
+    }
+
+    func testTwoDevicesConvergeThroughDeterministicCloud() async throws {
+        let cloud = try DeterministicCloud()
+        let firstStore = try makeStore()
+        let secondStore = try makeStore()
+        let firstEngine = makeEngine(
+            store: firstStore,
+            transport: cloud.makeTransport(),
+            deviceId: "device-a"
+        )
+        let secondEngine = makeEngine(
+            store: secondStore,
+            transport: cloud.makeTransport(),
+            deviceId: "device-b"
+        )
+
+        firstStore.setSyncDeviceId(deviceId: "device-a")
+        let itemId = try firstStore.saveText(
+            text: "alpha from device a",
+            sourceApp: nil,
+            sourceAppBundleId: nil
+        )
+
+        await firstEngine.runCoordinatorCycle()
+        assertSynced(firstEngine)
+        XCTAssertTrue(try firstStore.pendingLocalEvents().isEmpty)
+        XCTAssertEqual(cloud.recordCount(recordType: "ItemEvent"), 1)
+
+        await secondEngine.runCoordinatorCycle()
+        assertSynced(secondEngine)
+        try assertText("alpha from device a", itemId: itemId, in: secondStore)
+        try await assertSearchFinds(itemId, query: "alpha", in: secondStore)
+
+        secondStore.setSyncDeviceId(deviceId: "device-b")
+        try secondStore.updateTextItem(itemId: itemId, text: "beta edited on device b")
+        try secondStore.addTag(itemId: itemId, tag: .bookmark)
+
+        await secondEngine.runCoordinatorCycle()
+        assertSynced(secondEngine)
+        XCTAssertTrue(try secondStore.pendingLocalEvents().isEmpty)
+
+        await firstEngine.runCoordinatorCycle()
+        assertSynced(firstEngine)
+        try assertText("beta edited on device b", itemId: itemId, in: firstStore)
+        let firstItem = try XCTUnwrap(firstStore.fetchByIds(itemIds: [itemId]).first)
+        XCTAssertTrue(firstItem.itemMetadata.tags.contains(.bookmark))
+
+        try firstStore.deleteItem(itemId: itemId)
+
+        await firstEngine.runCoordinatorCycle()
+        assertSynced(firstEngine)
+        await secondEngine.runCoordinatorCycle()
+        assertSynced(secondEngine)
+        try assertMissing(itemId: itemId, in: firstStore)
+        try assertMissing(itemId: itemId, in: secondStore)
+    }
+
+    func testFullResyncRehydratesSnapshotAssetsFromDeterministicCloud() async throws {
+        let cloud = try DeterministicCloud()
+        let sourceStore = try makeStore()
+        let resyncStore = try makeStore()
+        let sourceEngine = makeEngine(
+            store: sourceStore,
+            transport: cloud.makeTransport(),
+            deviceId: "snapshot-source"
+        )
+        let resyncTransport = cloud.makeTransport()
+        let resyncEngine = makeEngine(
+            store: resyncStore,
+            transport: resyncTransport,
+            deviceId: "snapshot-target"
+        )
+        let bookmark = Data((0 ..< 255).map(UInt8.init))
+
+        sourceStore.setSyncDeviceId(deviceId: "snapshot-source")
+        let itemId = try sourceStore.saveFiles(
+            paths: ["/tmp/resync-document.txt"],
+            filenames: ["resync-document.txt"],
+            fileSizes: [UInt64(bookmark.count)],
+            utis: ["public.plain-text"],
+            bookmarkDataList: [bookmark],
+            previewSnapshots: [.unavailable(reason: .notCaptured)],
+            sourceApp: nil,
+            sourceAppBundleId: nil
+        )
+        _ = try sourceStore.runCompaction()
+
+        await sourceEngine.runCoordinatorCycle()
+        assertSynced(sourceEngine)
+        XCTAssertTrue(try sourceStore.pendingLocalEvents().isEmpty)
+        XCTAssertTrue(try sourceStore.pendingSnapshotRecords().isEmpty)
+        XCTAssertEqual(cloud.recordCount(recordType: "ItemSnapshot"), 1)
+
+        resyncTransport.expireTokenOnNextFetch()
+        await resyncEngine.runCoordinatorCycle()
+        assertSynced(resyncEngine)
+
+        let items = try resyncStore.fetchByIds(itemIds: [itemId])
+        XCTAssertEqual(items.count, 1)
+        guard case let .file(_, files) = try XCTUnwrap(items.first).content else {
+            return XCTFail("Expected file item after full resync")
+        }
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files[0].filename, "resync-document.txt")
+        XCTAssertEqual(files[0].bookmarkData, bookmark)
+        try await assertSearchFinds(itemId, query: "resync", in: resyncStore)
+    }
+
+    func testRetryableUploadFailureKeepsLocalEventUntilCloudAcceptsIt() async throws {
+        let cloud = try DeterministicCloud()
+        let sourceStore = try makeStore()
+        let targetStore = try makeStore()
+        let sourceEngine = makeEngine(
+            store: sourceStore,
+            transport: cloud.makeTransport(),
+            deviceId: "retry-source"
+        )
+        let targetEngine = makeEngine(
+            store: targetStore,
+            transport: cloud.makeTransport(),
+            deviceId: "retry-target"
+        )
+
+        sourceStore.setSyncDeviceId(deviceId: "retry-source")
+        let itemId = try sourceStore.saveText(
+            text: "event survives retryable upload failure",
+            sourceApp: nil,
+            sourceAppBundleId: nil
+        )
+        cloud.nextSaveOperationError = CKError(.networkUnavailable)
+
+        await sourceEngine.runCoordinatorCycle()
+        guard case .error = sourceEngine.status else {
+            return XCTFail("Expected retryable upload error, got \(sourceEngine.status)")
+        }
+        XCTAssertEqual(try sourceStore.pendingLocalEvents().map(\.itemId), [itemId])
+        XCTAssertEqual(cloud.recordCount(recordType: "ItemEvent"), 0)
+
+        await sourceEngine.runCoordinatorCycle()
+        assertSynced(sourceEngine)
+        XCTAssertTrue(try sourceStore.pendingLocalEvents().isEmpty)
+        XCTAssertEqual(cloud.recordCount(recordType: "ItemEvent"), 1)
+
+        await targetEngine.runCoordinatorCycle()
+        assertSynced(targetEngine)
+        try assertText("event survives retryable upload failure", itemId: itemId, in: targetStore)
+    }
+}

--- a/Tests/iOSTests/iOSSyncCoordinatorTests.swift
+++ b/Tests/iOSTests/iOSSyncCoordinatorTests.swift
@@ -15,13 +15,19 @@
         private(set) var startCallCount = 0
         private(set) var stopCallCount = 0
         private(set) var handleRemoteNotificationCallCount = 0
+        private(set) var runBackgroundSyncCycleCallCount = 0
 
         var stubbedStatus: SyncEngine.SyncStatus = .idle
+        var stubbedBackgroundSyncResult: SyncEngine.BackgroundSyncResult = .completed
         var status: SyncEngine.SyncStatus { stubbedStatus }
 
         func start() { startCallCount += 1 }
         func stop() { stopCallCount += 1 }
         func handleRemoteNotification() { handleRemoteNotificationCallCount += 1 }
+        func runBackgroundSyncCycle() async -> SyncEngine.BackgroundSyncResult {
+            runBackgroundSyncCycleCallCount += 1
+            return stubbedBackgroundSyncResult
+        }
     }
 
     private let sampleSyncingStatus = SyncEngine.SyncStatus.syncing(
@@ -336,6 +342,34 @@
 
             coordinator.handleRemoteNotification()
 
+            XCTAssertTrue(createdEngines.isEmpty)
+        }
+
+        func testPerformRemoteNotificationSyncRunsBackgroundCycleWhenEnabled() async {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: true,
+                onContentChanged: {},
+                engineFactory: spyFactory()
+            )
+
+            let result = await coordinator.performRemoteNotificationSync()
+
+            XCTAssertEqual(result, .completed)
+            XCTAssertEqual(latestEngine?.runBackgroundSyncCycleCallCount, 1)
+        }
+
+        func testPerformRemoteNotificationSyncReturnsUnavailableWhenDisabled() async {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: false,
+                onContentChanged: {},
+                engineFactory: spyFactory()
+            )
+
+            let result = await coordinator.performRemoteNotificationSync()
+
+            XCTAssertEqual(result, .unavailable)
             XCTAssertTrue(createdEngines.isEmpty)
         }
     }

--- a/Tests/iOSTests/iOSSyncCoordinatorTests.swift
+++ b/Tests/iOSTests/iOSSyncCoordinatorTests.swift
@@ -14,6 +14,7 @@
 
         private(set) var startCallCount = 0
         private(set) var stopCallCount = 0
+        private(set) var prepareForSuspendCallCount = 0
         private(set) var handleRemoteNotificationCallCount = 0
         private(set) var runBackgroundSyncCycleCallCount = 0
 
@@ -23,6 +24,7 @@
 
         func start() { startCallCount += 1 }
         func stop() { stopCallCount += 1 }
+        func prepareForSuspend() async { prepareForSuspendCallCount += 1 }
         func handleRemoteNotification() { handleRemoteNotificationCallCount += 1 }
         func runBackgroundSyncCycle() async -> SyncEngine.BackgroundSyncResult {
             runBackgroundSyncCycleCallCount += 1
@@ -272,7 +274,7 @@
             XCTAssertEqual(latestEngine?.stopCallCount, 1)
         }
 
-        func testInactivePhaseStopsEngineWhenEnabled() {
+        func testInactivePhaseLeavesEngineRunningWhenEnabled() {
             let coordinator = iOSSyncCoordinator(
                 store: store,
                 enabled: true,
@@ -282,7 +284,7 @@
 
             coordinator.handleScenePhaseChange(.inactive)
 
-            XCTAssertEqual(latestEngine?.stopCallCount, 1)
+            XCTAssertEqual(latestEngine?.stopCallCount, 0)
         }
 
         func testScenePhaseChangesAreNoOpWhenDisabled() {
@@ -314,6 +316,32 @@
 
             XCTAssertEqual(latestEngine?.startCallCount, 2)
             XCTAssertEqual(latestEngine?.stopCallCount, 1)
+        }
+
+        func testPrepareForSuspensionAwaitsEngineWhenEnabled() async {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: true,
+                onContentChanged: {},
+                engineFactory: spyFactory()
+            )
+
+            await coordinator.prepareForSuspension()
+
+            XCTAssertEqual(latestEngine?.prepareForSuspendCallCount, 1)
+        }
+
+        func testPrepareForSuspensionIsNoOpWhenDisabled() async {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: false,
+                onContentChanged: {},
+                engineFactory: spyFactory()
+            )
+
+            await coordinator.prepareForSuspension()
+
+            XCTAssertTrue(createdEngines.isEmpty)
         }
 
         // MARK: - Remote notification

--- a/Tests/iOSTests/iOSSyncCoordinatorTests.swift
+++ b/Tests/iOSTests/iOSSyncCoordinatorTests.swift
@@ -43,6 +43,7 @@
         private var tempDir: URL!
         private var store: ClipKittyRust.ClipboardStore!
         private var createdEngines: [SpySyncEngine]!
+        private var scheduleBackgroundSyncCallCount: Int!
 
         override func setUp() {
             super.setUp()
@@ -52,11 +53,13 @@
             let dbPath = tempDir.appendingPathComponent("test.db").path
             store = try! ClipKittyRust.ClipboardStore(dbPath: dbPath)
             createdEngines = []
+            scheduleBackgroundSyncCallCount = 0
         }
 
         override func tearDown() {
             store = nil
             createdEngines = nil
+            scheduleBackgroundSyncCallCount = nil
             if let tempDir {
                 try? FileManager.default.removeItem(at: tempDir)
             }
@@ -74,6 +77,10 @@
 
         private var latestEngine: SpySyncEngine? {
             createdEngines.last
+        }
+
+        private func countBackgroundSchedule() {
+            scheduleBackgroundSyncCallCount += 1
         }
 
         // MARK: - Initialization
@@ -120,6 +127,18 @@
             XCTAssertEqual(latestEngine?.startCallCount, 0)
         }
 
+        func testInitEnabledSchedulesBackgroundSync() {
+            _ = iOSSyncCoordinator(
+                store: store,
+                enabled: true,
+                onContentChanged: {},
+                engineFactory: spyFactory(),
+                scheduleBackgroundSync: countBackgroundSchedule
+            )
+
+            XCTAssertEqual(scheduleBackgroundSyncCallCount, 1)
+        }
+
         // MARK: - Status
 
         func testStatusIdleWhenDisabled() {
@@ -158,6 +177,20 @@
 
             XCTAssertEqual(createdEngines.count, 1)
             XCTAssertEqual(latestEngine?.startCallCount, 1)
+        }
+
+        func testEnableFromDisabledSchedulesBackgroundSync() {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: false,
+                onContentChanged: {},
+                engineFactory: spyFactory(),
+                scheduleBackgroundSync: countBackgroundSchedule
+            )
+
+            coordinator.setSyncEnabled(true)
+
+            XCTAssertEqual(scheduleBackgroundSyncCallCount, 1)
         }
 
         func testEnableFromDisabledWiresOnContentChanged() {
@@ -274,6 +307,21 @@
             XCTAssertEqual(latestEngine?.stopCallCount, 1)
         }
 
+        func testBackgroundPhaseSchedulesBackgroundSyncWhenEnabled() {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: true,
+                onContentChanged: {},
+                engineFactory: spyFactory(),
+                scheduleBackgroundSync: countBackgroundSchedule
+            )
+            scheduleBackgroundSyncCallCount = 0
+
+            coordinator.handleScenePhaseChange(.background)
+
+            XCTAssertEqual(scheduleBackgroundSyncCallCount, 1)
+        }
+
         func testInactivePhaseLeavesEngineRunningWhenEnabled() {
             let coordinator = iOSSyncCoordinator(
                 store: store,
@@ -323,12 +371,15 @@
                 store: store,
                 enabled: true,
                 onContentChanged: {},
-                engineFactory: spyFactory()
+                engineFactory: spyFactory(),
+                scheduleBackgroundSync: countBackgroundSchedule
             )
+            scheduleBackgroundSyncCallCount = 0
 
             await coordinator.prepareForSuspension()
 
             XCTAssertEqual(latestEngine?.prepareForSuspendCallCount, 1)
+            XCTAssertEqual(scheduleBackgroundSyncCallCount, 1)
         }
 
         func testPrepareForSuspensionIsNoOpWhenDisabled() async {
@@ -358,6 +409,21 @@
 
             XCTAssertEqual(latestEngine?.startCallCount, 1)
             XCTAssertEqual(latestEngine?.handleRemoteNotificationCallCount, 1)
+        }
+
+        func testRemoteNotificationSchedulesBackgroundSyncWhenEnabled() {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: true,
+                onContentChanged: {},
+                engineFactory: spyFactory(),
+                scheduleBackgroundSync: countBackgroundSchedule
+            )
+            scheduleBackgroundSyncCallCount = 0
+
+            coordinator.handleRemoteNotification()
+
+            XCTAssertEqual(scheduleBackgroundSyncCallCount, 1)
         }
 
         func testRemoteNotificationIsNoOpWhenDisabled() {

--- a/purr-sync/src/schema.rs
+++ b/purr-sync/src/schema.rs
@@ -40,9 +40,65 @@ fn reset_pre_release_sync_schema_if_needed(conn: &rusqlite::Connection) -> SyncR
         DROP TABLE IF EXISTS sync_dedup;
         DROP TABLE IF EXISTS sync_device_state;
         DROP TABLE IF EXISTS sync_dirty_flags;
+        DROP TABLE IF EXISTS sync_index_queue;
         "#,
     )?;
 
+    Ok(())
+}
+
+fn sync_index_queue_has_current_shape(conn: &rusqlite::Connection) -> SyncResult<bool> {
+    Ok(table_has_column(conn, "sync_index_queue", "queue_key")?
+        && table_has_column(conn, "sync_index_queue", "item_id")?)
+}
+
+fn create_sync_index_queue(conn: &rusqlite::Connection) -> SyncResult<()> {
+    conn.execute_batch(
+        r#"
+        -- Idempotent derived search-index maintenance queue. The SQLite sync
+        -- read model is authoritative; Tantivy catches up from this queue.
+        CREATE TABLE IF NOT EXISTS sync_index_queue (
+            queue_key TEXT PRIMARY KEY,
+            operation TEXT NOT NULL CHECK(operation IN ('reset', 'upsert', 'delete')),
+            item_id TEXT,
+            updated_at INTEGER NOT NULL,
+            CHECK (
+                (operation = 'reset' AND item_id IS NULL) OR
+                (operation IN ('upsert', 'delete') AND item_id IS NOT NULL)
+            )
+        );
+        CREATE INDEX IF NOT EXISTS idx_sync_index_queue_updated
+            ON sync_index_queue(updated_at, queue_key);
+        "#,
+    )?;
+    Ok(())
+}
+
+fn migrate_sync_index_queue_if_needed(conn: &rusqlite::Connection) -> SyncResult<()> {
+    if sync_index_queue_has_current_shape(conn)? {
+        return Ok(());
+    }
+
+    if !table_has_column(conn, "sync_index_queue", "operation")? {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        r#"
+        ALTER TABLE sync_index_queue RENAME TO sync_index_queue_legacy;
+        DROP INDEX IF EXISTS idx_sync_index_queue_updated;
+        "#,
+    )?;
+    create_sync_index_queue(conn)?;
+    conn.execute_batch(
+        r#"
+        INSERT INTO sync_index_queue (queue_key, operation, item_id, updated_at)
+        SELECT item_id, operation, item_id, updated_at
+        FROM sync_index_queue_legacy
+        WHERE operation IN ('upsert', 'delete');
+        DROP TABLE sync_index_queue_legacy;
+        "#,
+    )?;
     Ok(())
 }
 
@@ -50,6 +106,7 @@ fn reset_pre_release_sync_schema_if_needed(conn: &rusqlite::Connection) -> SyncR
 /// Called by the host crate during database initialization.
 pub fn setup_sync_schema(conn: &rusqlite::Connection) -> SyncResult<()> {
     reset_pre_release_sync_schema_if_needed(conn)?;
+    migrate_sync_index_queue_if_needed(conn)?;
 
     conn.execute_batch(
         r#"
@@ -134,6 +191,7 @@ pub fn setup_sync_schema(conn: &rusqlite::Connection) -> SyncResult<()> {
         );
         "#,
     )?;
+    create_sync_index_queue(conn)?;
 
     // Idempotent migration for existing databases: add checkpoint upload columns.
     let _ = conn.execute(

--- a/purr-sync/src/store.rs
+++ b/purr-sync/src/store.rs
@@ -5,7 +5,10 @@
 use crate::error::{SyncError, SyncResult};
 use crate::event::ItemEvent;
 use crate::snapshot::ItemSnapshot;
-use crate::types::{CheckpointState, DeferredReason, VersionVector};
+use crate::types::{
+    CheckpointState, DeferredReason, IndexQueueEntry, IndexQueueOperation, VersionVector,
+    INDEX_QUEUE_RESET_KEY,
+};
 use chrono::Utc;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
@@ -764,6 +767,147 @@ impl<'a> SyncStore<'a> {
         Ok(())
     }
 
+    // ── Search Index Queue ───────────────────────────────────────────────
+
+    fn enqueue_index_operation(
+        &self,
+        item_id: &str,
+        operation: IndexQueueOperation,
+    ) -> SyncResult<()> {
+        debug_assert_ne!(operation, IndexQueueOperation::Reset);
+        let now = Utc::now().timestamp();
+        let conn = self.get_conn()?;
+        conn.execute(
+            r#"INSERT INTO sync_index_queue (queue_key, operation, item_id, updated_at)
+               VALUES (?1, ?2, ?1, ?3)
+               ON CONFLICT(queue_key) DO UPDATE SET
+                 operation = excluded.operation,
+                 item_id = excluded.item_id,
+                 updated_at = excluded.updated_at"#,
+            params![item_id, operation.as_str(), now],
+        )?;
+        Ok(())
+    }
+
+    pub fn enqueue_index_reset(&self) -> SyncResult<()> {
+        let now = Utc::now().timestamp();
+        let conn = self.get_conn()?;
+        conn.execute(
+            r#"INSERT INTO sync_index_queue (queue_key, operation, item_id, updated_at)
+               VALUES (?1, ?2, NULL, ?3)
+               ON CONFLICT(queue_key) DO UPDATE SET
+                 operation = excluded.operation,
+                 item_id = excluded.item_id,
+                 updated_at = excluded.updated_at"#,
+            params![
+                INDEX_QUEUE_RESET_KEY,
+                IndexQueueOperation::Reset.as_str(),
+                now
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn enqueue_index_upsert(&self, item_id: &str) -> SyncResult<()> {
+        self.enqueue_index_operation(item_id, IndexQueueOperation::Upsert)
+    }
+
+    pub fn enqueue_index_delete(&self, item_id: &str) -> SyncResult<()> {
+        self.enqueue_index_operation(item_id, IndexQueueOperation::Delete)
+    }
+
+    pub fn fetch_index_queue(&self, limit: usize) -> SyncResult<Vec<IndexQueueEntry>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let conn = self.get_conn()?;
+        let mut stmt = conn.prepare(
+            r#"SELECT queue_key, operation, item_id
+               FROM sync_index_queue
+               ORDER BY
+                 CASE operation WHEN 'reset' THEN 0 ELSE 1 END,
+                 updated_at ASC,
+                 queue_key ASC
+               LIMIT ?1"#,
+        )?;
+        let entries = stmt
+            .query_map(params![limit as i64], |row| {
+                let queue_key: String = row.get(0)?;
+                let operation_raw: String = row.get(1)?;
+                let item_id: Option<String> = row.get(2)?;
+                Ok((queue_key, operation_raw, item_id))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        entries
+            .into_iter()
+            .map(|(queue_key, operation_raw, item_id)| {
+                let operation = IndexQueueOperation::from_str(&operation_raw).ok_or_else(|| {
+                    SyncError::InconsistentData(format!(
+                        "unknown index queue operation `{operation_raw}`"
+                    ))
+                })?;
+                match operation {
+                    IndexQueueOperation::Reset => {
+                        if queue_key == INDEX_QUEUE_RESET_KEY && item_id.is_none() {
+                            Ok(IndexQueueEntry::Reset)
+                        } else {
+                            Err(SyncError::InconsistentData(
+                                "index queue reset row has item data".to_string(),
+                            ))
+                        }
+                    }
+                    IndexQueueOperation::Upsert => item_id
+                        .map(|item_id| IndexQueueEntry::Upsert { item_id })
+                        .ok_or_else(|| {
+                            SyncError::InconsistentData(
+                                "index queue upsert row is missing item_id".to_string(),
+                            )
+                        }),
+                    IndexQueueOperation::Delete => item_id
+                        .map(|item_id| IndexQueueEntry::Delete { item_id })
+                        .ok_or_else(|| {
+                            SyncError::InconsistentData(
+                                "index queue delete row is missing item_id".to_string(),
+                            )
+                        }),
+                }
+            })
+            .collect()
+    }
+
+    pub fn remove_index_queue_entries(&self, queue_keys: &[&str]) -> SyncResult<usize> {
+        if queue_keys.is_empty() {
+            return Ok(0);
+        }
+        let conn = self.get_conn()?;
+        let placeholders: Vec<String> = (1..=queue_keys.len()).map(|i| format!("?{i}")).collect();
+        let sql = format!(
+            "DELETE FROM sync_index_queue WHERE queue_key IN ({})",
+            placeholders.join(", ")
+        );
+        let params: Vec<&dyn rusqlite::ToSql> = queue_keys
+            .iter()
+            .map(|id| id as &dyn rusqlite::ToSql)
+            .collect();
+        Ok(conn.execute(&sql, params.as_slice())?)
+    }
+
+    pub fn count_index_queue_entries(&self) -> SyncResult<usize> {
+        let conn = self.get_conn()?;
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM sync_index_queue", [], |row| {
+            row.get(0)
+        })?;
+        Ok(count as usize)
+    }
+
+    pub fn clear_index_queue(&self) -> SyncResult<()> {
+        let conn = self.get_conn()?;
+        conn.execute("DELETE FROM sync_index_queue", [])?;
+        Ok(())
+    }
+
     // ── Bulk Operations (for full resync) ────────────────────────────────
 
     /// Fetch event IDs that are compacted, uploaded, and older than the given threshold.
@@ -838,6 +982,7 @@ impl<'a> SyncStore<'a> {
             DELETE FROM sync_deferred_events;
             DELETE FROM sync_dedup;
             DELETE FROM sync_dirty_flags;
+            DELETE FROM sync_index_queue;
             "#,
         )?;
         Ok(())

--- a/purr-sync/src/types.rs
+++ b/purr-sync/src/types.rs
@@ -288,6 +288,54 @@ pub const FLAG_INDEX_DIRTY: &str = "index_dirty";
 pub const FLAG_NEEDS_FULL_RESYNC: &str = "needs_full_resync";
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Search Index Maintenance Queue
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub const INDEX_QUEUE_RESET_KEY: &str = "__clipkitty_index_reset__";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexQueueOperation {
+    Reset,
+    Upsert,
+    Delete,
+}
+
+impl IndexQueueOperation {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IndexQueueOperation::Reset => "reset",
+            IndexQueueOperation::Upsert => "upsert",
+            IndexQueueOperation::Delete => "delete",
+        }
+    }
+
+    pub fn from_str(raw: &str) -> Option<Self> {
+        match raw {
+            "reset" => Some(IndexQueueOperation::Reset),
+            "upsert" => Some(IndexQueueOperation::Upsert),
+            "delete" => Some(IndexQueueOperation::Delete),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexQueueEntry {
+    Reset,
+    Upsert { item_id: String },
+    Delete { item_id: String },
+}
+
+impl IndexQueueEntry {
+    pub fn queue_key(&self) -> &str {
+        match self {
+            IndexQueueEntry::Reset => INDEX_QUEUE_RESET_KEY,
+            IndexQueueEntry::Upsert { item_id } | IndexQueueEntry::Delete { item_id } => item_id,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Compaction Constants
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/purr/src/indexer.rs
+++ b/purr/src/indexer.rs
@@ -1046,6 +1046,13 @@ impl Indexer {
         })
     }
 
+    pub fn delete_all_documents(&self) -> IndexerResult<()> {
+        self.with_writer(|writer| {
+            writer.delete_all_documents()?;
+            Ok(())
+        })
+    }
+
     /// Tokenize text using the trigram tokenizer and return terms for the content field.
     fn trigram_terms(&self, text: &str) -> Vec<Term> {
         let mut tokenizer = self.index.tokenizers().get("trigram").unwrap();

--- a/purr/src/interface.rs
+++ b/purr/src/interface.rs
@@ -719,6 +719,14 @@ pub struct SyncDeviceState {
     pub index_dirty: bool,
 }
 
+/// Outcome of one bounded derived search-index maintenance pass.
+#[cfg(feature = "sync")]
+#[derive(Debug, Clone, PartialEq, uniffi::Enum)]
+pub enum IndexMaintenanceOutcome {
+    Completed { processed: u64 },
+    MoreRemaining { processed: u64, remaining: u64 },
+}
+
 /// Outcome of a compaction run.
 #[cfg(feature = "sync")]
 #[derive(Debug, Clone, PartialEq, uniffi::Record)]

--- a/purr/src/store.rs
+++ b/purr/src/store.rs
@@ -169,6 +169,7 @@ impl ClipboardStore {
 
     fn rebuild_index_contents(&self) -> Result<(), ClipKittyError> {
         let items = self.db.fetch_all_items()?;
+        self.indexer.delete_all_documents()?;
         use rayon::prelude::*;
         let prepared: Vec<_> = items
             .par_iter()
@@ -248,7 +249,17 @@ impl ClipboardStore {
     }
 
     pub fn rebuild_index(&self) -> Result<(), ClipKittyError> {
-        self.rebuild_index_contents()
+        self.rebuild_index_contents()?;
+        #[cfg(feature = "sync")]
+        {
+            use purr_sync::store::SyncStore;
+            use purr_sync::types::FLAG_INDEX_DIRTY;
+
+            let sync = SyncStore::new(self.db.pool());
+            sync.clear_index_queue()?;
+            sync.set_dirty_flag(FLAG_INDEX_DIRTY, false)?;
+        }
+        Ok(())
     }
 
     pub fn prepare_for_suspend(&self) {
@@ -614,44 +625,6 @@ impl ClipboardStoreApi for ClipboardStore {
 
 #[cfg(feature = "sync")]
 impl ClipboardStore {
-    fn materialize_search_document(
-        &self,
-        item: &crate::models::StoredItem,
-    ) -> Result<(), ClipKittyError> {
-        use purr_sync::store::SyncStore;
-        use purr_sync::types::FLAG_INDEX_DIRTY;
-
-        let text = item
-            .file_index_text()
-            .unwrap_or_else(|| item.text_content().to_string());
-        if self
-            .indexer
-            .add_document(&item.item_id, &text, item.timestamp_unix)
-            .and_then(|_| self.indexer.commit())
-            .is_err()
-        {
-            let sync = SyncStore::new(self.db.pool());
-            let _ = sync.set_dirty_flag(FLAG_INDEX_DIRTY, true);
-        }
-        Ok(())
-    }
-
-    fn remove_search_document(&self, item_id: &str) -> Result<(), ClipKittyError> {
-        use purr_sync::store::SyncStore;
-        use purr_sync::types::FLAG_INDEX_DIRTY;
-
-        if self
-            .indexer
-            .delete_document(item_id)
-            .and_then(|_| self.indexer.commit())
-            .is_err()
-        {
-            let sync = SyncStore::new(self.db.pool());
-            let _ = sync.set_dirty_flag(FLAG_INDEX_DIRTY, true);
-        }
-        Ok(())
-    }
-
     fn materialize_forked_snapshot(
         &self,
         snapshot: &purr_sync::types::ItemSnapshotData,
@@ -661,8 +634,8 @@ impl ClipboardStore {
         let fork_item_id = uuid::Uuid::new_v4().to_string();
         let item = stored_item_from_snapshot(fork_item_id.clone(), snapshot)
             .map_err(ClipKittyError::InvalidInput)?;
+        self.queue_search_upsert(&fork_item_id)?;
         let row_id = self.db.insert_item(&item)?;
-        self.materialize_search_document(&item)?;
         if snapshot.is_bookmarked {
             self.db
                 .add_tag(row_id, crate::interface::ItemTag::Bookmark)?;
@@ -670,6 +643,26 @@ impl ClipboardStore {
         self.sync_emitter
             .emit_item_created(&fork_item_id, snapshot.clone())?;
         Ok(fork_item_id)
+    }
+
+    fn queue_search_upsert(&self, item_id: &str) -> Result<(), ClipKittyError> {
+        use purr_sync::store::SyncStore;
+        use purr_sync::types::FLAG_INDEX_DIRTY;
+
+        let sync = SyncStore::new(self.db.pool());
+        sync.enqueue_index_upsert(item_id)?;
+        sync.set_dirty_flag(FLAG_INDEX_DIRTY, true)?;
+        Ok(())
+    }
+
+    fn queue_search_delete(&self, item_id: &str) -> Result<(), ClipKittyError> {
+        use purr_sync::store::SyncStore;
+        use purr_sync::types::FLAG_INDEX_DIRTY;
+
+        let sync = SyncStore::new(self.db.pool());
+        sync.enqueue_index_delete(item_id)?;
+        sync.set_dirty_flag(FLAG_INDEX_DIRTY, true)?;
+        Ok(())
     }
 
     /// Materialize a sync aggregate into the local items table.
@@ -702,11 +695,12 @@ impl ClipboardStore {
                 let item = stored_item_from_snapshot(item_id.to_string(), &live.snapshot)
                     .map_err(ClipKittyError::InvalidInput)?;
 
+                if index_dirty {
+                    self.queue_search_upsert(item_id)?;
+                }
+
                 if let Some(local_id) = local_item_id {
                     self.db.replace_item_preserving_id(local_id, &item)?;
-                    if index_dirty {
-                        self.materialize_search_document(&item)?;
-                    }
                     if live.snapshot.is_bookmarked {
                         self.db
                             .add_tag(local_id, crate::interface::ItemTag::Bookmark)?;
@@ -725,9 +719,6 @@ impl ClipboardStore {
 
                 // No existing local item — insert fresh.
                 let new_id = self.db.insert_item(&item)?;
-                if index_dirty {
-                    self.materialize_search_document(&item)?;
-                }
                 if live.snapshot.is_bookmarked {
                     self.db
                         .add_tag(new_id, crate::interface::ItemTag::Bookmark)?;
@@ -741,8 +732,10 @@ impl ClipboardStore {
                 Ok(Some(new_id))
             }
             ItemAggregate::Tombstoned(tomb) => {
+                if index_dirty {
+                    self.queue_search_delete(item_id)?;
+                }
                 if let Some(local_id) = local_item_id {
-                    self.remove_search_document(item_id)?;
                     self.db.delete_item(local_id)?;
                 }
                 sync.upsert_projection(
@@ -1250,7 +1243,6 @@ impl ClipboardStore {
         for (_original_item_id, plan) in &result.fork_plans {
             let _ = self.materialize_forked_snapshot(&plan.forked_snapshot)?;
         }
-        let _ = self.indexer.commit();
 
         Ok(SyncFullResyncResult {
             checkpoints_applied: result.checkpoints_applied as u64,
@@ -1273,7 +1265,8 @@ impl ClipboardStore {
         let sync = SyncStore::new(self.db.pool());
         let token = sync.fetch_zone_change_token(&device_id)?;
         let needs_resync = sync.get_dirty_flag(FLAG_NEEDS_FULL_RESYNC)?;
-        let index_dirty = sync.get_dirty_flag(FLAG_INDEX_DIRTY)?;
+        let index_dirty =
+            sync.get_dirty_flag(FLAG_INDEX_DIRTY)? || sync.count_index_queue_entries()? > 0;
 
         Ok(SyncDeviceState {
             device_id,
@@ -1326,8 +1319,100 @@ impl ClipboardStore {
         use purr_sync::types::FLAG_INDEX_DIRTY;
 
         let sync = SyncStore::new(self.db.pool());
-        sync.set_dirty_flag(FLAG_INDEX_DIRTY, false)?;
+        if sync.count_index_queue_entries()? == 0 {
+            sync.set_dirty_flag(FLAG_INDEX_DIRTY, false)?;
+        }
         Ok(())
+    }
+
+    /// Enqueue every live item for derived search-index catch-up.
+    pub fn enqueue_full_index_rebuild(&self) -> Result<u64, ClipKittyError> {
+        use purr_sync::store::SyncStore;
+        use purr_sync::types::FLAG_INDEX_DIRTY;
+
+        let sync = SyncStore::new(self.db.pool());
+        sync.clear_index_queue()?;
+        sync.enqueue_index_reset()?;
+        let items = self.db.fetch_all_items()?;
+        for item in &items {
+            sync.enqueue_index_upsert(&item.item_id)?;
+        }
+        sync.set_dirty_flag(FLAG_INDEX_DIRTY, true)?;
+        Ok(items.len() as u64)
+    }
+
+    /// Process a bounded number of queued search-index updates.
+    pub fn process_index_queue(
+        &self,
+        max_items: u32,
+    ) -> Result<crate::interface::IndexMaintenanceOutcome, ClipKittyError> {
+        use crate::interface::IndexMaintenanceOutcome;
+        use purr_sync::store::SyncStore;
+        use purr_sync::types::{IndexQueueEntry, FLAG_INDEX_DIRTY};
+
+        let sync = SyncStore::new(self.db.pool());
+        if max_items == 0 {
+            let remaining = sync.count_index_queue_entries()?;
+            sync.set_dirty_flag(FLAG_INDEX_DIRTY, remaining > 0)?;
+            if remaining == 0 {
+                return Ok(IndexMaintenanceOutcome::Completed { processed: 0 });
+            }
+            return Ok(IndexMaintenanceOutcome::MoreRemaining {
+                processed: 0,
+                remaining: remaining as u64,
+            });
+        }
+
+        let entries = sync.fetch_index_queue(max_items as usize)?;
+        if entries.is_empty() {
+            sync.set_dirty_flag(FLAG_INDEX_DIRTY, false)?;
+            return Ok(IndexMaintenanceOutcome::Completed { processed: 0 });
+        }
+
+        let mut processed_queue_keys = Vec::with_capacity(entries.len());
+        for entry in &entries {
+            match entry {
+                IndexQueueEntry::Reset => {
+                    self.indexer.delete_all_documents()?;
+                }
+                IndexQueueEntry::Upsert { item_id } => {
+                    let item = self
+                        .db
+                        .fetch_items_by_item_ids(&[item_id.clone()])?
+                        .into_iter()
+                        .next();
+                    if let Some(item) = item {
+                        let text = item
+                            .file_index_text()
+                            .unwrap_or_else(|| item.text_content().to_string());
+                        self.indexer
+                            .add_document(&item.item_id, &text, item.timestamp_unix)?;
+                    } else {
+                        self.indexer.delete_document(item_id)?;
+                    }
+                }
+                IndexQueueEntry::Delete { item_id } => {
+                    self.indexer.delete_document(item_id)?;
+                }
+            }
+            processed_queue_keys.push(entry.queue_key());
+        }
+
+        self.indexer.commit()?;
+        sync.remove_index_queue_entries(&processed_queue_keys)?;
+        let remaining = sync.count_index_queue_entries()?;
+        if remaining == 0 {
+            sync.set_dirty_flag(FLAG_INDEX_DIRTY, false)?;
+            return Ok(IndexMaintenanceOutcome::Completed {
+                processed: processed_queue_keys.len() as u64,
+            });
+        }
+
+        sync.set_dirty_flag(FLAG_INDEX_DIRTY, true)?;
+        Ok(IndexMaintenanceOutcome::MoreRemaining {
+            processed: processed_queue_keys.len() as u64,
+            remaining: remaining as u64,
+        })
     }
 }
 
@@ -1381,6 +1466,52 @@ mod tests {
 
         let dup = store.save_text("hello world".into(), None, None).unwrap();
         assert!(dup.is_empty());
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn queued_full_index_rebuild_resets_stale_index_documents() {
+        let store = ClipboardStore::new_in_memory().unwrap();
+        let stale = insert_indexed_text_with_timestamp(&store, "stale search unit", 1000);
+        store.indexer.commit().unwrap();
+        assert_eq!(store.indexer.num_docs(), 1);
+
+        store.db.delete_item(stale.id.unwrap()).unwrap();
+
+        assert_eq!(store.enqueue_full_index_rebuild().unwrap(), 0);
+        let outcome = store.process_index_queue(64).unwrap();
+        assert!(matches!(
+            outcome,
+            crate::interface::IndexMaintenanceOutcome::Completed { processed: 1 }
+        ));
+        assert_eq!(store.indexer.num_docs(), 0);
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn queued_full_index_rebuild_processes_reset_before_live_upserts() {
+        let store = ClipboardStore::new_in_memory().unwrap();
+        insert_indexed_text_with_timestamp(&store, "live search unit", 1000);
+        store.indexer.commit().unwrap();
+        assert_eq!(store.indexer.num_docs(), 1);
+
+        assert_eq!(store.enqueue_full_index_rebuild().unwrap(), 1);
+        let reset_pass = store.process_index_queue(1).unwrap();
+        assert!(matches!(
+            reset_pass,
+            crate::interface::IndexMaintenanceOutcome::MoreRemaining {
+                processed: 1,
+                remaining: 1
+            }
+        ));
+        assert_eq!(store.indexer.num_docs(), 0);
+
+        let upsert_pass = store.process_index_queue(1).unwrap();
+        assert!(matches!(
+            upsert_pass,
+            crate::interface::IndexMaintenanceOutcome::Completed { processed: 1 }
+        ));
+        assert_eq!(store.indexer.num_docs(), 1);
     }
 
     #[tokio::test]

--- a/purr/tests/sync_tests.rs
+++ b/purr/tests/sync_tests.rs
@@ -18,7 +18,7 @@ use purr_sync::types::{
 };
 
 use purr::database::Database;
-use purr::interface::{FilePreviewSnapshot, ItemTag};
+use purr::interface::{FilePreviewSnapshot, ItemTag, ListPresentationProfile};
 use purr::ClipboardStore;
 use purr::ClipboardStoreApi;
 use tempfile::TempDir;
@@ -2642,6 +2642,184 @@ mod replay_audit_tests {
         assert_eq!(after_items.len(), 1);
         assert_eq!(after_items[0].id.unwrap(), before_id);
         assert_eq!(after_items[0].text_content(), "after edit");
+    }
+
+    #[tokio::test]
+    async fn remote_apply_enqueues_index_work_until_bounded_maintenance_runs() {
+        let (store, dir) = test_store();
+
+        let created = ItemEvent::new_local(
+            "remote-index-queue".to_string(),
+            "device-A",
+            ItemEventPayload::ItemCreated {
+                snapshot: text_snapshot("queued search text"),
+            },
+        );
+
+        store.apply_remote_event(event_record(&created)).unwrap();
+
+        let db = store_db(&dir);
+        assert_eq!(db.fetch_all_items().unwrap().len(), 1);
+        let sync = SyncStore::new(db.pool());
+        assert_eq!(sync.count_index_queue_entries().unwrap(), 1);
+        assert!(
+            store
+                .get_sync_device_state("device-A".to_string())
+                .unwrap()
+                .index_dirty
+        );
+
+        let before = store
+            .search(
+                "queued search text".to_string(),
+                ListPresentationProfile::CompactRow,
+            )
+            .await
+            .unwrap();
+        assert_eq!(before.total_count, 0);
+
+        let zero_batch = store.process_index_queue(0).unwrap();
+        assert!(matches!(
+            zero_batch,
+            purr::interface::IndexMaintenanceOutcome::MoreRemaining {
+                processed: 0,
+                remaining: 1
+            }
+        ));
+        assert_eq!(sync.count_index_queue_entries().unwrap(), 1);
+        assert!(
+            store
+                .get_sync_device_state("device-A".to_string())
+                .unwrap()
+                .index_dirty
+        );
+
+        let outcome = store.process_index_queue(1).unwrap();
+        assert!(matches!(
+            outcome,
+            purr::interface::IndexMaintenanceOutcome::Completed { processed: 1 }
+        ));
+        assert_eq!(sync.count_index_queue_entries().unwrap(), 0);
+        assert!(
+            !store
+                .get_sync_device_state("device-A".to_string())
+                .unwrap()
+                .index_dirty
+        );
+
+        let after = store
+            .search(
+                "queued search text".to_string(),
+                ListPresentationProfile::CompactRow,
+            )
+            .await
+            .unwrap();
+        assert_eq!(after.total_count, 1);
+    }
+
+    #[tokio::test]
+    async fn remote_delete_enqueues_index_delete_until_maintenance_runs() {
+        let (store, dir) = test_store();
+
+        let created = ItemEvent::new_local(
+            "remote-index-delete".to_string(),
+            "device-A",
+            ItemEventPayload::ItemCreated {
+                snapshot: text_snapshot("delete from search"),
+            },
+        );
+        store.apply_remote_event(event_record(&created)).unwrap();
+        store.process_index_queue(1).unwrap();
+
+        let before = store
+            .search(
+                "delete from search".to_string(),
+                ListPresentationProfile::CompactRow,
+            )
+            .await
+            .unwrap();
+        assert_eq!(before.total_count, 1);
+
+        let deleted = ItemEvent::new_local(
+            "remote-index-delete".to_string(),
+            "device-A",
+            ItemEventPayload::ItemDeleted {
+                base_existence_version: 1,
+            },
+        );
+        store.apply_remote_event(event_record(&deleted)).unwrap();
+
+        let db = store_db(&dir);
+        assert!(db.fetch_all_items().unwrap().is_empty());
+        let sync = SyncStore::new(db.pool());
+        assert_eq!(sync.count_index_queue_entries().unwrap(), 1);
+
+        store.process_index_queue(1).unwrap();
+        let after = store
+            .search(
+                "delete from search".to_string(),
+                ListPresentationProfile::CompactRow,
+            )
+            .await
+            .unwrap();
+        assert_eq!(after.total_count, 0);
+        assert_eq!(sync.count_index_queue_entries().unwrap(), 0);
+    }
+
+    #[test]
+    fn index_queue_processing_is_bounded_and_resumable() {
+        let (store, dir) = test_store();
+
+        let first = ItemEvent::new_local(
+            "remote-index-one".to_string(),
+            "device-A",
+            ItemEventPayload::ItemCreated {
+                snapshot: text_snapshot("first queued item"),
+            },
+        );
+        let second = ItemEvent::new_local(
+            "remote-index-two".to_string(),
+            "device-A",
+            ItemEventPayload::ItemCreated {
+                snapshot: text_snapshot("second queued item"),
+            },
+        );
+        store
+            .apply_remote_batch(vec![event_record(&first), event_record(&second)], vec![])
+            .unwrap();
+
+        let db = store_db(&dir);
+        let sync = SyncStore::new(db.pool());
+        assert_eq!(sync.count_index_queue_entries().unwrap(), 2);
+
+        let first_pass = store.process_index_queue(1).unwrap();
+        assert!(matches!(
+            first_pass,
+            purr::interface::IndexMaintenanceOutcome::MoreRemaining {
+                processed: 1,
+                remaining: 1
+            }
+        ));
+        assert_eq!(sync.count_index_queue_entries().unwrap(), 1);
+        assert!(
+            store
+                .get_sync_device_state("device-A".to_string())
+                .unwrap()
+                .index_dirty
+        );
+
+        let second_pass = store.process_index_queue(1).unwrap();
+        assert!(matches!(
+            second_pass,
+            purr::interface::IndexMaintenanceOutcome::Completed { processed: 1 }
+        ));
+        assert_eq!(sync.count_index_queue_entries().unwrap(), 0);
+        assert!(
+            !store
+                .get_sync_device_state("device-A".to_string())
+                .unwrap()
+                .index_dirty
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add real iOS background sync registration/scheduling with `BGAppRefreshTask` and `BGProcessingTask`, plus silent-push scheduling, expiration cancellation, and coalescing for overlapping wakes.
- Replace sync-time Tantivy writes with a durable, tagged index-maintenance queue (`reset`, `upsert`, `delete`) so CloudKit apply/token progress is no longer gated by large search-index commits.
- Process queued index work in bounded batches from foreground sync, full resync, launch repair, and headless background sync; full rebuilds reset stale index docs first and then resume live upserts across later passes.
- Preserve the suspension safety path for the supplied `0xdead10cc` crash: iOS suspension schedules future work, then waits for active Rust store operations to drain before preparing the store for suspend.
- Keep the shorter iCloud catch-up copy from the prior commit and add regression coverage for background scheduling, suspension scheduling, bounded queue replay, zero-sized batches, delete replay, and full-reset ordering.

## Crash note

The TestFlight report was a RunningBoard `0xdead10cc` termination while `applyRemoteBatch` was materializing SQLite state and Tantivy index files. This update removes the biggest fragile piece from that path: remote apply now updates the authoritative SQLite sync/read model and records derived search-index work durably, while Tantivy catches up in small committed batches. If iOS suspends or kills the app after the CloudKit token advances, the queue remains and indexing resumes later instead of forcing another huge foreground rebuild.

This still cannot make iOS grant unlimited background time for a single synchronous SQLite/Rust operation, but it makes the expensive derived-index portion resumable and keeps suspend cleanup from closing/preparing the store while tracked Rust work is still active.

## Validation

- `cargo check -p purr-sync -p purr`
- `cargo test -p purr --test sync_tests`
- `cargo test -p purr queued_full_index_rebuild`
- `cargo test -p purr-sync`
- `make check`
- `git diff --check`
- `xcodebuild build -workspace ClipKitty.xcworkspace -scheme ClipKittyAppleServices -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`

## iOS build blocker

The local Xcode install refused all iOS destinations before compilation:

- `xcodebuild build -workspace ClipKitty.xcworkspace -scheme ClipKittyiOS -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -workspace ClipKitty.xcworkspace -scheme ClipKittyiOS -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -workspace ClipKitty.xcworkspace -scheme ClipKittyiOS -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -workspace ClipKitty.xcworkspace -scheme ClipKittyiOSSmokeTest -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO`

Xcode reported no eligible destination because the local iOS 26.5 platform/runtime is not installed or not resolved, even though SDK paths are listed.
