### PR TITLE
Add interactive storage limit bar with usage visualization

### DIFF
--- a/Sources/MacApp/ClipboardStore.swift
+++ b/Sources/MacApp/ClipboardStore.swift
@@ -1367,15 +1367,22 @@ final class ClipboardStore {
     // MARK: - Pruning
 
     func pruneIfNeeded() {
+        Task { await pruneToLimit() }
+    }
+
+    /// Prune the database to the configured size limit, then refresh the
+    /// cached size so observing views update.
+    func pruneToLimit() async {
         let maxSizeGB = AppSettings.shared.maxDatabaseSizeGB
         guard maxSizeGB > 0, let repository else { return }
 
-        let maxBytes = Int64(maxSizeGB * 1024 * 1024 * 1024)
-
-        Task {
-            if case let .failure(error) = await repository.pruneToSize(maxBytes: maxBytes, keepRatio: 0.8) {
-                ErrorReporter.report(error, showToast: false)
-            }
+        if case let .failure(error) = await repository.pruneToSize(
+            maxBytes: Utilities.bytes(fromGB: maxSizeGB)
+        ) {
+            ErrorReporter.report(error, showToast: false)
+        }
+        if case let .success(size) = await repository.databaseSize() {
+            databaseSizeBytes = size
         }
     }
 }

--- a/Sources/MacApp/Resources/Localizable.xcstrings
+++ b/Sources/MacApp/Resources/Localizable.xcstrings
@@ -2,6 +2,7 @@
   "sourceLanguage": "en",
   "strings": {
     "": {},
+    "%.0f GB": {},
     "%.0f KB": {},
     "%.1f GB": {},
     "%.1f MB": {},
@@ -16,6 +17,7 @@
         }
       }
     },
+    "%@ limit, %@ used": {},
     "%lld": {},
     "%lld bytes": {},
     "About": {
@@ -368,6 +370,9 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "應用程式字體" } }
       }
     },
+    "Drag the handle to set how much space history can use. When it fills, the oldest items are overwritten.": {},
+    "Drag to set the storage limit": {},
+    "History already uses more space than the new limit. The oldest items will be removed to fit.": {},
     "Preview Character Spacing": {
       "localizations": {
         "de": { "stringUnit": { "state": "translated", "value": "Zeichenabstand der Vorschau" } },
@@ -396,6 +401,8 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "ClipKitty 緊湊而獨特的字體。" } }
       }
     },
+    "Reduce Storage Limit?": {},
+    "Remove Oldest Items": {},
     "The native macOS system font.": {
       "localizations": {
         "de": { "stringUnit": { "state": "translated", "value": "Die native macOS-Systemschrift." } },
@@ -10452,6 +10459,7 @@
         }
       }
     },
