### PR TITLE
Make destructive actions safe and feedback truthful across Mac and iOS

### DIFF
--- a/Sources/MacApp/Browser/BrowserSearchBar.swift
+++ b/Sources/MacApp/Browser/BrowserSearchBar.swift
@@ -86,12 +86,12 @@ struct BrowserSearchBar<FilterPopoverContent: View>: View {
                 .onKeyPress(characters: .decimalDigits, phases: .down) { keyPress in
                     onHandleNumberKey(keyPress)
                 }
-                .onKeyPress(.delete) {
+                .onKeyPress(.delete, phases: .down) { _ in
                     guard selectedItemAvailable else { return .ignored }
                     onDelete()
                     return .handled
                 }
-                .onKeyPress(.deleteForward) {
+                .onKeyPress(.deleteForward, phases: .down) { _ in
                     guard selectedItemAvailable else { return .ignored }
                     onDelete()
                     return .handled

--- a/Sources/MacApp/Browser/BrowserView.swift
+++ b/Sources/MacApp/Browser/BrowserView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct BrowserView: View {
     @Bindable var viewModel: BrowserViewModel
     let displayVersion: Int
+    let isPanelVisible: () -> Bool
 
     @ObservedObject private var settings = AppSettings.shared
     @State private var commandKeyEventMonitor: Any?
@@ -92,10 +93,16 @@ struct BrowserView: View {
                 .ignoresSafeArea(.all)
         )
         .overlay(alignment: .bottom) {
-            if let message = viewModel.mutationFailureMessage {
-                mutationFailureBanner(message: message)
-                    .padding(.bottom, 12)
+            // Transition and animation are scoped inside the overlay so the
+            // simultaneous restoreSnapshot list changes do not animate.
+            ZStack {
+                if let message = viewModel.mutationFailureMessage {
+                    mutationFailureBanner(message: message)
+                        .padding(.bottom, 12)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
+            .animation(.spring(duration: 0.25), value: viewModel.mutationFailureMessage)
         }
         .ignoresSafeArea(edges: .top)
         .onAppear {
@@ -229,6 +236,8 @@ struct BrowserView: View {
     private func installCommandKeyEventMonitor() {
         guard commandKeyEventMonitor == nil else { return }
         commandKeyEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard isPanelVisible() else { return event }
+
             if let number = commandNumber(from: event) {
                 return handleCommandNumberShortcut(number) ? nil : event
             }
@@ -236,11 +245,25 @@ struct BrowserView: View {
             // Configurable delete-item shortcut (default ⌘-)
             let deleteHotKey = AppSettings.shared.deleteHotKey
             let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if modifiers == deleteHotKey.modifierMask, UInt32(event.keyCode) == deleteHotKey.keyCode {
+            if modifiers == deleteHotKey.modifierMask,
+               UInt32(event.keyCode) == deleteHotKey.keyCode,
+               !event.isARepeat
+            {
                 if viewModel.selectedItem != nil {
                     viewModel.deleteSelectedItem()
                     return nil
                 }
+            }
+
+            // While a delete is pending, Cmd+Z intentionally undoes the item
+            // delete instead of text undo; otherwise the event passes through
+            // unchanged so the field editor keeps its text undo.
+            if modifiers == .command,
+               event.charactersIgnoringModifiers == "z",
+               viewModel.hasPendingDelete
+            {
+                viewModel.undoPendingDelete()
+                return nil
             }
 
             return event

--- a/Sources/MacApp/ClipboardStore.swift
+++ b/Sources/MacApp/ClipboardStore.swift
@@ -1117,17 +1117,20 @@ final class ClipboardStore {
 
     // MARK: - Actions
 
-    func paste(itemId: String, content: ClipboardContent) {
+    /// Writes the item to the pasteboard, returning whether the write succeeded.
+    /// Image writes convert off the main thread and are awaited so callers can
+    /// give honest feedback; text and file writes are synchronous and always succeed.
+    @discardableResult
+    func paste(itemId: String, content: ClipboardContent) async -> Bool {
         // Handle images differently - convert off main thread
         if case let .image(data, _, isAnimated) = content {
-            pasteImage(data: Data(data), isAnimated: isAnimated, itemId: itemId)
-            return
+            return await pasteImage(data: Data(data), isAnimated: isAnimated, itemId: itemId)
         }
 
         #if ENABLE_FILE_CLIPBOARD_ITEMS
             if case let .file(_, files) = content {
                 pasteFiles(files: files, itemId: itemId)
-                return
+                return true
             }
         #endif
 
@@ -1136,53 +1139,53 @@ final class ClipboardStore {
         Task { [weak self] in
             await self?.updateItemTimestamp(id: itemId)
         }
+        return true
     }
 
-    private func pasteImage(data: Data, isAnimated: Bool, itemId: String?) {
-        Task {
-            if isAnimated {
-                // Convert animated HEIC to GIF for pasting (CPU-intensive, use background)
-                let gifData: Data? = await withCheckedContinuation { continuation in
-                    Task.detached(priority: .userInitiated) {
-                        continuation.resume(returning: Self.convertAnimatedHEICToGIF(data))
-                    }
+    private func pasteImage(data: Data, isAnimated: Bool, itemId: String?) async -> Bool {
+        if isAnimated {
+            // Convert animated HEIC to GIF for pasting (CPU-intensive, use background)
+            let gifData: Data? = await withCheckedContinuation { continuation in
+                Task.detached(priority: .userInitiated) {
+                    continuation.resume(returning: Self.convertAnimatedHEICToGIF(data))
                 }
-
-                guard let gifData else {
-                    self.pasteboardMonitor.acknowledgeLocalWrite(changeCount: self.pasteboard.changeCount)
-                    return
-                }
-
-                let fallback = NSImage(data: data)?.tiffRepresentation
-                self.pasteboardMonitor.acknowledgeLocalWrite(
-                    changeCount: self.pasteService.writeAnimatedImage(gifData: gifData, tiffFallback: fallback)
-                )
-            } else {
-                // Convert from stored format (HEIC) to TIFF off main thread
-                let tiffData: Data? = await withCheckedContinuation { continuation in
-                    Task.detached(priority: .userInitiated) {
-                        guard let image = NSImage(data: data),
-                              let tiff = image.tiffRepresentation
-                        else {
-                            continuation.resume(returning: nil)
-                            return
-                        }
-                        continuation.resume(returning: tiff)
-                    }
-                }
-
-                guard let tiffData else {
-                    self.pasteboardMonitor.acknowledgeLocalWrite(changeCount: self.pasteboard.changeCount)
-                    return
-                }
-
-                self.pasteboardMonitor.acknowledgeLocalWrite(changeCount: self.pasteService.writeStaticImage(tiffData))
             }
 
-            if let itemId {
-                await self.updateItemTimestamp(id: itemId)
+            guard let gifData else {
+                pasteboardMonitor.acknowledgeLocalWrite(changeCount: pasteboard.changeCount)
+                return false
             }
+
+            let fallback = NSImage(data: data)?.tiffRepresentation
+            pasteboardMonitor.acknowledgeLocalWrite(
+                changeCount: pasteService.writeAnimatedImage(gifData: gifData, tiffFallback: fallback)
+            )
+        } else {
+            // Convert from stored format (HEIC) to TIFF off main thread
+            let tiffData: Data? = await withCheckedContinuation { continuation in
+                Task.detached(priority: .userInitiated) {
+                    guard let image = NSImage(data: data),
+                          let tiff = image.tiffRepresentation
+                    else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+                    continuation.resume(returning: tiff)
+                }
+            }
+
+            guard let tiffData else {
+                pasteboardMonitor.acknowledgeLocalWrite(changeCount: pasteboard.changeCount)
+                return false
+            }
+
+            pasteboardMonitor.acknowledgeLocalWrite(changeCount: pasteService.writeStaticImage(tiffData))
         }
+
+        if let itemId {
+            await updateItemTimestamp(id: itemId)
+        }
+        return true
     }
 
     /// Convert animated HEIC (HEICS) to GIF format

--- a/Sources/MacApp/ContentView.swift
+++ b/Sources/MacApp/ContentView.swift
@@ -44,7 +44,11 @@ struct ContentView: View {
         let contentRevision = store.contentRevision
         let isPanelVisible = store.isPanelVisible
 
-        return BrowserView(viewModel: viewModel, displayVersion: displayVersion)
+        return BrowserView(
+            viewModel: viewModel,
+            displayVersion: displayVersion,
+            isPanelVisible: { store.isPanelVisible }
+        )
             .onAppear {
                 viewModel.onAppear(
                     initialSearchQuery: initialSearchQuery,

--- a/Sources/MacApp/FloatingPanelController.swift
+++ b/Sources/MacApp/FloatingPanelController.swift
@@ -51,6 +51,9 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
     /// Initial search query to pre-fill (for CI screenshots)
     var initialSearchQuery: String?
 
+    /// Whether the Accessibility-permission notice has been shown this launch.
+    private var hasShownNoPermissionNotice = false
+
     private var textScaleCancellable: AnyCancellable?
 
     init(
@@ -374,29 +377,75 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
     }
 
     private func selectItem(itemId: String, content: ClipboardContent) {
-        store.paste(itemId: itemId, content: content)
         #if ENABLE_SYNTHETIC_PASTE
             let targetApp = hide()
-            switch AppSettings.shared.pasteMode {
-            case .autoPaste:
-                switch activationService.syntheticPasteBehavior(for: targetApp) {
-                case let .paste(targetApp):
-                    activationService.simulatePaste(to: targetApp)
+            Task { @MainActor in
+                guard await pasteReportingProgress(itemId: itemId, content: content) else { return }
+                switch AppSettings.shared.pasteMode {
+                case .autoPaste:
+                    switch activationService.syntheticPasteBehavior(for: targetApp) {
+                    case let .paste(targetApp):
+                        activationService.simulatePaste(to: targetApp)
+                    case .copyOnly:
+                        snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+                    }
                 case .copyOnly:
                     snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+                case .noPermission:
+                    showCopiedWithPermissionNotice()
                 }
-            case .copyOnly, .noPermission:
-                snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
             }
         #else
             hide()
-            snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+            Task { @MainActor in
+                guard await pasteReportingProgress(itemId: itemId, content: content) else { return }
+                snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+            }
         #endif
     }
 
     private func copyOnlyItem(itemId: String, content: ClipboardContent) {
-        store.paste(itemId: itemId, content: content)
         hide()
-        snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+        Task { @MainActor in
+            guard await pasteReportingProgress(itemId: itemId, content: content) else { return }
+            snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+        }
+    }
+
+    /// Writes the item to the pasteboard, surfacing a delayed progress snackbar
+    /// for slow image conversions and an error snackbar on failure.
+    private func pasteReportingProgress(itemId: String, content: ClipboardContent) async -> Bool {
+        let progressTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            snackbarWindow.showProgress(.preparingPaste)
+        }
+        let ok = await store.paste(itemId: itemId, content: content)
+        progressTask.cancel()
+        snackbarWindow.dismissProgress()
+        if !ok {
+            snackbarWindow.showNotification(.passive(message: String(localized: "Couldn’t copy image"), iconSystemName: "exclamationmark.triangle.fill"))
+        }
+        return ok
+    }
+
+    /// Copy succeeded but synthetic paste is unavailable because the Accessibility
+    /// permission is missing; tell the user how to enable it, once per launch.
+    private func showCopiedWithPermissionNotice() {
+        if hasShownNoPermissionNotice {
+            snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+            return
+        }
+        hasShownNoPermissionNotice = true
+        snackbarWindow.showNotification(
+            .actionable(
+                message: String(localized: "Copied. Enable Accessibility to paste automatically"),
+                iconSystemName: "exclamationmark.triangle.fill",
+                actionTitle: String(localized: "Enable")
+            ),
+            onAction: {
+                NotificationCenter.default.post(name: .clipKittyOpenSettings, object: nil)
+            }
+        )
     }
 }

--- a/Sources/MacApp/Resources/Localizable.xcstrings
+++ b/Sources/MacApp/Resources/Localizable.xcstrings
@@ -11801,7 +11801,63 @@
                   }
               }
           }
+      },
+    "Preparing image…": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Bild wird vorbereitet…" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Preparing image…" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Preparando imagen…" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Préparation de l’image…" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "画像を準備中…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이미지 준비 중…" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Preparando imagem…" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Подготовка изображения…" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "正在准备图像…" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "正在準備圖像…" } }
       }
+    },
+    "Couldn’t copy image": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Bild konnte nicht kopiert werden" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Couldn’t copy image" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No se pudo copiar la imagen" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Impossible de copier l’image" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "画像をコピーできませんでした" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이미지를 복사할 수 없음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não foi possível copiar a imagem" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось скопировать изображение" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法拷贝图像" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法拷貝圖像" } }
+      }
+    },
+    "Copied. Enable Accessibility to paste automatically": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Kopiert. Aktivieren Sie die Bedienungshilfen, um automatisch einzusetzen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Copied. Enable Accessibility to paste automatically" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Copiado. Activa Accesibilidad para pegar automáticamente" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Copié. Activez Accessibilité pour coller automatiquement" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コピー済み。自動でペーストするにはアクセシビリティを有効にしてください" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "복사됨. 자동으로 붙여넣으려면 손쉬운 사용을 활성화하세요" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Copiado. Ative a Acessibilidade para colar automaticamente" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Скопировано. Включите Универсальный доступ для автоматической вставки" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已拷贝。启用辅助功能以自动粘贴" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已拷貝。啟用輔助使用以自動貼上" } }
+      }
+    },
+    "Couldn’t save": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Konnte nicht gesichert werden" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Couldn’t save" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No se pudo guardar" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Impossible d’enregistrer" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "保存できませんでした" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "저장할 수 없음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não foi possível salvar" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось сохранить" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法存储" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法儲存" } }
+      }
+    }
   },
   "version": "1.0"
 }

--- a/Sources/MacApp/Snackbar.swift
+++ b/Sources/MacApp/Snackbar.swift
@@ -9,12 +9,28 @@ struct GlassBackgroundModifier: ViewModifier {
             content.glassEffect(.regular, in: .capsule)
         } else {
             content
-                .background(.thickMaterial, in: RoundedRectangle(cornerRadius: 10))
+                .background(.thickMaterial, in: Capsule())
                 .overlay(
-                    RoundedRectangle(cornerRadius: 10)
+                    Capsule()
                         .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
                 )
         }
+    }
+}
+
+/// Glass capsule shared by every Mac snackbar variant, so they all agree on
+/// shape, spacing, and type size; the iOS equivalent lives in RootView.swift.
+private struct SnackbarCapsule<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        HStack(spacing: 8) {
+            content
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .fixedSize()
+        .modifier(GlassBackgroundModifier())
     }
 }
 
@@ -42,13 +58,13 @@ private struct NotificationSnackbarView: View {
     let onAction: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
+        SnackbarCapsule {
             Image(systemName: kind.iconSystemName)
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(.secondary)
 
             Text(kind.message)
-                .font(.system(size: 14, weight: .medium))
+                .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.primary)
 
             if case let .actionable(_, _, actionTitle) = kind {
@@ -59,10 +75,6 @@ private struct NotificationSnackbarView: View {
                     .padding(.leading, 8)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .fixedSize()
-        .modifier(GlassBackgroundModifier())
     }
 }
 
@@ -71,7 +83,7 @@ private struct LaunchAtLoginNudgeView: View {
     let onDismiss: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
+        SnackbarCapsule {
             Image(systemName: "sunrise.fill")
                 .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(.orange)
@@ -98,10 +110,6 @@ private struct LaunchAtLoginNudgeView: View {
             .buttonStyle(.plain)
             .padding(.leading, 2)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .fixedSize()
-        .modifier(GlassBackgroundModifier())
     }
 }
 
@@ -109,7 +117,7 @@ private struct InfoSnackbarView: View {
     let kind: InfoKind
 
     var body: some View {
-        HStack(spacing: 8) {
+        SnackbarCapsule {
             if let icon = kind.iconSystemName {
                 Image(systemName: icon)
                     .font(.system(size: 16, weight: .medium))
@@ -123,9 +131,5 @@ private struct InfoSnackbarView: View {
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.primary)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .fixedSize()
-        .modifier(GlassBackgroundModifier())
     }
 }

--- a/Sources/MacApp/SnackbarWindow.swift
+++ b/Sources/MacApp/SnackbarWindow.swift
@@ -8,6 +8,8 @@ final class SnackbarWindow {
 
     private var nudgeWindow: NSWindow?
     private var notification: ActiveNotification?
+    private var progressWindow: NSWindow?
+    private var progressAnchoredToPanel = false
 
     /// Last known panel frame — used for positioning. Nil when panel is hidden.
     private var panelFrame: NSRect?
@@ -58,7 +60,12 @@ final class SnackbarWindow {
 
         if let existingWindow = nudgeWindow {
             existingWindow.contentView = hostingView
-            positionRelativeToPanel(existingWindow, size: fittingSize, panelFrame: panelFrame)
+            let target = frameRelativeToPanel(size: fittingSize, panelFrame: panelFrame)
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.15
+                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                existingWindow.animator().setFrame(target, display: true)
+            }
             existingWindow.orderFront(nil)
             return
         }
@@ -80,7 +87,10 @@ final class SnackbarWindow {
     func showNotification(_ kind: NotificationKind, onAction: (() -> Void)? = nil) {
         if let existing = notification {
             existing.dismissTask?.cancel()
-            existing.window.orderOut(nil)
+            // Cross-fade: the old window fades while the new one animates in.
+            // Windows animate independently, so a third notification mid-fade
+            // is safe.
+            fadeOutAndOrderOut(existing.window)
             notification = nil
         }
 
@@ -119,12 +129,54 @@ final class SnackbarWindow {
 
         animateIn(window, slideUp: !anchored)
 
+        // VoiceOver may suppress announcements from apps that never become
+        // active; the snackbar window is used as the element because this
+        // accessory app has no main window.
+        NSAccessibility.post(
+            element: window,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: kind.message,
+                .priority: NSAccessibilityPriorityLevel.high.rawValue,
+            ]
+        )
+
         notification = ActiveNotification(
             window: window,
             anchoredToPanel: anchored,
             dismissTask: scheduleDismiss(after: kind.duration),
             action: onAction
         )
+    }
+
+    // MARK: - Progress (explicitly dismissed, no auto-dismiss)
+
+    /// Shows a spinner snackbar for an in-flight operation. Stays up until
+    /// `dismissProgress()` is called; never produced by scheduler evaluation.
+    func showProgress(_ kind: InfoKind) {
+        guard progressWindow == nil else { return }
+
+        let view = SnackbarView(item: .info(kind), onAction: {}, onDismiss: {})
+        let hostingView = NSHostingView(rootView: view)
+        let fittingSize = hostingView.fittingSize
+        hostingView.frame = NSRect(origin: .zero, size: fittingSize)
+
+        let window = makeWindow(hostingView: hostingView)
+        let anchored = panelFrame != nil
+        if let panelFrame {
+            positionRelativeToPanel(window, size: fittingSize, panelFrame: panelFrame)
+        } else {
+            positionScreenCenter(window, size: fittingSize)
+        }
+        animateIn(window, slideUp: !anchored)
+        progressWindow = window
+        progressAnchoredToPanel = anchored
+    }
+
+    func dismissProgress() {
+        guard let progressWindow else { return }
+        self.progressWindow = nil
+        animateOut(progressWindow, slideUp: progressAnchoredToPanel)
     }
 
     func dismissNotification() {
@@ -155,14 +207,19 @@ final class SnackbarWindow {
     func hideAll() {
         dismissNudge()
         dismissNotification()
+        dismissProgress()
     }
 
     // MARK: - Positioning
 
-    private func positionRelativeToPanel(_ window: NSWindow, size: NSSize, panelFrame: NSRect) {
+    private func frameRelativeToPanel(size: NSSize, panelFrame: NSRect) -> NSRect {
         let x = panelFrame.minX
         let y = panelFrame.minY - size.height - 8
-        window.setFrame(NSRect(x: x, y: y, width: size.width, height: size.height), display: true)
+        return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
+
+    private func positionRelativeToPanel(_ window: NSWindow, size: NSSize, panelFrame: NSRect) {
+        window.setFrame(frameRelativeToPanel(size: size, panelFrame: panelFrame), display: true)
     }
 
     private func positionScreenCenter(_ window: NSWindow, size: NSSize) {
@@ -207,6 +264,15 @@ final class SnackbarWindow {
             endFrame.origin.y += slideUp ? 20 : -10
             window.animator().setFrame(endFrame, display: true)
             window.animator().alphaValue = 1
+        }
+    }
+
+    private func fadeOutAndOrderOut(_ window: NSWindow) {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.15
+            window.animator().alphaValue = 0
+        } completionHandler: {
+            window.orderOut(nil)
         }
     }
 

--- a/Sources/Shared/BrowserViewModel.swift
+++ b/Sources/Shared/BrowserViewModel.swift
@@ -15,6 +15,9 @@ public final class BrowserViewModel {
     private let onDismiss: () -> Void
     private let showSnackbarNotification: (NotificationKind, (() -> Void)?) -> Void
     private let dismissSnackbarNotification: () -> Void
+    /// How long a pending delete stays undoable before committing; injectable
+    /// so tests don't have to wait out the real undo window.
+    private let deleteCommitDelay: TimeInterval
 
     private enum SearchExecution {
         case idle
@@ -76,6 +79,7 @@ public final class BrowserViewModel {
     private var prefetchTask: Task<Void, Never>?
     private var previewSpinnerTask: Task<Void, Never>?
     private var pendingDeleteTask: Task<Void, Never>?
+    private var deleteCommitTask: Task<Void, Never>?
     private var pendingTagSettleTask: Task<Void, Never>?
     private var queryGeneration = 0
     private var previewGeneration = 0
@@ -107,7 +111,8 @@ public final class BrowserViewModel {
         onCopyOnly: @escaping (String, ClipboardContent) -> Void,
         onDismiss: @escaping () -> Void,
         showSnackbarNotification: @escaping (NotificationKind, (() -> Void)?) -> Void = { _, _ in },
-        dismissSnackbarNotification: @escaping () -> Void = {}
+        dismissSnackbarNotification: @escaping () -> Void = {},
+        deleteCommitDelay: TimeInterval = NotificationKind.undoWindow
     ) {
         self.client = client
         self.shouldGenerateLinkPreviews = shouldGenerateLinkPreviews
@@ -116,6 +121,7 @@ public final class BrowserViewModel {
         self.onDismiss = onDismiss
         self.showSnackbarNotification = showSnackbarNotification
         self.dismissSnackbarNotification = dismissSnackbarNotification
+        self.deleteCommitDelay = deleteCommitDelay
     }
 
     public var searchText: String {
@@ -187,6 +193,11 @@ public final class BrowserViewModel {
         return failure.message
     }
 
+    public var hasPendingDelete: Bool {
+        if case .deleting(.pending) = mutationState { return true }
+        return false
+    }
+
     /// Draft text for the currently-editing item, if any.
     /// Callers should prefer matching `editSession` directly.
     public var draftText: (itemId: String, text: String)? {
@@ -203,6 +214,7 @@ public final class BrowserViewModel {
     }
 
     public func handleDisplayReset(initialSearchQuery: String, contentRevision: Int = 0) {
+        flushPendingDelete()
         cancelInFlightWork()
         latestKnownContentRevision = contentRevision
         lastLoadedContentRevision = nil
@@ -211,7 +223,7 @@ public final class BrowserViewModel {
         previewPayloadsByItemId.removeAll()
         resolvedMatchedExcerptsByItemId.removeAll()
         overlayState = .none
-        mutationState = .idle
+        resetMutationStateUnlessCommitting()
         editSession = .inactive
         // Clear selection so the fresh search lands on the top item rather
         // than carrying the prior highlight across a hide/show cycle.
@@ -223,12 +235,37 @@ public final class BrowserViewModel {
     }
 
     public func prepareForSuspension() {
+        flushPendingDelete()
         cancelInFlightWork()
         dismissSnackbarNotification()
         overlayState = .none
-        mutationState = .idle
+        resetMutationStateUnlessCommitting()
         editSession = .inactive
         hasUserNavigated = false
+    }
+
+    /// Commits any still-pending delete immediately. Called when the UI is
+    /// about to reset or suspend, so an optimistic delete is never dropped on
+    /// the floor with the item silently resurrecting later.
+    private func flushPendingDelete() {
+        guard case .deleting(.pending) = mutationState else { return }
+        pendingDeleteTask?.cancel()
+        pendingDeleteTask = nil
+        commitPendingDelete()
+    }
+
+    /// Flushes a pending delete and waits for the commit to reach the store.
+    /// Used on iOS before suspension tears the container down.
+    public func flushPendingDeleteAndWait() async {
+        flushPendingDelete()
+        await deleteCommitTask?.value
+    }
+
+    /// `.deleting(.committing)` must survive resets: the commit task resets to
+    /// `.idle` itself, and `restoreDeleteFailure` matches on it.
+    private func resetMutationStateUnlessCommitting() {
+        if case .deleting(.committing) = mutationState { return }
+        mutationState = .idle
     }
 
     public func handleContentRevisionChange(_ contentRevision: Int, isPanelVisible: Bool) {
@@ -444,8 +481,9 @@ public final class BrowserViewModel {
 
     private func scheduleDeleteCommit() {
         pendingDeleteTask?.cancel()
+        let delay = deleteCommitDelay
         pendingDeleteTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(3))
+            try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 self?.commitPendingDelete()
@@ -559,12 +597,11 @@ public final class BrowserViewModel {
             editSession = .inactive
             return
         }
-        editSession = .inactive
 
-        guard let selectedItemState else {
-            showSnackbarNotification(.passive(message: String(localized: "Saved"), iconSystemName: "checkmark.circle.fill"), nil)
-            return
-        }
+        // Without a selected item there is nothing to write; claiming "Saved"
+        // here would be a lie, and clearing the draft would lose the edit.
+        guard let selectedItemState else { return }
+        editSession = .inactive
 
         let currentItem = selectedItemState.item
         let updatedContent = ClipboardContent.text(value: editedText)
@@ -597,15 +634,29 @@ public final class BrowserViewModel {
         resolvedMatchedExcerptsByItemId.removeValue(forKey: id)
         previewPayloadsByItemId[id] = PreviewPayload(item: updatedItem, decoration: nil)
 
-        showSnackbarNotification(.passive(message: String(localized: "Saved"), iconSystemName: "checkmark.circle.fill"), nil)
-
+        // The rows above update optimistically, but "Saved" only shows once the
+        // write actually lands; on failure the draft is restored and the rows
+        // return to DB truth.
         Task { [weak self] in
             guard let self else { return }
-            _ = await self.client.updateTextItem(itemId: id, text: editedText)
-            // Resubmit the active search so Rust re-evaluates whether this item
-            // still matches, re-ranks it, and emits fresh highlight ranges.
-            if !self.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                self.submitSearch(text: self.searchText, filter: self.contentState.request.filter)
+            switch await self.client.updateTextItem(itemId: id, text: editedText) {
+            case .success:
+                self.showSnackbarNotification(.passive(message: String(localized: "Saved"), iconSystemName: "checkmark.circle.fill"), nil)
+                // Resubmit the active search so Rust re-evaluates whether this item
+                // still matches, re-ranks it, and emits fresh highlight ranges.
+                if !self.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    self.submitSearch(text: self.searchText, filter: self.contentState.request.filter)
+                }
+            case .failure:
+                self.showSnackbarNotification(.passive(message: String(localized: "Couldn’t save"), iconSystemName: "exclamationmark.triangle.fill"), nil)
+                // Restore the draft unless the user already started a new edit.
+                if case .inactive = self.editSession {
+                    self.editSession = .dirty(itemId: id, draft: editedText)
+                }
+                self.previewPayloadsByItemId.removeValue(forKey: id)
+                // Resubmit even an empty query so the optimistic rows return
+                // to what the database actually holds.
+                self.submitSearch(request: self.contentState.request, targetContentRevision: self.latestKnownContentRevision)
             }
         }
     }
@@ -1286,8 +1337,10 @@ public final class BrowserViewModel {
         guard case let .deleting(.pending(transaction)) = mutationState else { return }
         pendingDeleteTask = nil
         mutationState = .deleting(.committing(transaction))
+        // The undo window is over; the Undo button must not outlive it.
+        dismissSnackbarNotification()
 
-        Task { [weak self] in
+        deleteCommitTask = Task { [weak self] in
             guard let self else { return }
             var lastError: ClipboardError?
             for itemId in transaction.deletedItemIds {

--- a/Sources/Shared/NotificationTypes.swift
+++ b/Sources/Shared/NotificationTypes.swift
@@ -12,6 +12,9 @@ public enum InfoKind: Equatable {
     case rebuildingIndex
     case catchingUpWithCloud
     case syncingCloudChanges(count: Int)
+    /// Shown by the Mac panel while an image paste is being prepared off the main
+    /// thread. Driven explicitly by the paste flow; never produced by scheduler evaluation.
+    case preparingPaste
 
     public var message: String {
         switch self {
@@ -21,6 +24,8 @@ public enum InfoKind: Equatable {
             return String(localized: "Catching up with iCloud")
         case let .syncingCloudChanges(count):
             return String(localized: "Syncing \(count) changes from iCloud")
+        case .preparingPaste:
+            return String(localized: "Preparing image…")
         }
     }
 
@@ -29,7 +34,7 @@ public enum InfoKind: Equatable {
     /// presentation).
     public var iconSystemName: String? {
         switch self {
-        case .rebuildingIndex:
+        case .rebuildingIndex, .preparingPaste:
             return nil
         case .catchingUpWithCloud, .syncingCloudChanges:
             return "icloud.and.arrow.down"
@@ -40,6 +45,11 @@ public enum InfoKind: Equatable {
 public enum NotificationKind: Equatable {
     case passive(message: String, iconSystemName: String)
     case actionable(message: String, iconSystemName: String, actionTitle: String)
+
+    /// How long an undoable action stays actionable. The delete commit delay
+    /// and the actionable snackbar duration both derive from this so the Undo
+    /// button never outlives the window in which undo still works.
+    public static let undoWindow: TimeInterval = 4.0
 
     public var message: String {
         switch self {
@@ -63,7 +73,7 @@ public enum NotificationKind: Equatable {
             let extraTime = Double(extraChars / 10) * 0.5
             return min(baseDuration + extraTime, 4.5)
         case .actionable:
-            return 4.0
+            return Self.undoWindow
         }
     }
 }

--- a/Sources/iOSApp/App/AppContainer.swift
+++ b/Sources/iOSApp/App/AppContainer.swift
@@ -113,8 +113,8 @@ final class AppContainer {
             repository: repository,
             previewLoader: previewLoader
         )
-        let clipboardService = iOSClipboardService()
         let settings = iOSSettingsStore()
+        let clipboardService = iOSClipboardService(settings: settings)
         let haptics = HapticsClient(settings: settings)
 
         return .success(AppContainer(

--- a/Sources/iOSApp/App/iOSSettingsStore.swift
+++ b/Sources/iOSApp/App/iOSSettingsStore.swift
@@ -24,11 +24,24 @@ final class iOSSettingsStore {
         }
     #endif
 
+    // MARK: - Pasteboard ingest state
+
+    /// The pasteboard `changeCount` already ingested by auto-add. This is
+    /// state, not a user-facing preference, so it bypasses the
+    /// `isInitializing`/`save()` flow and writes straight to UserDefaults.
+    /// Persistence is required because backgrounding tears down the container
+    /// and rebootstraps on foreground.
+    @ObservationIgnored
+    var lastIngestedPasteboardChangeCount: Int {
+        didSet { defaults.set(lastIngestedPasteboardChangeCount, forKey: lastIngestedPasteboardChangeCountKey) }
+    }
+
     // MARK: - Keys
 
     private let hapticsEnabledKey = "iOSHapticsEnabled"
     private let generateLinkPreviewsKey = "iOSGenerateLinkPreviews"
     private let autoAddFromClipboardKey = "iOSAutoAddFromClipboard"
+    private let lastIngestedPasteboardChangeCountKey = "iOSLastIngestedPasteboardChangeCount"
     #if ENABLE_ICLOUD_SYNC
         private let syncEnabledKey = "iOSSyncEnabled"
     #endif
@@ -47,6 +60,7 @@ final class iOSSettingsStore {
         hapticsEnabled = defaults.object(forKey: hapticsEnabledKey) as? Bool ?? true
         generateLinkPreviews = defaults.object(forKey: generateLinkPreviewsKey) as? Bool ?? true
         autoAddFromClipboard = defaults.object(forKey: autoAddFromClipboardKey) as? Bool ?? false
+        lastIngestedPasteboardChangeCount = defaults.object(forKey: lastIngestedPasteboardChangeCountKey) as? Int ?? 0
 
         #if ENABLE_ICLOUD_SYNC
             syncEnabled = defaults.object(forKey: syncEnabledKey) as? Bool ?? false

--- a/Sources/iOSApp/App/iOSSyncCoordinator.swift
+++ b/Sources/iOSApp/App/iOSSyncCoordinator.swift
@@ -165,6 +165,17 @@
                 return await engine.runBackgroundSyncCycle()
             }
         }
+
+        @discardableResult
+        func performUserInitiatedSync() async -> SyncEngine.BackgroundSyncResult {
+            switch runtime {
+            case .disabled:
+                return .unavailable
+            case let .enabled(_, engine):
+                engine.start()
+                return await engine.runBackgroundSyncCycle()
+            }
+        }
     }
 
     // MARK: - Background Sync

--- a/Sources/iOSApp/ClipKittyiOSApp.swift
+++ b/Sources/iOSApp/ClipKittyiOSApp.swift
@@ -1,3 +1,4 @@
+import Accessibility
 import ClipKittyAppleServices
 import ClipKittyRust
 import ClipKittyShared
@@ -95,6 +96,9 @@ final class AppState {
         withAnimation(.bouncy) {
             toast = ToastState(kind: kind, action: action)
         }
+        // Toasts are the only confirmation many actions give; make sure
+        // VoiceOver users hear them too.
+        AccessibilityNotification.Announcement(kind.message).post()
         Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(kind.duration))
             guard let self, self.toast.kind == kind else { return }
@@ -161,6 +165,18 @@ final class AppState {
 
     func autoAddFromClipboard() async {
         guard container.settings.autoAddFromClipboard else { return }
+
+        // Reading changeCount does not trigger the paste-consent alert. If the
+        // pasteboard has not changed since we last looked, skip the read so we
+        // don't prompt for "Allow Paste" on every foreground.
+        let changeCount = container.clipboardService.pasteboardChangeCount
+        guard changeCount != container.settings.lastIngestedPasteboardChangeCount else { return }
+
+        // Record this generation now, before attempting the read, so a user
+        // denial or unreadable content is not re-prompted for the same
+        // pasteboard generation; we intentionally respect the denial.
+        container.settings.lastIngestedPasteboardChangeCount = changeCount
+
         guard let content = container.clipboardService.readCurrentClipboard() else { return }
 
         let result: Result<String, ClipboardError>
@@ -426,6 +442,9 @@ struct ClipKittyiOSApp: App {
                 else {
                     return
                 }
+                // A delete inside its undo window must reach the store before
+                // the container is torn down, or the item resurrects later.
+                await session.appState.viewModel.flushPendingDeleteAndWait()
                 session.appState.prepareForSuspension()
                 session.container.prepareForSuspension()
             }
@@ -435,6 +454,7 @@ struct ClipKittyiOSApp: App {
             else {
                 return
             }
+            await session.appState.viewModel.flushPendingDeleteAndWait()
             session.appState.prepareForSuspension()
             session.container.prepareForSuspension()
         #endif

--- a/Sources/iOSApp/Resources/Localizable.xcstrings
+++ b/Sources/iOSApp/Resources/Localizable.xcstrings
@@ -5280,7 +5280,71 @@
                   }
               }
           }
+      },
+    "Couldn’t save" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konnte nicht gesichert werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn’t save"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo guardar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’enregistrer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장할 수 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível salvar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось сохранить"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法存储"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法儲存"
+          }
+        }
       }
+    }
   },
   "version" : "1.0"
 }

--- a/Sources/iOSApp/Services/iOSClipboardService.swift
+++ b/Sources/iOSApp/Services/iOSClipboardService.swift
@@ -15,6 +15,16 @@ enum PasteboardContent {
 
 @MainActor
 final class iOSClipboardService {
+    private let settings: iOSSettingsStore
+
+    init(settings: iOSSettingsStore) {
+        self.settings = settings
+    }
+
+    /// The current pasteboard generation. Reading `changeCount` never triggers
+    /// the system paste-consent alert, unlike reading the pasteboard contents.
+    var pasteboardChangeCount: Int { UIPasteboard.general.changeCount }
+
     func copy(content: ClipboardContent) {
         let pasteboard = UIPasteboard.general
         switch content {
@@ -37,6 +47,9 @@ final class iOSClipboardService {
                 pasteboard.string = first.filename
             }
         }
+        // Record our own write as already-ingested so auto-add never re-reads
+        // it back on the next foreground (mirrors the Mac acknowledgeLocalWrite).
+        settings.lastIngestedPasteboardChangeCount = pasteboard.changeCount
     }
 
     func readCurrentClipboard() -> PasteboardContent? {

--- a/Sources/iOSApp/Views/CardSurfaceModifier.swift
+++ b/Sources/iOSApp/Views/CardSurfaceModifier.swift
@@ -29,3 +29,12 @@ extension View {
         modifier(CardSurface())
     }
 }
+
+struct CardPressButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .opacity(configuration.isPressed ? 0.85 : 1)
+            .animation(.snappy(duration: 0.15), value: configuration.isPressed)
+    }
+}

--- a/Sources/iOSApp/Views/CardView.swift
+++ b/Sources/iOSApp/Views/CardView.swift
@@ -47,23 +47,24 @@ struct CardView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            metadataLine
-            contentPreview
-        }
-        .cardSurface()
-        .padding(.horizontal, 16)
-        .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityCardLabel)
-        .accessibilityHint(String(localized: "Double tap to copy"))
-        .accessibilityAddTraits(.isButton)
-        .onTapGesture {
+        Button {
             viewModel.copyOnlyItem(itemId: metadata.itemId)
             haptics.fire(.copy)
             appState.showToast(.copied)
+        } label: {
+            VStack(alignment: .leading, spacing: 10) {
+                metadataLine
+                contentPreview
+            }
+            .cardSurface()
+            .padding(.horizontal, 16)
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
-        .contextMenu { contextMenuActions }
+        .buttonStyle(CardPressButtonStyle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityCardLabel)
+        .accessibilityHint(String(localized: "Double tap to copy"))
+        .contextMenu(menuItems: { contextMenuActions }, preview: { cardPeek })
         .onDrag {
             let storeClient = container.storeClient
             return DragItemProvider.make(itemId: metadata.itemId) { id in
@@ -191,6 +192,58 @@ struct CardView: View {
                 highlightedText(displayExcerpt.text, highlights: displayExcerpt.highlights, font: .custom(FontManager.sansSerif, size: 15))
                     .lineLimit(2)
             }
+        }
+    }
+
+    // MARK: - Long-press peek
+
+    /// Expanded preview shown above the context menu; sized close to the card
+    /// width so the lift animation doesn't visibly morph.
+    @ViewBuilder
+    private var cardPeek: some View {
+        Group {
+            switch metadata.icon {
+            case let .symbol(iconType):
+                highlightedText(
+                    displayExcerpt.text,
+                    highlights: displayExcerpt.highlights,
+                    font: peekFont(for: iconType)
+                )
+                .lineLimit(30)
+                .padding(16)
+
+            case let .colorSwatch(rgba):
+                VStack(spacing: 12) {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(colorFromRGBA(rgba))
+                        .frame(height: 140)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .strokeBorder(.primary.opacity(0.1), lineWidth: 1)
+                        )
+
+                    Text(hexStringFromRGBA(rgba))
+                        .font(.custom(FontManager.mono, size: 17))
+                }
+                .padding(16)
+
+            case let .thumbnail(bytes):
+                CardImagePreview(itemId: metadata.itemId, thumbnailBytes: bytes)
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .padding(16)
+            }
+        }
+        .containerRelativeFrame(.horizontal, alignment: .leading) { length, _ in
+            max(length - 32, 0)
+        }
+    }
+
+    private func peekFont(for iconType: IconType) -> Font {
+        switch iconType {
+        case .text, .color:
+            return .custom(FontManager.mono, size: 15)
+        case .link, .image, .file:
+            return .custom(FontManager.sansSerif, size: 15)
         }
     }
 

--- a/Sources/iOSApp/Views/HomeFeedView.swift
+++ b/Sources/iOSApp/Views/HomeFeedView.swift
@@ -6,6 +6,10 @@ struct HomeFeedView: View {
     @Environment(AppState.self) private var appState
     @Environment(BrowserViewModel.self) private var viewModel
 
+    #if ENABLE_ICLOUD_SYNC
+        @Environment(iOSSyncCoordinator.self) private var syncCoordinator: iOSSyncCoordinator?
+    #endif
+
     @State private var isSearchActive = false
     @State private var previewItemId: String?
     @State private var hasAppeared = false
@@ -108,6 +112,9 @@ struct HomeFeedView: View {
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+        .refreshable {
+            await refreshFeed()
+        }
     }
 
     /// Filter out file items — iPhone app doesn't support file sharing.
@@ -128,6 +135,18 @@ struct HomeFeedView: View {
     }
 
     private var emptyStateView: some View {
+        ScrollView {
+            emptyStateContent
+                .frame(maxWidth: .infinity)
+                .containerRelativeFrame(.vertical)
+        }
+        .scrollContentBackground(.hidden)
+        .refreshable {
+            await refreshFeed()
+        }
+    }
+
+    private var emptyStateContent: some View {
         VStack(spacing: 16) {
             Spacer()
 
@@ -182,6 +201,16 @@ struct HomeFeedView: View {
 
     private func loadMatchedExcerptIfNeeded(for row: DisplayRow) {
         viewModel.loadMatchedExcerptsForItems([row.id])
+    }
+
+    /// Pull-to-refresh: kick an immediate iCloud sync cycle when sync is
+    /// available, then always requery the local store so a refresh does
+    /// something even with sync disabled or the feature flag off.
+    private func refreshFeed() async {
+        #if ENABLE_ICLOUD_SYNC
+            _ = await syncCoordinator?.performUserInitiatedSync()
+        #endif
+        appState.refreshFeed()
     }
 }
 

--- a/Sources/iOSApp/Views/PreviewScreen.swift
+++ b/Sources/iOSApp/Views/PreviewScreen.swift
@@ -349,8 +349,9 @@ struct PreviewScreen: View {
                         .glassEffect(.regular.interactive(), in: .capsule)
 
                         Button {
+                            // The view model toasts Saved itself once the
+                            // write actually lands.
                             viewModel.commitCurrentEdit()
-                            appState.showToast(.saved)
                         } label: {
                             Text(String(localized: "Save"))
                                 .font(.body.weight(.semibold))

--- a/Tests/UnitTests/BrowserViewModelTests.swift
+++ b/Tests/UnitTests/BrowserViewModelTests.swift
@@ -775,7 +775,8 @@ final class BrowserViewModelTests: XCTestCase {
             client: client,
             onSelect: { _, _ in },
             onCopyOnly: { _, _ in },
-            onDismiss: {}
+            onDismiss: {},
+            deleteCommitDelay: 0.05
         )
 
         viewModel.onAppear(initialSearchQuery: "")
@@ -785,7 +786,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         viewModel.deleteSelectedItem()
         await flushMainActor()
-        try? await Task.sleep(for: .milliseconds(3100))
+        try? await Task.sleep(for: .milliseconds(300))
         await flushMainActor()
 
         XCTAssertEqual(viewModel.itemIds, ["1", "2"])
@@ -1039,6 +1040,185 @@ final class BrowserViewModelTests: XCTestCase {
         }
     }
 
+    func testHasPendingDeleteTracksDeleteAndUndo() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 2
+        ))
+
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {}
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "first"))
+        await flushMainActor()
+
+        XCTAssertFalse(viewModel.hasPendingDelete)
+
+        viewModel.deleteSelectedItem()
+        await flushMainActor()
+
+        XCTAssertTrue(viewModel.hasPendingDelete)
+
+        viewModel.undoPendingDelete()
+        await flushMainActor()
+
+        XCTAssertFalse(viewModel.hasPendingDelete)
+    }
+
+    func testHasPendingDeleteIsFalseAfterCommit() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 2
+        ))
+
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {},
+            deleteCommitDelay: 0.05
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "first"))
+        await flushMainActor()
+
+        viewModel.deleteSelectedItem()
+        await flushMainActor()
+
+        XCTAssertTrue(viewModel.hasPendingDelete)
+
+        try? await Task.sleep(for: .milliseconds(300))
+        await flushMainActor()
+
+        XCTAssertFalse(viewModel.hasPendingDelete)
+        guard case .idle = viewModel.mutationState else {
+            return XCTFail("Expected idle mutation after commit")
+        }
+        XCTAssertEqual(client.deletedItemIds, ["1"])
+    }
+
+    func testHandleDisplayResetCommitsPendingDelete() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 2
+        ))
+
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {}
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "first"))
+        await flushMainActor()
+
+        viewModel.deleteSelectedItem()
+        await flushMainActor()
+        XCTAssertTrue(viewModel.hasPendingDelete)
+
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 1
+        ))
+        viewModel.handleDisplayReset(initialSearchQuery: "")
+        await flushMainActor()
+
+        // The pending delete commits instead of being dropped; the item must
+        // not resurrect in the fresh search.
+        XCTAssertEqual(client.deletedItemIds, ["1"])
+        XCTAssertFalse(viewModel.itemIds.contains("1"))
+    }
+
+    func testPrepareForSuspensionCommitsPendingDelete() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 2
+        ))
+
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {}
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "first"))
+        await flushMainActor()
+
+        viewModel.deleteSelectedItem()
+        await flushMainActor()
+        XCTAssertTrue(viewModel.hasPendingDelete)
+
+        viewModel.prepareForSuspension()
+        await viewModel.flushPendingDeleteAndWait()
+        await flushMainActor()
+
+        XCTAssertEqual(client.deletedItemIds, ["1"])
+    }
+
+    func testUndoSnackbarDismissedWhenCommitStarts() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 2
+        ))
+
+        var dismissCount = 0
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {},
+            dismissSnackbarNotification: { dismissCount += 1 },
+            deleteCommitDelay: 0.05
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "first"))
+        await flushMainActor()
+
+        viewModel.deleteSelectedItem()
+        await flushMainActor()
+        XCTAssertEqual(dismissCount, 0)
+
+        try? await Task.sleep(for: .milliseconds(300))
+        await flushMainActor()
+
+        // The Undo button must not outlive the window in which undo works.
+        XCTAssertEqual(dismissCount, 1)
+        XCTAssertEqual(client.deletedItemIds, ["1"])
+    }
+
     func testDeleteLastItemClearsSelection() async {
         let client = MockBrowserStoreClient()
         client.enqueueSearchResponse(BrowserSearchResponse(
@@ -1080,11 +1260,13 @@ final class BrowserViewModelTests: XCTestCase {
             totalCount: 1
         ))
 
+        var shownNotifications: [NotificationKind] = []
         let viewModel = BrowserViewModel(
             client: client,
             onSelect: { _, _ in },
             onCopyOnly: { _, _ in },
-            onDismiss: {}
+            onDismiss: {},
+            showSnackbarNotification: { kind, _ in shownNotifications.append(kind) }
         )
 
         viewModel.onAppear(initialSearchQuery: "")
@@ -1094,7 +1276,6 @@ final class BrowserViewModelTests: XCTestCase {
 
         viewModel.onTextEdit("edited text", for: "1", originalText: "original text")
         viewModel.commitCurrentEdit()
-        await flushMainActor()
 
         guard case let .text(value)? = viewModel.selectedItem?.content else {
             return XCTFail("Expected selected item text content")
@@ -1104,10 +1285,62 @@ final class BrowserViewModelTests: XCTestCase {
             return XCTFail("Expected optimistic baseline excerpt")
         }
         XCTAssertTrue(excerpt.text.contains("edited"))
+        // Saved must not show before the write lands.
+        XCTAssertTrue(shownNotifications.isEmpty)
+
+        await flushMainActor()
+
         XCTAssertEqual(client.updatedTexts.count, 1)
         XCTAssertEqual(client.updatedTexts.first?.itemId, "1")
         XCTAssertEqual(client.updatedTexts.first?.text, "edited text")
         XCTAssertEqual(viewModel.editSession, .inactive)
+        XCTAssertEqual(shownNotifications.map(\.message), [String(localized: "Saved")])
+    }
+
+    func testCommitEditFailureRestoresDraftAndRevertsRows() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "original text")],
+            firstPreviewPayload: nil,
+            totalCount: 1
+        ))
+        client.updateTextResult = .failure(.databaseOperationFailed(
+            operation: "updateTextItem",
+            underlying: NSError(domain: "ClipKitty", code: 7)
+        ))
+
+        var shownNotifications: [NotificationKind] = []
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {},
+            showSnackbarNotification: { kind, _ in shownNotifications.append(kind) }
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "original text"))
+        await flushMainActor()
+
+        viewModel.onTextEdit("edited text", for: "1", originalText: "original text")
+        // The failure path resubmits the search so rows return to DB truth.
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "original text")],
+            firstPreviewPayload: nil,
+            totalCount: 1
+        ))
+        viewModel.commitCurrentEdit()
+        await flushMainActor()
+
+        XCTAssertEqual(shownNotifications.map(\.message), [String(localized: "Couldn’t save")])
+        XCTAssertEqual(viewModel.editSession, .dirty(itemId: "1", draft: "edited text"))
+        guard case let .baseline(excerpt)? = viewModel.contentState.items.first?.presentation else {
+            return XCTFail("Expected baseline excerpt after revert")
+        }
+        XCTAssertTrue(excerpt.text.contains("original"))
     }
 
     func testDiscardEditClearsPendingState() async {
@@ -1513,7 +1746,8 @@ final class BrowserViewModelTests: XCTestCase {
             client: client,
             onSelect: { _, _ in },
             onCopyOnly: { _, _ in },
-            onDismiss: {}
+            onDismiss: {},
+            deleteCommitDelay: 0.05
         )
 
         viewModel.onAppear(initialSearchQuery: "")
@@ -1522,7 +1756,7 @@ final class BrowserViewModelTests: XCTestCase {
         await flushMainActor()
 
         viewModel.deleteSelectedItem()
-        try? await Task.sleep(for: .seconds(4))
+        try? await Task.sleep(for: .milliseconds(300))
         await flushMainActor()
 
         XCTAssertNotNil(viewModel.mutationFailureMessage)
@@ -1649,6 +1883,7 @@ private final class MockBrowserStoreClient: BrowserStoreClient {
     var addTagResult: Result<Void, ClipboardError> = .success(())
     var removeTagResult: Result<Void, ClipboardError> = .success(())
     var deleteResult: Result<Void, ClipboardError> = .success(())
+    var deletedItemIds: [String] = []
     var clearResult: Result<Void, ClipboardError> = .success(())
     var updateTextResult: Result<Void, ClipboardError> = .success(())
     var updatedTexts: [(itemId: String, text: String)] = []
@@ -1746,8 +1981,9 @@ private final class MockBrowserStoreClient: BrowserStoreClient {
         removeTagResult
     }
 
-    func delete(itemId _: String) async -> Result<Void, ClipboardError> {
-        deleteResult
+    func delete(itemId: String) async -> Result<Void, ClipboardError> {
+        deletedItemIds.append(itemId)
+        return deleteResult
     }
 
     func clear() async -> Result<Void, ClipboardError> {

--- a/Tests/iOSTests/iOSSettingsStoreTests.swift
+++ b/Tests/iOSTests/iOSSettingsStoreTests.swift
@@ -22,6 +22,15 @@ final class iOSSettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.hapticsEnabled)
         XCTAssertTrue(store.generateLinkPreviews)
         XCTAssertFalse(store.autoAddFromClipboard)
+        XCTAssertEqual(store.lastIngestedPasteboardChangeCount, 0)
+    }
+
+    func testLastIngestedPasteboardChangeCountPersists() {
+        let store = iOSSettingsStore(defaults: defaults)
+        store.lastIngestedPasteboardChangeCount = 42
+
+        let reloaded = iOSSettingsStore(defaults: defaults)
+        XCTAssertEqual(reloaded.lastIngestedPasteboardChangeCount, 42)
     }
 
     func testHapticsEnabledPersists() {

--- a/Tests/iOSTests/iOSSyncCoordinatorTests.swift
+++ b/Tests/iOSTests/iOSSyncCoordinatorTests.swift
@@ -485,6 +485,38 @@
             XCTAssertTrue(createdEngines.isEmpty)
         }
 
+        // MARK: - User-initiated sync
+
+        func testPerformUserInitiatedSyncStartsEngineAndRunsCycleWhenEnabled() async {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: true,
+                onContentChanged: {},
+                engineFactory: spyFactory()
+            )
+            latestEngine?.stubbedBackgroundSyncResult = .failed("network")
+
+            let result = await coordinator.performUserInitiatedSync()
+
+            XCTAssertEqual(result, .failed("network"))
+            XCTAssertEqual(latestEngine?.startCallCount, 1)
+            XCTAssertEqual(latestEngine?.runBackgroundSyncCycleCallCount, 1)
+        }
+
+        func testPerformUserInitiatedSyncReturnsUnavailableWhenDisabled() async {
+            let coordinator = iOSSyncCoordinator(
+                store: store,
+                enabled: false,
+                onContentChanged: {},
+                engineFactory: spyFactory()
+            )
+
+            let result = await coordinator.performUserInitiatedSync()
+
+            XCTAssertEqual(result, .unavailable)
+            XCTAssertTrue(createdEngines.isEmpty)
+        }
+
         // MARK: - Background runner cancellation
 
         func testCancelInFlightSyncKeepsLaterWakeJoinedUntilOperationFinishes() async {


### PR DESCRIPTION
## Summary

A UX pass focused on destructive-action safety, honest feedback, and snackbar polish. Eight items from a code-grounded UX audit of both apps.

### Mac panel safety
- The Cmd+1-9 / delete-hotkey event monitor now checks live panel visibility. Previously it stayed armed while the panel was hidden, so pressing Cmd+1 in Settings silently overwrote the clipboard and Cmd+- silently deleted the newest history item; it also made those combos unrecordable in the hotkey recorder.
- The delete shortcut ignores key repeats, so holding it no longer chain-deletes items.
- Cmd+Z during the undo window undoes the pending delete; otherwise the event passes through so text undo keeps working.

### Truthful paste pipeline (Mac)
- `ClipboardStore.paste` is now `async -> Bool`; image conversion failures show "Couldn't copy image" instead of a false success toast.
- Image conversions slower than 150ms show a spinner snackbar.
- When the Accessibility permission is missing, the first paste shows an actionable "Enable" snackbar that opens Settings, instead of silently degrading to copy-only.
- Mac snackbars post VoiceOver announcements.

### Durable deletes and honest saves (shared view model)
- Pending deletes commit on display reset and suspension instead of being dropped (the deleted item used to resurrect later). iOS awaits the commit before container teardown.
- The Undo snackbar is dismissed the moment the commit starts; the commit delay and snackbar duration derive from one shared `undoWindow` constant.
- "Saved" only shows after the database write lands. On failure: "Couldn't save", the draft is restored, and optimistic rows revert to DB truth.
- iOS toasts post VoiceOver announcements.

### iOS quality of life
- Clipboard auto-add is gated behind a persisted `changeCount` guard, so the system Allow Paste prompt only appears when the pasteboard actually changed; the app also never re-reads its own writes.
- Pull-to-refresh triggers an immediate iCloud sync cycle (works on the empty state too), then requeries.
- Feed cards get press-scale feedback and a long-press content peek via the context-menu preview.

### Snackbar and motion polish (Mac)
- All snackbar variants share one capsule container (uniform metrics, icon and text sizes; the pre-macOS-26 fallback is now also a capsule).
- Replacing a notification cross-fades instead of blinking; nudge repositioning animates; the mutation-failure banner springs in and out, scoped so simultaneous list restores do not animate.

New strings ("Preparing image…", "Couldn't copy image", "Copied. Enable Accessibility to paste automatically", "Couldn't save") are localized in all ten languages in both catalogs.

## Testing

- Mac build and iOS simulator build pass.
- Mac unit tests: 160/160 pass, including 6 new tests covering flush-on-reset, flush-on-suspension, undo-snackbar dismissal on commit, truthful Saved ordering, and the save-failure path. (The 14 failures in the scheme's full test action are pre-existing: iOS XCUIApplication UI tests hosted in the Mac unit bundle fail with "No target application path" on main as well.)
- iOS unit tests: 79/79 pass.
- `make check` (repo invariants incl. catalog validation) passes.
- Manual checks recommended on a real Mac: VoiceOver announcement delivery from a never-active accessory app, and clicking the "Enable" snackbar button while ClipKitty is inactive.