### PR TITLE
Port panel and clipboard safety fixes

### DIFF
--- a/Sources/MacApp/Browser/BrowserSearchBar.swift
+++ b/Sources/MacApp/Browser/BrowserSearchBar.swift
@@ -86,12 +86,12 @@ struct BrowserSearchBar<FilterPopoverContent: View>: View {
                 .onKeyPress(characters: .decimalDigits, phases: .down) { keyPress in
                     onHandleNumberKey(keyPress)
                 }
-                .onKeyPress(.delete) {
+                .onKeyPress(.delete, phases: .down) { _ in
                     guard selectedItemAvailable else { return .ignored }
                     onDelete()
                     return .handled
                 }
-                .onKeyPress(.deleteForward) {
+                .onKeyPress(.deleteForward, phases: .down) { _ in
                     guard selectedItemAvailable else { return .ignored }
                     onDelete()
                     return .handled

--- a/Sources/MacApp/Browser/BrowserView.swift
+++ b/Sources/MacApp/Browser/BrowserView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct BrowserView: View {
     @Bindable var viewModel: BrowserViewModel
     let displayVersion: Int
+    let isPanelVisible: () -> Bool
 
     @ObservedObject private var settings = AppSettings.shared
     @State private var commandKeyEventMonitor: Any?
@@ -229,6 +230,8 @@ struct BrowserView: View {
     private func installCommandKeyEventMonitor() {
         guard commandKeyEventMonitor == nil else { return }
         commandKeyEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard isPanelVisible() else { return event }
+
             if let number = commandNumber(from: event) {
                 return handleCommandNumberShortcut(number) ? nil : event
             }
@@ -236,11 +239,25 @@ struct BrowserView: View {
             // Configurable delete-item shortcut (default ⌘-)
             let deleteHotKey = AppSettings.shared.deleteHotKey
             let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if modifiers == deleteHotKey.modifierMask, UInt32(event.keyCode) == deleteHotKey.keyCode {
+            if modifiers == deleteHotKey.modifierMask,
+               UInt32(event.keyCode) == deleteHotKey.keyCode,
+               !event.isARepeat
+            {
                 if viewModel.selectedItem != nil {
                     viewModel.deleteSelectedItem()
                     return nil
                 }
+            }
+
+            // While a delete is pending, Cmd+Z intentionally undoes the item
+            // delete instead of text undo; otherwise the event passes through
+            // unchanged so the field editor keeps its text undo.
+            if modifiers == .command,
+               event.charactersIgnoringModifiers == "z",
+               case .deleting(.pending) = viewModel.mutationState
+            {
+                viewModel.undoPendingDelete()
+                return nil
             }
 
             return event

--- a/Sources/MacApp/ClipboardStore.swift
+++ b/Sources/MacApp/ClipboardStore.swift
@@ -1117,17 +1117,20 @@ final class ClipboardStore {
 
     // MARK: - Actions
 
-    func paste(itemId: String, content: ClipboardContent) {
+    /// Writes the item to the pasteboard, returning whether the write succeeded.
+    /// Image writes convert off the main thread and are awaited so callers can
+    /// give honest feedback; text and file writes are synchronous and always succeed.
+    @discardableResult
+    func paste(itemId: String, content: ClipboardContent) async -> Bool {
         // Handle images differently - convert off main thread
         if case let .image(data, _, isAnimated) = content {
-            pasteImage(data: Data(data), isAnimated: isAnimated, itemId: itemId)
-            return
+            return await pasteImage(data: Data(data), isAnimated: isAnimated, itemId: itemId)
         }
 
         #if ENABLE_FILE_CLIPBOARD_ITEMS
             if case let .file(_, files) = content {
                 pasteFiles(files: files, itemId: itemId)
-                return
+                return true
             }
         #endif
 
@@ -1136,53 +1139,53 @@ final class ClipboardStore {
         Task { [weak self] in
             await self?.updateItemTimestamp(id: itemId)
         }
+        return true
     }
 
-    private func pasteImage(data: Data, isAnimated: Bool, itemId: String?) {
-        Task {
-            if isAnimated {
-                // Convert animated HEIC to GIF for pasting (CPU-intensive, use background)
-                let gifData: Data? = await withCheckedContinuation { continuation in
-                    Task.detached(priority: .userInitiated) {
-                        continuation.resume(returning: Self.convertAnimatedHEICToGIF(data))
-                    }
+    private func pasteImage(data: Data, isAnimated: Bool, itemId: String?) async -> Bool {
+        if isAnimated {
+            // Convert animated HEIC to GIF for pasting (CPU-intensive, use background)
+            let gifData: Data? = await withCheckedContinuation { continuation in
+                Task.detached(priority: .userInitiated) {
+                    continuation.resume(returning: Self.convertAnimatedHEICToGIF(data))
                 }
-
-                guard let gifData else {
-                    self.pasteboardMonitor.acknowledgeLocalWrite(changeCount: self.pasteboard.changeCount)
-                    return
-                }
-
-                let fallback = NSImage(data: data)?.tiffRepresentation
-                self.pasteboardMonitor.acknowledgeLocalWrite(
-                    changeCount: self.pasteService.writeAnimatedImage(gifData: gifData, tiffFallback: fallback)
-                )
-            } else {
-                // Convert from stored format (HEIC) to TIFF off main thread
-                let tiffData: Data? = await withCheckedContinuation { continuation in
-                    Task.detached(priority: .userInitiated) {
-                        guard let image = NSImage(data: data),
-                              let tiff = image.tiffRepresentation
-                        else {
-                            continuation.resume(returning: nil)
-                            return
-                        }
-                        continuation.resume(returning: tiff)
-                    }
-                }
-
-                guard let tiffData else {
-                    self.pasteboardMonitor.acknowledgeLocalWrite(changeCount: self.pasteboard.changeCount)
-                    return
-                }
-
-                self.pasteboardMonitor.acknowledgeLocalWrite(changeCount: self.pasteService.writeStaticImage(tiffData))
             }
 
-            if let itemId {
-                await self.updateItemTimestamp(id: itemId)
+            guard let gifData else {
+                pasteboardMonitor.acknowledgeLocalWrite(changeCount: pasteboard.changeCount)
+                return false
             }
+
+            let fallback = NSImage(data: data)?.tiffRepresentation
+            pasteboardMonitor.acknowledgeLocalWrite(
+                changeCount: pasteService.writeAnimatedImage(gifData: gifData, tiffFallback: fallback)
+            )
+        } else {
+            // Convert from stored format (HEIC) to TIFF off main thread
+            let tiffData: Data? = await withCheckedContinuation { continuation in
+                Task.detached(priority: .userInitiated) {
+                    guard let image = NSImage(data: data),
+                          let tiff = image.tiffRepresentation
+                    else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+                    continuation.resume(returning: tiff)
+                }
+            }
+
+            guard let tiffData else {
+                pasteboardMonitor.acknowledgeLocalWrite(changeCount: pasteboard.changeCount)
+                return false
+            }
+
+            pasteboardMonitor.acknowledgeLocalWrite(changeCount: pasteService.writeStaticImage(tiffData))
         }
+
+        if let itemId {
+            await updateItemTimestamp(id: itemId)
+        }
+        return true
     }
 
     /// Convert animated HEIC (HEICS) to GIF format

--- a/Sources/MacApp/ContentView.swift
+++ b/Sources/MacApp/ContentView.swift
@@ -44,7 +44,11 @@ struct ContentView: View {
         let contentRevision = store.contentRevision
         let isPanelVisible = store.isPanelVisible
 
-        return BrowserView(viewModel: viewModel, displayVersion: displayVersion)
+        return BrowserView(
+            viewModel: viewModel,
+            displayVersion: displayVersion,
+            isPanelVisible: { store.isPanelVisible }
+        )
             .onAppear {
                 viewModel.onAppear(
                     initialSearchQuery: initialSearchQuery,

--- a/Sources/MacApp/FloatingPanelController.swift
+++ b/Sources/MacApp/FloatingPanelController.swift
@@ -51,6 +51,9 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
     /// Initial search query to pre-fill (for CI screenshots)
     var initialSearchQuery: String?
 
+    /// Whether the Accessibility-permission notice has been shown this launch.
+    private var hasShownNoPermissionNotice = false
+
     private var textScaleCancellable: AnyCancellable?
 
     init(
@@ -374,29 +377,75 @@ final class FloatingPanelController: NSObject, NSWindowDelegate {
     }
 
     private func selectItem(itemId: String, content: ClipboardContent) {
-        store.paste(itemId: itemId, content: content)
         #if ENABLE_SYNTHETIC_PASTE
             let targetApp = hide()
-            switch AppSettings.shared.pasteMode {
-            case .autoPaste:
-                switch activationService.syntheticPasteBehavior(for: targetApp) {
-                case let .paste(targetApp):
-                    activationService.simulatePaste(to: targetApp)
+            Task { @MainActor in
+                guard await pasteReportingProgress(itemId: itemId, content: content) else { return }
+                switch AppSettings.shared.pasteMode {
+                case .autoPaste:
+                    switch activationService.syntheticPasteBehavior(for: targetApp) {
+                    case let .paste(targetApp):
+                        activationService.simulatePaste(to: targetApp)
+                    case .copyOnly:
+                        snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+                    }
                 case .copyOnly:
                     snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+                case .noPermission:
+                    showCopiedWithPermissionNotice()
                 }
-            case .copyOnly, .noPermission:
-                snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
             }
         #else
             hide()
-            snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+            Task { @MainActor in
+                guard await pasteReportingProgress(itemId: itemId, content: content) else { return }
+                snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+            }
         #endif
     }
 
     private func copyOnlyItem(itemId: String, content: ClipboardContent) {
-        store.paste(itemId: itemId, content: content)
         hide()
-        snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+        Task { @MainActor in
+            guard await pasteReportingProgress(itemId: itemId, content: content) else { return }
+            snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+        }
+    }
+
+    /// Writes the item to the pasteboard, surfacing a delayed progress snackbar
+    /// for slow image conversions and an error snackbar on failure.
+    private func pasteReportingProgress(itemId: String, content: ClipboardContent) async -> Bool {
+        let progressTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            snackbarWindow.showProgress(.preparingPaste)
+        }
+        let ok = await store.paste(itemId: itemId, content: content)
+        progressTask.cancel()
+        snackbarWindow.dismissProgress()
+        if !ok {
+            snackbarWindow.showNotification(.passive(message: String(localized: "Couldn’t copy image"), iconSystemName: "exclamationmark.triangle.fill"))
+        }
+        return ok
+    }
+
+    /// Copy succeeded but synthetic paste is unavailable because the Accessibility
+    /// permission is missing; tell the user how to enable it, once per launch.
+    private func showCopiedWithPermissionNotice() {
+        if hasShownNoPermissionNotice {
+            snackbarWindow.showNotification(.passive(message: String(localized: "Copied"), iconSystemName: "checkmark.circle.fill"))
+            return
+        }
+        hasShownNoPermissionNotice = true
+        snackbarWindow.showNotification(
+            .actionable(
+                message: String(localized: "Copied. Enable Accessibility to paste automatically"),
+                iconSystemName: "exclamationmark.triangle.fill",
+                actionTitle: String(localized: "Enable")
+            ),
+            onAction: {
+                NotificationCenter.default.post(name: .clipKittyOpenSettings, object: nil)
+            }
+        )
     }
 }

--- a/Sources/MacApp/Resources/Localizable.xcstrings
+++ b/Sources/MacApp/Resources/Localizable.xcstrings
@@ -2373,6 +2373,134 @@
         }
       }
     },
+    "Copied. Enable Accessibility to paste automatically": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiert. Aktivieren Sie die Bedienungshilfen, um automatisch einzusetzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied. Enable Accessibility to paste automatically"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado. Activa Accesibilidad para pegar automáticamente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copié. Activez Accessibilité pour coller automatiquement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー済み。自動でペーストするにはアクセシビリティを有効にしてください"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사됨. 자동으로 붙여넣으려면 손쉬운 사용을 활성화하세요"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado. Ative a Acessibilidade para colar automaticamente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопировано. Включите Универсальный доступ для автоматической вставки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已拷贝。启用辅助功能以自动粘贴"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已拷貝。啟用輔助使用以自動貼上"
+          }
+        }
+      }
+    },
+    "Couldn’t copy image": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bild konnte nicht kopiert werden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t copy image"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo copiar la imagen"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de copier l’image"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像をコピーできませんでした"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지를 복사할 수 없음"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível copiar a imagem"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось скопировать изображение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法拷贝图像"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法拷貝圖像"
+          }
+        }
+      }
+    },
     "Copy": {
       "localizations": {
         "de": {
@@ -7290,6 +7418,70 @@
           "stringUnit": {
             "state": "translated",
             "value": "按下按鍵⋯"
+          }
+        }
+      }
+    },
+    "Preparing image…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bild wird vorbereitet…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing image…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando imagen…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Préparation de l’image…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像を準備中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이미지 준비 중…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando imagem…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка изображения…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在准备图像…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在準備圖像…"
           }
         }
       }

--- a/Sources/MacApp/Snackbar.swift
+++ b/Sources/MacApp/Snackbar.swift
@@ -9,12 +9,28 @@ struct GlassBackgroundModifier: ViewModifier {
             content.glassEffect(.regular, in: .capsule)
         } else {
             content
-                .background(.thickMaterial, in: RoundedRectangle(cornerRadius: 10))
+                .background(.thickMaterial, in: Capsule())
                 .overlay(
-                    RoundedRectangle(cornerRadius: 10)
+                    Capsule()
                         .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
                 )
         }
+    }
+}
+
+/// Glass capsule shared by every Mac snackbar variant, so they all agree on
+/// shape, spacing, and type size; the iOS equivalent lives in RootView.swift.
+private struct SnackbarCapsule<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        HStack(spacing: 8) {
+            content
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .fixedSize()
+        .modifier(GlassBackgroundModifier())
     }
 }
 
@@ -42,13 +58,13 @@ private struct NotificationSnackbarView: View {
     let onAction: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
+        SnackbarCapsule {
             Image(systemName: kind.iconSystemName)
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(.secondary)
 
             Text(kind.message)
-                .font(.system(size: 14, weight: .medium))
+                .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.primary)
 
             if case let .actionable(_, _, actionTitle) = kind {
@@ -59,10 +75,6 @@ private struct NotificationSnackbarView: View {
                     .padding(.leading, 8)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .fixedSize()
-        .modifier(GlassBackgroundModifier())
     }
 }
 
@@ -71,7 +83,7 @@ private struct LaunchAtLoginNudgeView: View {
     let onDismiss: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
+        SnackbarCapsule {
             Image(systemName: "sunrise.fill")
                 .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(.orange)
@@ -98,10 +110,6 @@ private struct LaunchAtLoginNudgeView: View {
             .buttonStyle(.plain)
             .padding(.leading, 2)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .fixedSize()
-        .modifier(GlassBackgroundModifier())
     }
 }
 
@@ -109,7 +117,7 @@ private struct InfoSnackbarView: View {
     let kind: InfoKind
 
     var body: some View {
-        HStack(spacing: 8) {
+        SnackbarCapsule {
             if let icon = kind.iconSystemName {
                 Image(systemName: icon)
                     .font(.system(size: 16, weight: .medium))
@@ -123,9 +131,5 @@ private struct InfoSnackbarView: View {
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(.primary)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .fixedSize()
-        .modifier(GlassBackgroundModifier())
     }
 }

--- a/Sources/MacApp/SnackbarWindow.swift
+++ b/Sources/MacApp/SnackbarWindow.swift
@@ -8,6 +8,8 @@ final class SnackbarWindow {
 
     private var nudgeWindow: NSWindow?
     private var notification: ActiveNotification?
+    private var progressWindow: NSWindow?
+    private var progressAnchoredToPanel = false
 
     /// Last known panel frame — used for positioning. Nil when panel is hidden.
     private var panelFrame: NSRect?
@@ -58,7 +60,12 @@ final class SnackbarWindow {
 
         if let existingWindow = nudgeWindow {
             existingWindow.contentView = hostingView
-            positionRelativeToPanel(existingWindow, size: fittingSize, panelFrame: panelFrame)
+            let target = frameRelativeToPanel(size: fittingSize, panelFrame: panelFrame)
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.15
+                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                existingWindow.animator().setFrame(target, display: true)
+            }
             existingWindow.orderFront(nil)
             return
         }
@@ -80,7 +87,10 @@ final class SnackbarWindow {
     func showNotification(_ kind: NotificationKind, onAction: (() -> Void)? = nil) {
         if let existing = notification {
             existing.dismissTask?.cancel()
-            existing.window.orderOut(nil)
+            // Cross-fade: the old window fades while the new one animates in.
+            // Windows animate independently, so a third notification mid-fade
+            // is safe.
+            fadeOutAndOrderOut(existing.window)
             notification = nil
         }
 
@@ -119,12 +129,54 @@ final class SnackbarWindow {
 
         animateIn(window, slideUp: !anchored)
 
+        // VoiceOver may suppress announcements from apps that never become
+        // active; the snackbar window is used as the element because this
+        // accessory app has no main window.
+        NSAccessibility.post(
+            element: window,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: kind.message,
+                .priority: NSAccessibilityPriorityLevel.high.rawValue,
+            ]
+        )
+
         notification = ActiveNotification(
             window: window,
             anchoredToPanel: anchored,
             dismissTask: scheduleDismiss(after: kind.duration),
             action: onAction
         )
+    }
+
+    // MARK: - Progress (explicitly dismissed, no auto-dismiss)
+
+    /// Shows a spinner snackbar for an in-flight operation. Stays up until
+    /// `dismissProgress()` is called; never produced by scheduler evaluation.
+    func showProgress(_ kind: InfoKind) {
+        guard progressWindow == nil else { return }
+
+        let view = SnackbarView(item: .info(kind), onAction: {}, onDismiss: {})
+        let hostingView = NSHostingView(rootView: view)
+        let fittingSize = hostingView.fittingSize
+        hostingView.frame = NSRect(origin: .zero, size: fittingSize)
+
+        let window = makeWindow(hostingView: hostingView)
+        let anchored = panelFrame != nil
+        if let panelFrame {
+            positionRelativeToPanel(window, size: fittingSize, panelFrame: panelFrame)
+        } else {
+            positionScreenCenter(window, size: fittingSize)
+        }
+        animateIn(window, slideUp: !anchored)
+        progressWindow = window
+        progressAnchoredToPanel = anchored
+    }
+
+    func dismissProgress() {
+        guard let progressWindow else { return }
+        self.progressWindow = nil
+        animateOut(progressWindow, slideUp: progressAnchoredToPanel)
     }
 
     func dismissNotification() {
@@ -155,14 +207,19 @@ final class SnackbarWindow {
     func hideAll() {
         dismissNudge()
         dismissNotification()
+        dismissProgress()
     }
 
     // MARK: - Positioning
 
-    private func positionRelativeToPanel(_ window: NSWindow, size: NSSize, panelFrame: NSRect) {
+    private func frameRelativeToPanel(size: NSSize, panelFrame: NSRect) -> NSRect {
         let x = panelFrame.minX
         let y = panelFrame.minY - size.height - 8
-        window.setFrame(NSRect(x: x, y: y, width: size.width, height: size.height), display: true)
+        return NSRect(x: x, y: y, width: size.width, height: size.height)
+    }
+
+    private func positionRelativeToPanel(_ window: NSWindow, size: NSSize, panelFrame: NSRect) {
+        window.setFrame(frameRelativeToPanel(size: size, panelFrame: panelFrame), display: true)
     }
 
     private func positionScreenCenter(_ window: NSWindow, size: NSSize) {
@@ -207,6 +264,15 @@ final class SnackbarWindow {
             endFrame.origin.y += slideUp ? 20 : -10
             window.animator().setFrame(endFrame, display: true)
             window.animator().alphaValue = 1
+        }
+    }
+
+    private func fadeOutAndOrderOut(_ window: NSWindow) {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.15
+            window.animator().alphaValue = 0
+        } completionHandler: {
+            window.orderOut(nil)
         }
     }
 

--- a/Sources/Shared/BrowserViewModel.swift
+++ b/Sources/Shared/BrowserViewModel.swift
@@ -15,6 +15,9 @@ public final class BrowserViewModel {
     private let onDismiss: () -> Void
     private let showSnackbarNotification: (NotificationKind, (() -> Void)?) -> Void
     private let dismissSnackbarNotification: () -> Void
+    /// How long a pending delete stays undoable before committing; injectable
+    /// so tests don't have to wait out the real undo window.
+    private let deleteCommitDelay: TimeInterval
 
     private enum SearchExecution {
         case idle
@@ -107,7 +110,8 @@ public final class BrowserViewModel {
         onCopyOnly: @escaping (String, ClipboardContent) -> Void,
         onDismiss: @escaping () -> Void,
         showSnackbarNotification: @escaping (NotificationKind, (() -> Void)?) -> Void = { _, _ in },
-        dismissSnackbarNotification: @escaping () -> Void = {}
+        dismissSnackbarNotification: @escaping () -> Void = {},
+        deleteCommitDelay: TimeInterval = NotificationKind.undoWindow
     ) {
         self.client = client
         self.shouldGenerateLinkPreviews = shouldGenerateLinkPreviews
@@ -116,6 +120,7 @@ public final class BrowserViewModel {
         self.onDismiss = onDismiss
         self.showSnackbarNotification = showSnackbarNotification
         self.dismissSnackbarNotification = dismissSnackbarNotification
+        self.deleteCommitDelay = deleteCommitDelay
     }
 
     public var searchText: String {
@@ -203,15 +208,16 @@ public final class BrowserViewModel {
     }
 
     public func handleDisplayReset(initialSearchQuery: String, contentRevision: Int = 0) {
+        flushPendingDelete()
         cancelInFlightWork()
-        latestKnownContentRevision = contentRevision
+        latestKnownContentRevision = max(latestKnownContentRevision, contentRevision)
         lastLoadedContentRevision = nil
         hasUserNavigated = false
         prefetchCache.removeAll()
         previewPayloadsByItemId.removeAll()
         resolvedMatchedExcerptsByItemId.removeAll()
         overlayState = .none
-        mutationState = .idle
+        resetMutationStateUnlessCommitting()
         editSession = .inactive
         // Clear selection so the fresh search lands on the top item rather
         // than carrying the prior highlight across a hide/show cycle.
@@ -223,12 +229,30 @@ public final class BrowserViewModel {
     }
 
     public func prepareForSuspension() {
+        flushPendingDelete()
         cancelInFlightWork()
         dismissSnackbarNotification()
         overlayState = .none
-        mutationState = .idle
+        resetMutationStateUnlessCommitting()
         editSession = .inactive
         hasUserNavigated = false
+    }
+
+    /// Commits any still-pending delete immediately. Called when the UI is
+    /// about to reset or suspend, so an optimistic delete is never dropped on
+    /// the floor with the item silently resurrecting later.
+    private func flushPendingDelete() {
+        guard case .deleting(.pending) = mutationState else { return }
+        pendingDeleteTask?.cancel()
+        pendingDeleteTask = nil
+        commitPendingDelete()
+    }
+
+    /// `.deleting(.committing)` must survive resets: the commit task resets to
+    /// `.idle` itself, and `restoreDeleteFailure` matches on it.
+    private func resetMutationStateUnlessCommitting() {
+        if case .deleting(.committing) = mutationState { return }
+        mutationState = .idle
     }
 
     public func handleContentRevisionChange(_ contentRevision: Int, isPanelVisible: Bool) {
@@ -444,8 +468,9 @@ public final class BrowserViewModel {
 
     private func scheduleDeleteCommit() {
         pendingDeleteTask?.cancel()
+        let delay = deleteCommitDelay
         pendingDeleteTask = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(3))
+            try? await Task.sleep(for: .seconds(delay))
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 self?.commitPendingDelete()
@@ -1286,6 +1311,8 @@ public final class BrowserViewModel {
         guard case let .deleting(.pending(transaction)) = mutationState else { return }
         pendingDeleteTask = nil
         mutationState = .deleting(.committing(transaction))
+        // The undo window is over; the Undo button must not outlive it.
+        dismissSnackbarNotification()
 
         Task { [weak self] in
             guard let self else { return }

--- a/Sources/Shared/NotificationTypes.swift
+++ b/Sources/Shared/NotificationTypes.swift
@@ -12,6 +12,9 @@ public enum InfoKind: Equatable {
     case rebuildingIndex
     case catchingUpWithCloud
     case syncingCloudChanges(count: Int)
+    /// Shown by the Mac panel while an image paste is being prepared off the main
+    /// thread. Driven explicitly by the paste flow; never produced by scheduler evaluation.
+    case preparingPaste
 
     public var message: String {
         switch self {
@@ -21,6 +24,8 @@ public enum InfoKind: Equatable {
             return String(localized: "Catching up with iCloud")
         case let .syncingCloudChanges(count):
             return String(localized: "Syncing \(count) changes from iCloud")
+        case .preparingPaste:
+            return String(localized: "Preparing image…")
         }
     }
 
@@ -29,7 +34,7 @@ public enum InfoKind: Equatable {
     /// presentation).
     public var iconSystemName: String? {
         switch self {
-        case .rebuildingIndex:
+        case .rebuildingIndex, .preparingPaste:
             return nil
         case .catchingUpWithCloud, .syncingCloudChanges:
             return "icloud.and.arrow.down"
@@ -40,6 +45,11 @@ public enum InfoKind: Equatable {
 public enum NotificationKind: Equatable {
     case passive(message: String, iconSystemName: String)
     case actionable(message: String, iconSystemName: String, actionTitle: String)
+
+    /// How long an undoable action stays actionable. The delete commit delay
+    /// and the actionable snackbar duration both derive from this so the Undo
+    /// button never outlives the window in which undo still works.
+    public static let undoWindow: TimeInterval = 4.0
 
     public var message: String {
         switch self {
@@ -63,7 +73,7 @@ public enum NotificationKind: Equatable {
             let extraTime = Double(extraChars / 10) * 0.5
             return min(baseDuration + extraTime, 4.5)
         case .actionable:
-            return 4.0
+            return Self.undoWindow
         }
     }
 }

--- a/Sources/iOSApp/App/AppContainer.swift
+++ b/Sources/iOSApp/App/AppContainer.swift
@@ -113,8 +113,8 @@ final class AppContainer {
             repository: repository,
             previewLoader: previewLoader
         )
-        let clipboardService = iOSClipboardService()
         let settings = iOSSettingsStore()
+        let clipboardService = iOSClipboardService(settings: settings)
         let haptics = HapticsClient(settings: settings)
 
         return .success(AppContainer(

--- a/Sources/iOSApp/App/iOSSettingsStore.swift
+++ b/Sources/iOSApp/App/iOSSettingsStore.swift
@@ -30,12 +30,25 @@ final class iOSSettingsStore {
         }
     #endif
 
+    // MARK: - Pasteboard ingest state
+
+    /// The pasteboard `changeCount` already ingested by auto-add. This is
+    /// state, not a user-facing preference, so it bypasses the
+    /// `isInitializing`/`save()` flow and writes straight to UserDefaults.
+    /// Persistence is required because backgrounding tears down the container
+    /// and rebootstraps on foreground.
+    @ObservationIgnored
+    var lastIngestedPasteboardChangeCount: Int {
+        didSet { defaults.set(lastIngestedPasteboardChangeCount, forKey: lastIngestedPasteboardChangeCountKey) }
+    }
+
     // MARK: - Keys
 
     private let hapticsEnabledKey = "iOSHapticsEnabled"
     private let generateLinkPreviewsKey = "iOSGenerateLinkPreviews"
     private let autoAddFromClipboardKey = "iOSAutoAddFromClipboard"
     private let maxDatabaseSizeGBKey = "iOSMaxDatabaseSizeGB"
+    private let lastIngestedPasteboardChangeCountKey = "iOSLastIngestedPasteboardChangeCount"
     #if ENABLE_ICLOUD_SYNC
         private let syncEnabledKey = "iOSSyncEnabled"
     #endif
@@ -55,6 +68,7 @@ final class iOSSettingsStore {
         generateLinkPreviews = defaults.object(forKey: generateLinkPreviewsKey) as? Bool ?? true
         autoAddFromClipboard = defaults.object(forKey: autoAddFromClipboardKey) as? Bool ?? false
         maxDatabaseSizeGB = defaults.object(forKey: maxDatabaseSizeGBKey) as? Double ?? 7.0
+        lastIngestedPasteboardChangeCount = defaults.object(forKey: lastIngestedPasteboardChangeCountKey) as? Int ?? 0
 
         #if ENABLE_ICLOUD_SYNC
             syncEnabled = defaults.object(forKey: syncEnabledKey) as? Bool ?? false

--- a/Sources/iOSApp/ClipKittyiOSApp.swift
+++ b/Sources/iOSApp/ClipKittyiOSApp.swift
@@ -161,6 +161,18 @@ final class AppState {
 
     func autoAddFromClipboard() async {
         guard container.settings.autoAddFromClipboard else { return }
+
+        // Reading changeCount does not trigger the paste-consent alert. If the
+        // pasteboard has not changed since we last looked, skip the read so we
+        // don't prompt for "Allow Paste" on every foreground.
+        let changeCount = container.clipboardService.pasteboardChangeCount
+        guard changeCount != container.settings.lastIngestedPasteboardChangeCount else { return }
+
+        // Record this generation now, before attempting the read, so a user
+        // denial or unreadable content is not re-prompted for the same
+        // pasteboard generation; we intentionally respect the denial.
+        container.settings.lastIngestedPasteboardChangeCount = changeCount
+
         guard let content = container.clipboardService.readCurrentClipboard() else { return }
 
         let result: Result<String, ClipboardError>

--- a/Sources/iOSApp/Services/iOSClipboardService.swift
+++ b/Sources/iOSApp/Services/iOSClipboardService.swift
@@ -15,6 +15,16 @@ enum PasteboardContent {
 
 @MainActor
 final class iOSClipboardService {
+    private let settings: iOSSettingsStore
+
+    init(settings: iOSSettingsStore) {
+        self.settings = settings
+    }
+
+    /// The current pasteboard generation. Reading `changeCount` never triggers
+    /// the system paste-consent alert, unlike reading the pasteboard contents.
+    var pasteboardChangeCount: Int { UIPasteboard.general.changeCount }
+
     func copy(content: ClipboardContent) {
         let pasteboard = UIPasteboard.general
         switch content {
@@ -37,6 +47,9 @@ final class iOSClipboardService {
                 pasteboard.string = first.filename
             }
         }
+        // Record our own write as already-ingested so auto-add never re-reads
+        // it back on the next foreground (mirrors the Mac acknowledgeLocalWrite).
+        settings.lastIngestedPasteboardChangeCount = pasteboard.changeCount
     }
 
     func readCurrentClipboard() -> PasteboardContent? {

--- a/Tests/UnitTests/BrowserViewModelTests.swift
+++ b/Tests/UnitTests/BrowserViewModelTests.swift
@@ -775,7 +775,8 @@ final class BrowserViewModelTests: XCTestCase {
             client: client,
             onSelect: { _, _ in },
             onCopyOnly: { _, _ in },
-            onDismiss: {}
+            onDismiss: {},
+            deleteCommitDelay: 0.05
         )
 
         viewModel.onAppear(initialSearchQuery: "")
@@ -785,7 +786,7 @@ final class BrowserViewModelTests: XCTestCase {
 
         viewModel.deleteSelectedItem()
         await flushMainActor()
-        try? await Task.sleep(for: .milliseconds(3100))
+        try? await Task.sleep(for: .milliseconds(300))
         await flushMainActor()
 
         XCTAssertEqual(viewModel.itemIds, ["1", "2"])
@@ -1037,6 +1038,118 @@ final class BrowserViewModelTests: XCTestCase {
         guard case .idle = viewModel.mutationState else {
             return XCTFail("Expected idle mutation after undo")
         }
+    }
+
+    func testDeleteCommitDismissesUndoSnackbarWhenWindowEnds() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 2
+        ))
+
+        var dismissCount = 0
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {},
+            dismissSnackbarNotification: { dismissCount += 1 },
+            deleteCommitDelay: 0.05
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "first"))
+        await flushMainActor()
+
+        viewModel.deleteSelectedItem()
+        await flushMainActor()
+
+        XCTAssertEqual(dismissCount, 0)
+
+        try? await Task.sleep(for: .milliseconds(300))
+        await flushMainActor()
+
+        XCTAssertEqual(dismissCount, 1)
+        XCTAssertEqual(client.deletedItemIds, ["1"])
+        guard case .idle = viewModel.mutationState else {
+            return XCTFail("Expected idle mutation after commit")
+        }
+    }
+
+    func testHandleDisplayResetCommitsPendingDelete() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 2
+        ))
+
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {}
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "first"))
+        await flushMainActor()
+
+        viewModel.deleteSelectedItem()
+        await flushMainActor()
+        guard case .deleting(.pending) = viewModel.mutationState else {
+            return XCTFail("Expected pending delete before reset")
+        }
+
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 1
+        ))
+        viewModel.handleDisplayReset(initialSearchQuery: "")
+        await flushMainActor()
+
+        XCTAssertEqual(client.deletedItemIds, ["1"])
+        XCTAssertFalse(viewModel.itemIds.contains("1"))
+    }
+
+    func testPrepareForSuspensionCommitsPendingDelete() async {
+        let client = MockBrowserStoreClient()
+        client.enqueueSearchResponse(BrowserSearchResponse(
+            request: SearchRequest(text: "", filter: .all),
+            items: [makeMatch(id: "1", excerpt: "one"), makeMatch(id: "2", excerpt: "two")],
+            firstPreviewPayload: nil,
+            totalCount: 2
+        ))
+
+        let viewModel = BrowserViewModel(
+            client: client,
+            onSelect: { _, _ in },
+            onCopyOnly: { _, _ in },
+            onDismiss: {}
+        )
+
+        viewModel.onAppear(initialSearchQuery: "")
+        await flushMainActor()
+        client.resumeFetch(id: "1", with: makeItem(id: "1", text: "first"))
+        await flushMainActor()
+
+        viewModel.deleteSelectedItem()
+        await flushMainActor()
+        guard case .deleting(.pending) = viewModel.mutationState else {
+            return XCTFail("Expected pending delete before suspension")
+        }
+
+        viewModel.prepareForSuspension()
+        await flushMainActor()
+
+        XCTAssertEqual(client.deletedItemIds, ["1"])
     }
 
     func testDeleteLastItemClearsSelection() async {
@@ -1513,7 +1626,8 @@ final class BrowserViewModelTests: XCTestCase {
             client: client,
             onSelect: { _, _ in },
             onCopyOnly: { _, _ in },
-            onDismiss: {}
+            onDismiss: {},
+            deleteCommitDelay: 0.05
         )
 
         viewModel.onAppear(initialSearchQuery: "")
@@ -1522,7 +1636,7 @@ final class BrowserViewModelTests: XCTestCase {
         await flushMainActor()
 
         viewModel.deleteSelectedItem()
-        try? await Task.sleep(for: .seconds(4))
+        try? await Task.sleep(for: .milliseconds(300))
         await flushMainActor()
 
         XCTAssertNotNil(viewModel.mutationFailureMessage)
@@ -1649,6 +1763,7 @@ private final class MockBrowserStoreClient: BrowserStoreClient {
     var addTagResult: Result<Void, ClipboardError> = .success(())
     var removeTagResult: Result<Void, ClipboardError> = .success(())
     var deleteResult: Result<Void, ClipboardError> = .success(())
+    var deletedItemIds: [String] = []
     var clearResult: Result<Void, ClipboardError> = .success(())
     var updateTextResult: Result<Void, ClipboardError> = .success(())
     var updatedTexts: [(itemId: String, text: String)] = []
@@ -1746,8 +1861,9 @@ private final class MockBrowserStoreClient: BrowserStoreClient {
         removeTagResult
     }
 
-    func delete(itemId _: String) async -> Result<Void, ClipboardError> {
-        deleteResult
+    func delete(itemId: String) async -> Result<Void, ClipboardError> {
+        deletedItemIds.append(itemId)
+        return deleteResult
     }
 
     func clear() async -> Result<Void, ClipboardError> {

--- a/Tests/iOSTests/iOSSettingsStoreTests.swift
+++ b/Tests/iOSTests/iOSSettingsStoreTests.swift
@@ -23,6 +23,7 @@ final class iOSSettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.generateLinkPreviews)
         XCTAssertFalse(store.autoAddFromClipboard)
         XCTAssertEqual(store.maxDatabaseSizeGB, 7.0, accuracy: 1e-9)
+        XCTAssertEqual(store.lastIngestedPasteboardChangeCount, 0)
     }
 
     func testMaxDatabaseSizeGBPersists() {
@@ -31,6 +32,14 @@ final class iOSSettingsStoreTests: XCTestCase {
 
         let reloaded = iOSSettingsStore(defaults: defaults)
         XCTAssertEqual(reloaded.maxDatabaseSizeGB, 16.0, accuracy: 1e-9)
+    }
+
+    func testLastIngestedPasteboardChangeCountPersists() {
+        let store = iOSSettingsStore(defaults: defaults)
+        store.lastIngestedPasteboardChangeCount = 42
+
+        let reloaded = iOSSettingsStore(defaults: defaults)
+        XCTAssertEqual(reloaded.lastIngestedPasteboardChangeCount, 42)
     }
 
     func testHapticsEnabledPersists() {


### PR DESCRIPTION
## Summary

Ports the safety pieces from #417 while leaving out the reverted UX changes:

- make `ClipboardStore.paste` async and return success/failure so image conversion errors show "Couldn't copy image" instead of a false success toast
- show an actionable Accessibility "Enable" snackbar on the first copy-only fallback, opening Settings for automatic paste permission
- harden Mac panel behavior around hidden panels, repeated delete keys, pending delete flushing, and paste progress feedback
- gate iOS clipboard auto-add behind a persisted pasteboard `changeCount` guard and acknowledge app-owned writes so we do not reread them
- share one capsule snackbar container across variants, including the pre-macOS-26 fallback

## Validation

- `make check`
- `git diff --check`
- `python3 -m json.tool Sources/MacApp/Resources/Localizable.xcstrings`
- `python3 -m json.tool Sources/iOSApp/Resources/Localizable.xcstrings`

## Not run

- Full workspace/Xcode test pass. I attempted `make workspace`, but stopped it after prolonged Nix GC under disk pressure (`/` and `/nix` at 100%, roughly 1.4-2.1 GB free).