+    "of %@": {},
     "⌘-": {},
     "⌘K Actions": {
       "localizations": {

--- a/Sources/MacApp/Settings/GeneralSettingsView.swift
+++ b/Sources/MacApp/Settings/GeneralSettingsView.swift
@@ -18,6 +18,8 @@ struct GeneralSettingsView: View {
     @State private var isICloudAvailable = true
     @State private var iCloudStatusMessage: String? = nil
     @State private var logsCopied = false
+    @State private var committedLimitGB: Double?
+    @State private var showShrinkConfirmation = false
 
     let store: ClipboardStore
     #if ENABLE_SPARKLE_UPDATES
@@ -31,8 +33,7 @@ struct GeneralSettingsView: View {
         return formatter
     }()
 
-    private let minDatabaseSizeGB = 0.5
-    private let maxDatabaseSizeGB = 64.0
+    private let limitScale = StorageLimitScale()
 
     private var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
@@ -117,25 +118,47 @@ struct GeneralSettingsView: View {
             }
 
             Section(String(localized: "History")) {
-                LabeledContent(String(localized: "Storage Limit")) {
-                    HStack(spacing: 8) {
-                        Slider(value: databaseSizeSlider, in: 0 ... 1)
-                            .frame(maxWidth: .infinity)
-                        Text(databaseSizeLabel)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 80, alignment: .trailing)
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-
-                Text(
-                    String(
-                        localized:
-                        "Currently using \(Utilities.formatBytes(store.databaseSizeBytes)). Oldest items removed when limit is reached."
+                VStack(spacing: 10) {
+                    StorageBarView(
+                        limitGB: $settings.maxDatabaseSizeGB,
+                        usedBytes: store.databaseSizeBytes,
+                        scale: limitScale,
+                        onEditingEnded: handleStorageLimitEdit
                     )
-                )
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+
+                    Text(
+                        String(
+                            localized:
+                            "Drag the handle to set how much space history can use. When it fills, the oldest items are overwritten."
+                        )
+                    )
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+                .alert(
+                    String(localized: "Reduce Storage Limit?"),
+                    isPresented: $showShrinkConfirmation
+                ) {
+                    Button(String(localized: "Remove Oldest Items"), role: .destructive) {
+                        committedLimitGB = settings.maxDatabaseSizeGB
+                        Task { await store.pruneToLimit() }
+                    }
+                    Button(String(localized: "Cancel"), role: .cancel) {
+                        if let committed = committedLimitGB {
+                            settings.maxDatabaseSizeGB = committed
+                        }
+                    }
+                } message: {
+                    Text(
+                        String(
+                            localized:
+                            "History already uses more space than the new limit. The oldest items will be removed to fit."
+                        )
+                    )
+                }
 
                 Button(role: .destructive) {
                     showClearConfirmation = true
@@ -330,8 +353,20 @@ struct GeneralSettingsView: View {
         .onAppear {
             store.refreshDatabaseSize()
             if settings.maxDatabaseSizeGB <= 0 {
-                settings.maxDatabaseSizeGB = minDatabaseSizeGB
+                settings.maxDatabaseSizeGB = limitScale.minGB
             }
+            committedLimitGB = settings.maxDatabaseSizeGB
+        }
+    }
+
+    /// Called when the user releases the dial knob. Shrinking the limit below
+    /// the space already used deletes the oldest items, so confirm first;
+    /// otherwise just remember the new value as the committed one.
+    private func handleStorageLimitEdit() {
+        if store.databaseSizeBytes > Utilities.bytes(fromGB: settings.maxDatabaseSizeGB) {
+            showShrinkConfirmation = true
+        } else {
+            committedLimitGB = settings.maxDatabaseSizeGB
         }
     }
 
@@ -344,39 +379,6 @@ struct GeneralSettingsView: View {
                 }
             }
         )
-    }
-
-    private var databaseSizeSlider: Binding<Double> {
-        Binding(
-            get: {
-                sliderValue(for: max(settings.maxDatabaseSizeGB, minDatabaseSizeGB))
-            },
-            set: { newValue in
-                settings.maxDatabaseSizeGB = gbValue(for: newValue)
-            }
-        )
-    }
-
-    private var databaseSizeLabel: String {
-        String(localized: "\(settings.maxDatabaseSizeGB, specifier: "%.1f") GB")
-    }
-
-    private func sliderValue(for gb: Double) -> Double {
-        let clamped = min(max(gb, minDatabaseSizeGB), maxDatabaseSizeGB)
-        let ratio = maxDatabaseSizeGB / minDatabaseSizeGB
-        return log(clamped / minDatabaseSizeGB) / log(ratio)
-    }
-
-    private func gbValue(for sliderValue: Double) -> Double {
-        let ratio = maxDatabaseSizeGB / minDatabaseSizeGB
-        let value = minDatabaseSizeGB * pow(ratio, sliderValue)
-        let rounded: Double
-        if value >= 1.0 {
-            rounded = value.rounded()
-        } else {
-            rounded = (value * 10).rounded() / 10
-        }
-        return min(max(rounded, minDatabaseSizeGB), maxDatabaseSizeGB)
     }
 
     #if ENABLE_ICLOUD_SYNC

--- a/Sources/Shared/ClipboardRepository.swift
+++ b/Sources/Shared/ClipboardRepository.swift
@@ -217,7 +217,10 @@ public final class ClipboardRepository: @unchecked Sendable {
         }
     }
 
-    public func pruneToSize(maxBytes: Int64, keepRatio: Double) async -> Result<UInt64, ClipboardError> {
+    /// Prune oldest items until the database fits within `maxBytes`. When
+    /// over the limit, prunes down to `keepRatio` of it so the store isn't
+    /// re-pruned on every new item.
+    public func pruneToSize(maxBytes: Int64, keepRatio: Double = 0.8) async -> Result<UInt64, ClipboardError> {
         await runRepositoryOperation("pruneToSize", on: store) { store in
             try store.pruneToSize(maxBytes: maxBytes, keepRatio: keepRatio)
         }

--- a/Sources/Shared/StorageBar.swift
+++ b/Sources/Shared/StorageBar.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+
+/// Logarithmic mapping between a normalized control position in `0...1` and a
+/// storage amount in gigabytes. Equal travel corresponds to equal size
+/// ratios, so small limits (0.5–2 GB) are as easy to pick as large ones.
+public struct StorageLimitScale: Equatable, Sendable {
+    public let minGB: Double
+    public let maxGB: Double
+
+    public init(minGB: Double = 0.5, maxGB: Double = 64.0) {
+        self.minGB = minGB
+        self.maxGB = maxGB
+    }
+
+    /// Control position in `0...1` for a size in gigabytes (clamped to the range).
+    public func position(forGB gb: Double) -> Double {
+        let clamped = min(max(gb, minGB), maxGB)
+        return log(clamped / minGB) / log(maxGB / minGB)
+    }
+
+    /// Size in gigabytes for a control position in `0...1`, rounded so values
+    /// read cleanly: whole gigabytes from 1 GB up, tenths below.
+    public func gb(forPosition position: Double) -> Double {
+        let clamped = min(max(position, 0), 1)
+        return rounded(minGB * pow(maxGB / minGB, clamped))
+    }
+
+    /// The next clean value in the given direction (+1/-1), for keyboard and
+    /// VoiceOver adjustment: 1 GB steps from 1 GB up, 0.1 GB steps below.
+    public func adjusting(_ gb: Double, by direction: Int) -> Double {
+        let fineStep = gb < 1.0 || (gb == 1.0 && direction < 0)
+        return rounded(gb + (fineStep ? 0.1 : 1.0) * Double(direction))
+    }
+
+    private func rounded(_ gb: Double) -> Double {
+        let rounded = gb >= 1.0 ? gb.rounded() : (gb * 10).rounded() / 10
+        return min(max(rounded, minGB), maxGB)
+    }
+}
+
+/// A horizontal allotment bar that sets the storage limit and visualizes how
+/// much of it is already used.
+///
+/// The draggable handle sets the limit on a logarithmic scale; the filled
+/// region grows from the left toward the handle as history accumulates. When
+/// the fill reaches the handle the allotted space is full and the oldest
+/// items are overwritten in place, the same way the underlying storage
+/// recycles itself.
+public struct StorageBarView: View {
+    @Binding private var limitGB: Double
+    private let usedBytes: Int64
+    private let scale: StorageLimitScale
+    private let onEditingEnded: () -> Void
+
+    @State private var isDragging = false
+
+    public init(
+        limitGB: Binding<Double>,
+        usedBytes: Int64,
+        scale: StorageLimitScale = StorageLimitScale(),
+        onEditingEnded: @escaping () -> Void = {}
+    ) {
+        _limitGB = limitGB
+        self.usedBytes = usedBytes
+        self.scale = scale
+        self.onEditingEnded = onEditingEnded
+    }
+
+    private let trackHeight: CGFloat = 26
+    private let handleWidth: CGFloat = 9
+    private let handleOvershoot: CGFloat = 5
+
+    private var limitPosition: Double { scale.position(forGB: limitGB) }
+
+    /// How much of the allotted space is used, in `0...1`.
+    private var usedFraction: Double {
+        let limitBytes = Utilities.bytes(fromGB: limitGB)
+        guard limitBytes > 0 else { return 0 }
+        return min(max(Double(usedBytes) / Double(limitBytes), 0), 1)
+    }
+
+    private var isFull: Bool { usedFraction >= 0.999 }
+
+    public var body: some View {
+        VStack(spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(Utilities.formatBytes(usedBytes))
+                    .font(.system(.body, design: .rounded).weight(.semibold))
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                if isFull {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Text(String(localized: "of \(Self.formatGB(limitGB))"))
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+                Spacer(minLength: 0)
+            }
+
+            GeometryReader { proxy in
+                track(width: proxy.size.width)
+                    .contentShape(Rectangle())
+                    .gesture(dragGesture(width: proxy.size.width))
+            }
+            .frame(height: trackHeight + handleOvershoot * 2)
+
+            HStack {
+                Text(Self.formatGB(scale.minGB))
+                Spacer(minLength: 0)
+                Text(Self.formatGB(scale.maxGB))
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+        .animation(isDragging ? nil : .snappy(duration: 0.35), value: limitGB)
+        .animation(.snappy(duration: 0.45), value: usedBytes)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(String(localized: "Storage Limit")))
+        .accessibilityValue(
+            Text(
+                String(
+                    localized:
+                    "\(Self.formatGB(limitGB)) limit, \(Utilities.formatBytes(usedBytes)) used"
+                )
+            )
+        )
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment:
+                limitGB = scale.adjusting(limitGB, by: 1)
+            case .decrement:
+                limitGB = scale.adjusting(limitGB, by: -1)
+            @unknown default:
+                return
+            }
+            onEditingEnded()
+        }
+        .help(String(localized: "Drag to set the storage limit"))
+    }
+
+    // MARK: - Pieces
+
+    private func track(width: CGFloat) -> some View {
+        let allotmentWidth = allotmentWidth(in: width)
+        let fillWidth = fillWidth(allotmentWidth: allotmentWidth)
+
+        return ZStack(alignment: .leading) {
+            Capsule()
+                .fill(.quaternary.opacity(0.5))
+                .frame(height: trackHeight)
+
+            Capsule()
+                .fill(Color.accentColor.opacity(0.15))
+                .frame(width: allotmentWidth, height: trackHeight)
+
+            if fillWidth > 0 {
+                Capsule()
+                    .fill(fillGradient)
+                    .frame(width: fillWidth, height: trackHeight)
+            }
+
+            handle
+                .position(
+                    x: allotmentWidth - handleWidth / 2 - 2,
+                    y: trackHeight / 2 + handleOvershoot
+                )
+        }
+        .frame(height: trackHeight + handleOvershoot * 2)
+    }
+
+    private var handle: some View {
+        Capsule()
+            .fill(.background)
+            .overlay(Capsule().strokeBorder(Color.accentColor, lineWidth: 2))
+            .frame(width: handleWidth, height: trackHeight + handleOvershoot * 2)
+            .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
+            .scaleEffect(isDragging ? 1.1 : 1)
+            .animation(.snappy(duration: 0.2), value: isDragging)
+    }
+
+    private var fillGradient: LinearGradient {
+        LinearGradient(
+            colors: [Color.accentColor.opacity(0.45), Color.accentColor],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    }
+
+    private static func formatGB(_ gb: Double) -> String {
+        gb >= 1
+            ? String(localized: "\(gb, specifier: "%.0f") GB")
+            : String(localized: "\(gb, specifier: "%.1f") GB")
+    }
+
+    // MARK: - Geometry
+
+    /// Width of the allotted region: from the left edge to the handle. Never
+    /// narrower than the capsule's end caps so it stays visually coherent.
+    private func allotmentWidth(in width: CGFloat) -> CGFloat {
+        let minWidth = trackHeight
+        return minWidth + (width - minWidth) * limitPosition
+    }
+
+    /// Width of the usage fill inside the allotment. Anything stored at all
+    /// shows as a visible dot.
+    private func fillWidth(allotmentWidth: CGFloat) -> CGFloat {
+        guard usedBytes > 0 else { return 0 }
+        return max(allotmentWidth * usedFraction, trackHeight)
+    }
+
+    private func dragGesture(width: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                isDragging = true
+                let minWidth = trackHeight
+                let position = (value.location.x - minWidth) / max(width - minWidth, 1)
+                limitGB = scale.gb(forPosition: position)
+            }
+            .onEnded { _ in
+                isDragging = false
+                onEditingEnded()
+            }
+    }
+}
+
+#Preview {
+    StorageBarPreviewHost()
+}
+
+private struct StorageBarPreviewHost: View {
+    @State private var limitGB = 7.0
+
+    var body: some View {
+        StorageBarView(limitGB: $limitGB, usedBytes: 2_470_000_000)
+            .frame(width: 360)
+            .padding()
+    }
+}

--- a/Sources/Shared/Utilities.swift
+++ b/Sources/Shared/Utilities.swift
@@ -23,6 +23,13 @@ public enum Utilities {
         }
     }
 
+    /// Convert a size in gigabytes to bytes.
+    /// - Parameter gb: Size in gigabytes (binary: 1 GB = 1024³ bytes)
+    /// - Returns: Size in bytes
+    public static func bytes(fromGB gb: Double) -> Int64 {
+        Int64(gb * 1024 * 1024 * 1024)
+    }
+
     /// Compute SHA-256 hash of a file
     /// - Parameter url: File URL to hash
     /// - Returns: Lowercase hex string of the hash, or nil if file cannot be read

--- a/Sources/iOSApp/App/AppContainer.swift
+++ b/Sources/iOSApp/App/AppContainer.swift
@@ -150,6 +150,19 @@ final class AppContainer {
         store.prepareForSuspend()
     }
 
+    /// Prune the database to the user's storage limit, removing oldest items
+    /// first. Runs once at bootstrap and again when the limit is lowered in
+    /// Settings.
+    func pruneToStorageLimit() async {
+        let maxGB = settings.maxDatabaseSizeGB
+        guard maxGB > 0 else { return }
+        if case let .failure(error) = await repository.pruneToSize(
+            maxBytes: Utilities.bytes(fromGB: maxGB)
+        ) {
+            Self.logger.error("Storage limit prune failed: \(error.localizedDescription)")
+        }
+    }
+
     #if ENABLE_ICLOUD_SYNC
         private static func logIndexMaintenanceOutcome(
             _ outcome: IndexMaintenanceOutcome,

--- a/Sources/iOSApp/App/iOSSettingsStore.swift
+++ b/Sources/iOSApp/App/iOSSettingsStore.swift
@@ -18,6 +18,12 @@ final class iOSSettingsStore {
         didSet { save() }
     }
 
+    /// Maximum database size in gigabytes; oldest items are pruned beyond it.
+    /// Matches the macOS default of 7 GB.
+    var maxDatabaseSizeGB: Double {
+        didSet { save() }
+    }
+
     #if ENABLE_ICLOUD_SYNC
         var syncEnabled: Bool {
             didSet { save() }
@@ -29,6 +35,7 @@ final class iOSSettingsStore {
     private let hapticsEnabledKey = "iOSHapticsEnabled"
     private let generateLinkPreviewsKey = "iOSGenerateLinkPreviews"
     private let autoAddFromClipboardKey = "iOSAutoAddFromClipboard"
+    private let maxDatabaseSizeGBKey = "iOSMaxDatabaseSizeGB"
     #if ENABLE_ICLOUD_SYNC
         private let syncEnabledKey = "iOSSyncEnabled"
     #endif
@@ -47,6 +54,7 @@ final class iOSSettingsStore {
         hapticsEnabled = defaults.object(forKey: hapticsEnabledKey) as? Bool ?? true
         generateLinkPreviews = defaults.object(forKey: generateLinkPreviewsKey) as? Bool ?? true
         autoAddFromClipboard = defaults.object(forKey: autoAddFromClipboardKey) as? Bool ?? false
+        maxDatabaseSizeGB = defaults.object(forKey: maxDatabaseSizeGBKey) as? Double ?? 7.0
 
         #if ENABLE_ICLOUD_SYNC
             syncEnabled = defaults.object(forKey: syncEnabledKey) as? Bool ?? false
@@ -60,6 +68,7 @@ final class iOSSettingsStore {
         defaults.set(hapticsEnabled, forKey: hapticsEnabledKey)
         defaults.set(generateLinkPreviews, forKey: generateLinkPreviewsKey)
         defaults.set(autoAddFromClipboard, forKey: autoAddFromClipboardKey)
+        defaults.set(maxDatabaseSizeGB, forKey: maxDatabaseSizeGBKey)
         #if ENABLE_ICLOUD_SYNC
             defaults.set(syncEnabled, forKey: syncEnabledKey)
         #endif

--- a/Sources/iOSApp/ClipKittyiOSApp.swift
+++ b/Sources/iOSApp/ClipKittyiOSApp.swift
@@ -349,6 +349,7 @@ struct ClipKittyiOSApp: App {
             #endif
 
             launchState = .ready(session)
+            Task { await container.pruneToStorageLimit() }
         case let .failure(error):
             launchState = .failed(error.localizedDescription)
         }

--- a/Sources/iOSApp/Resources/Localizable.xcstrings
+++ b/Sources/iOSApp/Resources/Localizable.xcstrings
@@ -1,6 +1,15 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "%.0f GB" : {
+
+    },
+    "%.1f GB" : {
+
+    },
+    "%@ limit, %@ used" : {
+
+    },
     "About" : {
 
     },
@@ -1656,6 +1665,12 @@
         }
       }
     },
+    "Drag the handle to set how much space history can use. When it fills, the oldest items are overwritten." : {
+
+    },
+    "Drag to set the storage limit" : {
+
+    },
     "Edit" : {
       "localizations" : {
         "de" : {
@@ -1868,6 +1883,18 @@
 
     },
     "History" : {
+
+    },
+    "History already uses more space than the new limit. The oldest items will be removed to fit." : {
+
+    },
+    "Reduce Storage Limit?" : {
+
+    },
+    "Remove Oldest Items" : {
+
+    },
+    "Storage Limit" : {
 
     },
     "iCloud Sync" : {
@@ -3726,6 +3753,9 @@
       }
     },
     "Version" : {
+
+    },
+    "of %@" : {
 
     },
     "Yes" : {

--- a/Sources/iOSApp/Views/Settings/HistorySettingsSection.swift
+++ b/Sources/iOSApp/Views/Settings/HistorySettingsSection.swift
@@ -5,7 +5,9 @@ struct HistorySettingsSection: View {
     @Environment(AppContainer.self) private var container
     @Environment(AppState.self) private var appState
 
-    @State private var databaseSizeText: String = "Calculating..."
+    @State private var usedBytes: Int64 = 0
+    @State private var committedLimitGB: Double?
+    @State private var showShrinkConfirmation = false
     @State private var historyAction: HistoryAction = .idle
 
     enum HistoryAction {
@@ -16,8 +18,34 @@ struct HistorySettingsSection: View {
     }
 
     var body: some View {
+        @Bindable var settings = container.settings
         Section("History") {
-            LabeledContent("Database Size", value: databaseSizeText)
+            VStack(spacing: 10) {
+                StorageBarView(
+                    limitGB: $settings.maxDatabaseSizeGB,
+                    usedBytes: usedBytes,
+                    onEditingEnded: handleStorageLimitEdit
+                )
+
+                Text("Drag the handle to set how much space history can use. When it fills, the oldest items are overwritten.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.vertical, 6)
+            .alert("Reduce Storage Limit?", isPresented: $showShrinkConfirmation) {
+                Button("Remove Oldest Items", role: .destructive) {
+                    committedLimitGB = settings.maxDatabaseSizeGB
+                    Task { await pruneToLimit() }
+                }
+                Button("Cancel", role: .cancel) {
+                    if let committed = committedLimitGB {
+                        settings.maxDatabaseSizeGB = committed
+                    }
+                }
+            } message: {
+                Text("History already uses more space than the new limit. The oldest items will be removed to fit.")
+            }
 
             switch historyAction {
             case .idle:
@@ -49,17 +77,31 @@ struct HistorySettingsSection: View {
             }
         }
         .task {
+            committedLimitGB = container.settings.maxDatabaseSizeGB
             await loadDatabaseSize()
         }
     }
 
+    /// Called when the user releases the dial knob. Shrinking the limit below
+    /// the space already used deletes the oldest items, so confirm first;
+    /// otherwise just remember the new value as the committed one.
+    private func handleStorageLimitEdit() {
+        if usedBytes > Utilities.bytes(fromGB: container.settings.maxDatabaseSizeGB) {
+            showShrinkConfirmation = true
+        } else {
+            committedLimitGB = container.settings.maxDatabaseSizeGB
+        }
+    }
+
+    private func pruneToLimit() async {
+        await container.pruneToStorageLimit()
+        appState.refreshFeed()
+        await loadDatabaseSize()
+    }
+
     private func loadDatabaseSize() async {
-        let result = await container.repository.databaseSize()
-        switch result {
-        case let .success(bytes):
-            databaseSizeText = Utilities.formatBytes(bytes)
-        case .failure:
-            databaseSizeText = "Unknown"
+        if case let .success(bytes) = await container.repository.databaseSize() {
+            usedBytes = bytes
         }
     }
 

--- a/Tests/UnitTests/StorageLimitScaleTests.swift
+++ b/Tests/UnitTests/StorageLimitScaleTests.swift
@@ -1,0 +1,70 @@
+import ClipKittyShared
+import XCTest
+
+final class StorageLimitScaleTests: XCTestCase {
+    private let scale = StorageLimitScale()
+
+    func testEndpointPositions() {
+        XCTAssertEqual(scale.position(forGB: 0.5), 0, accuracy: 1e-9)
+        XCTAssertEqual(scale.position(forGB: 64), 1, accuracy: 1e-9)
+    }
+
+    func testPositionClampsOutOfRangeSizes() {
+        XCTAssertEqual(scale.position(forGB: 0.1), 0, accuracy: 1e-9)
+        XCTAssertEqual(scale.position(forGB: 500), 1, accuracy: 1e-9)
+    }
+
+    func testPositionIsMonotonic() {
+        let positions = [0.5, 0.8, 1.0, 2.0, 7.0, 16.0, 64.0].map { scale.position(forGB: $0) }
+        XCTAssertEqual(positions, positions.sorted())
+    }
+
+    func testRoundTripForCleanSizes() {
+        for gb in [0.5, 0.7, 1.0, 2.0, 7.0, 16.0, 64.0] {
+            XCTAssertEqual(scale.gb(forPosition: scale.position(forGB: gb)), gb, accuracy: 1e-9)
+        }
+    }
+
+    func testPositionsRoundToCleanSizes() {
+        XCTAssertEqual(scale.gb(forPosition: 0), 0.5, accuracy: 1e-9)
+        XCTAssertEqual(scale.gb(forPosition: 1), 64, accuracy: 1e-9)
+
+        // From 1 GB up, values round to whole gigabytes.
+        let large = scale.gb(forPosition: 0.6)
+        XCTAssertGreaterThanOrEqual(large, 1)
+        XCTAssertEqual(large, large.rounded(), accuracy: 1e-9)
+
+        // Below 1 GB, values round to tenths.
+        let small = scale.gb(forPosition: 0.05)
+        XCTAssertLessThan(small, 1)
+        XCTAssertEqual(small * 10, (small * 10).rounded(), accuracy: 1e-9)
+    }
+
+    func testGBClampsOutOfRangePositions() {
+        XCTAssertEqual(scale.gb(forPosition: -0.5), 0.5, accuracy: 1e-9)
+        XCTAssertEqual(scale.gb(forPosition: 1.5), 64, accuracy: 1e-9)
+    }
+
+    func testAdjustingUsesWholeGigabyteStepsFromOneUp() {
+        XCTAssertEqual(scale.adjusting(7, by: 1), 8, accuracy: 1e-9)
+        XCTAssertEqual(scale.adjusting(7, by: -1), 6, accuracy: 1e-9)
+        XCTAssertEqual(scale.adjusting(1, by: 1), 2, accuracy: 1e-9)
+    }
+
+    func testAdjustingUsesTenthStepsBelowOneGigabyte() {
+        XCTAssertEqual(scale.adjusting(0.5, by: 1), 0.6, accuracy: 1e-9)
+        XCTAssertEqual(scale.adjusting(1, by: -1), 0.9, accuracy: 1e-9)
+        XCTAssertEqual(scale.adjusting(0.9, by: 1), 1.0, accuracy: 1e-9)
+    }
+
+    func testAdjustingClampsAtRangeEnds() {
+        XCTAssertEqual(scale.adjusting(64, by: 1), 64, accuracy: 1e-9)
+        XCTAssertEqual(scale.adjusting(0.5, by: -1), 0.5, accuracy: 1e-9)
+    }
+
+    func testBytesFromGB() {
+        XCTAssertEqual(Utilities.bytes(fromGB: 1), 1_073_741_824)
+        XCTAssertEqual(Utilities.bytes(fromGB: 0.5), 536_870_912)
+        XCTAssertEqual(Utilities.bytes(fromGB: 7), 7_516_192_768)
+    }
+}

--- a/Tests/iOSTests/iOSSettingsStoreTests.swift
+++ b/Tests/iOSTests/iOSSettingsStoreTests.swift
@@ -22,6 +22,15 @@ final class iOSSettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.hapticsEnabled)
         XCTAssertTrue(store.generateLinkPreviews)
         XCTAssertFalse(store.autoAddFromClipboard)
+        XCTAssertEqual(store.maxDatabaseSizeGB, 7.0, accuracy: 1e-9)
+    }
+
+    func testMaxDatabaseSizeGBPersists() {
+        let store = iOSSettingsStore(defaults: defaults)
+        store.maxDatabaseSizeGB = 16.0
+
+        let reloaded = iOSSettingsStore(defaults: defaults)
+        XCTAssertEqual(reloaded.maxDatabaseSizeGB, 16.0, accuracy: 1e-9)
     }
 
     func testHapticsEnabledPersists() {


### PR DESCRIPTION
## Summary

Replaces the storage limit slider with a shared `StorageBarView`: a horizontal allotment bar whose draggable handle sets the limit on a logarithmic 0.5–64 GB scale. A gradient fill shows current usage growing toward the handle; the tinted region up to the handle is the allotment, and the dimmed track beyond it is capacity you could still grant. When the fill reaches the handle the oldest items are overwritten in place (matching the pruning behavior underneath), indicated by a recycling icon.

- **Shared component** (`ClipKittyShared`): `StorageBarView` + `StorageLimitScale`, which extracts the log-scale mapping and rounding previously inlined in `GeneralSettingsView`. VoiceOver-adjustable (1 GB steps, 0.1 GB below 1 GB).
- **macOS**: releasing the handle prunes immediately instead of waiting for next launch. Shrinking the limit below current usage shows a confirmation alert first, since that deletes the oldest items; Cancel restores the previous limit.
- **iOS**: adds the previously missing `maxDatabaseSizeGB` setting (default 7 GB, matching macOS) and enforcement, via a prune at app bootstrap and after lowering the limit in Settings.
- `ClipboardRepository.pruneToSize` gains a default `keepRatio` of 0.8; `Utilities.bytes(fromGB:)` centralizes the GB→bytes conversion.
- New localization keys added to both string catalogs (English only for now); the obsolete slider strings remain for translators to retire.

## Testing

- macOS unit tests: 164 passed, including 11 new `StorageLimitScaleTests` (round-trip, rounding, clamping, stepping). The only failures are the pre-existing `Tests/iOSUITests/` XCUITest classes that the `ClipKittyTests` glob mistakenly includes in the macOS unit bundle (unrelated to this change; worth a separate one-line glob fix).
- iOS simulator tests: all passed, including new default/persistence tests for the setting.
- `make check` passes (string catalogs remain valid JSON in their respective formats).
- Visually verified via a standalone SwiftUI harness in light/dark across four states: typical, full (recycling), minimum limit, maximum limit.