### PR TITLE
Adopt keytap 6: decrypt secrets via keytap, drop DIY age-key keychain cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783356341,
-        "narHash": "sha256-vuVTWZO0MzN1E3BhVnbcQNdqX9rle24l4CoKqN0ZVG8=",
+        "lastModified": 1783357767,
+        "narHash": "sha256-zEB13KLqipAtwa8Tuo6O3SxITLgy5/LcctSmqy34SiQ=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "95af346bd2bc22a829b22bf1f4f1b4cb69b06b0c",
+        "rev": "6f7d5d1b5aa5917e46c8ee5df8e831c4a0ba755f",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "95af346bd2bc22a829b22bf1f4f1b4cb69b06b0c",
+        "rev": "6f7d5d1b5aa5917e46c8ee5df8e831c4a0ba755f",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783362824,
-        "narHash": "sha256-Jy1rpUALWHADzjYXxrJHyN9wQz3/c1PgWi5ghVvkWPY=",
+        "lastModified": 1783367026,
+        "narHash": "sha256-78G/wCq2pE1VrcSG+qp2SblPFDES1IIHchm2iekI4TE=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "21881ccd1d880f3703c9db48c210415d88990365",
+        "rev": "a29f8c51b46cb4e2a755c7c77058b1c2fa8f448b",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "21881ccd1d880f3703c9db48c210415d88990365",
+        "rev": "a29f8c51b46cb4e2a755c7c77058b1c2fa8f448b",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783361313,
-        "narHash": "sha256-NMpgEHC3VUmGJkIv2sinb+z/7GZimp9Eo/MX4SvY0wU=",
+        "lastModified": 1783362824,
+        "narHash": "sha256-Jy1rpUALWHADzjYXxrJHyN9wQz3/c1PgWi5ghVvkWPY=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "92154f13235fd8ff26e5d51aa34d63428ae7dfcf",
+        "rev": "21881ccd1d880f3703c9db48c210415d88990365",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "92154f13235fd8ff26e5d51aa34d63428ae7dfcf",
+        "rev": "21881ccd1d880f3703c9db48c210415d88990365",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783360307,
-        "narHash": "sha256-3RzfVhuP7u82zXfXAaZUpmALHuoynSrmTBiZUIXJ8wQ=",
+        "lastModified": 1783361313,
+        "narHash": "sha256-NMpgEHC3VUmGJkIv2sinb+z/7GZimp9Eo/MX4SvY0wU=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "70b0220e829d3fa090f77fee8521388dea7c169b",
+        "rev": "92154f13235fd8ff26e5d51aa34d63428ae7dfcf",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "70b0220e829d3fa090f77fee8521388dea7c169b",
+        "rev": "92154f13235fd8ff26e5d51aa34d63428ae7dfcf",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1775145531,
-        "narHash": "sha256-QSHrsnYj9pfJ1o2JzpGo6hERdMdzrj2Dp6GHSsusyiE=",
+        "lastModified": 1783354299,
+        "narHash": "sha256-bQLa1YX0CJRpjCTptGY03oo0TWsZbOQTjVTWq1Yl168=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "f5488b54d4d9c271a9e12ad5691208a6c0ffd3fc",
+        "rev": "a4d2ca948edc750f4cd1743c3e2c6d99cb2b4da4",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "f5488b54d4d9c271a9e12ad5691208a6c0ffd3fc",
+        "rev": "a4d2ca948edc750f4cd1743c3e2c6d99cb2b4da4",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783357767,
-        "narHash": "sha256-zEB13KLqipAtwa8Tuo6O3SxITLgy5/LcctSmqy34SiQ=",
+        "lastModified": 1783360307,
+        "narHash": "sha256-3RzfVhuP7u82zXfXAaZUpmALHuoynSrmTBiZUIXJ8wQ=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "6f7d5d1b5aa5917e46c8ee5df8e831c4a0ba755f",
+        "rev": "70b0220e829d3fa090f77fee8521388dea7c169b",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "6f7d5d1b5aa5917e46c8ee5df8e831c4a0ba755f",
+        "rev": "70b0220e829d3fa090f77fee8521388dea7c169b",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783354299,
-        "narHash": "sha256-bQLa1YX0CJRpjCTptGY03oo0TWsZbOQTjVTWq1Yl168=",
+        "lastModified": 1783356341,
+        "narHash": "sha256-vuVTWZO0MzN1E3BhVnbcQNdqX9rle24l4CoKqN0ZVG8=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "a4d2ca948edc750f4cd1743c3e2c6d99cb2b4da4",
+        "rev": "95af346bd2bc22a829b22bf1f4f1b4cb69b06b0c",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "a4d2ca948edc750f4cd1743c3e2c6d99cb2b4da4",
+        "rev": "95af346bd2bc22a829b22bf1f4f1b4cb69b06b0c",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/70b0220e829d3fa090f77fee8521388dea7c169b";
+    keytap.url = "github:jul-sh/keytap/92154f13235fd8ff26e5d51aa34d63428ae7dfcf";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/a4d2ca948edc750f4cd1743c3e2c6d99cb2b4da4";
+    keytap.url = "github:jul-sh/keytap/95af346bd2bc22a829b22bf1f4f1b4cb69b06b0c";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/21881ccd1d880f3703c9db48c210415d88990365";
+    keytap.url = "github:jul-sh/keytap/a29f8c51b46cb4e2a755c7c77058b1c2fa8f448b";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/6f7d5d1b5aa5917e46c8ee5df8e831c4a0ba755f";
+    keytap.url = "github:jul-sh/keytap/70b0220e829d3fa090f77fee8521388dea7c169b";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/92154f13235fd8ff26e5d51aa34d63428ae7dfcf";
+    keytap.url = "github:jul-sh/keytap/21881ccd1d880f3703c9db48c210415d88990365";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/95af346bd2bc22a829b22bf1f4f1b4cb69b06b0c";
+    keytap.url = "github:jul-sh/keytap/6f7d5d1b5aa5917e46c8ee5df8e831c4a0ba755f";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/f5488b54d4d9c271a9e12ad5691208a6c0ffd3fc";
+    keytap.url = "github:jul-sh/keytap/a4d2ca948edc750f4cd1743c3e2c6d99cb2b4da4";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:

--- a/tools/xtask/src/cmd/release.rs
+++ b/tools/xtask/src/cmd/release.rs
@@ -153,7 +153,7 @@ impl<'a> AppStoreSigningSession<'a> {
 
         self.reporter
             .info("Decrypting provisioning profile from secrets...");
-        let encoded = secrets::read_secret(self.repo, &secret_path, self.reporter)
+        let encoded = secrets::read_secret(&secret_path, self.reporter)
             .with_context(|| format!("decrypting {secret_path}"))?;
         let encoded = std::str::from_utf8(&encoded)
             .context("PROVISION_PROFILE_BASE64 secret is not valid UTF-8")?;

--- a/tools/xtask/src/cmd/secrets.rs
+++ b/tools/xtask/src/cmd/secrets.rs
@@ -3,9 +3,9 @@
 //! [`read_secret`] directly to decrypt other age-encrypted secrets.
 
 use std::env;
+use std::fs::File;
 use std::io::Write;
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -13,7 +13,6 @@ use camino::{Utf8Path, Utf8PathBuf};
 use crate::cli::{AscAuthArgs, SecretsCmd};
 use crate::model::{AscAuthField, SideEffectLevel};
 use crate::output::Reporter;
-use crate::process::Runner;
 use crate::repo::RepoRoot;
 
 pub fn run(cmd: &SecretsCmd, dry_run: bool, reporter: &Reporter) -> Result<()> {
@@ -29,42 +28,43 @@ fn secret_path(repo: &RepoRoot, name: &str) -> Utf8PathBuf {
     repo.join(format!("secrets/{stem}.age"))
 }
 
-/// Resolve an age-encrypted secret to plaintext. The age identity comes from
-/// `$AGE_SECRET_KEY` (CI) or `keytap reveal` (local development). Key
-/// persistence is keytap's job: `keytap remember clipkitty` makes reveals
-/// prompt-free on this machine.
+/// Resolve an age-encrypted secret to plaintext. With `$AGE_SECRET_KEY` set
+/// (CI), decrypt with the `age` CLI; otherwise hand the whole job to
+/// `keytap decrypt`, so the derived age identity never enters this process.
+/// Prompt-freedom is keytap's job: after a one-time `keytap remember
+/// clipkitty`, decrypts stop prompting on this machine; without it, every
+/// decrypt is its own passkey ceremony.
 pub(crate) fn read_secret(secret_path: &Utf8Path, reporter: &Reporter) -> Result<Vec<u8>> {
-    let identity = age_identity(reporter)
-        .with_context(|| format!("resolving age identity to decrypt {secret_path}"))?;
-    age_decrypt(&identity, secret_path)
-}
-
-/// Key revealed by keytap during this run, so commands that decrypt several
-/// secrets (e.g. signing setup) invoke keytap at most once.
-static REVEALED_KEY: OnceLock<String> = OnceLock::new();
-
-fn age_identity(reporter: &Reporter) -> Result<String> {
     if let Ok(key) = env::var("AGE_SECRET_KEY") {
         if !key.is_empty() {
-            return Ok(key);
+            return age_decrypt(&key, secret_path);
         }
     }
-    if let Some(key) = REVEALED_KEY.get() {
-        return Ok(key.clone());
-    }
+    keytap_decrypt(secret_path, reporter)
+}
+
+fn keytap_decrypt(secret_path: &Utf8Path, reporter: &Reporter) -> Result<Vec<u8>> {
     if !tool_exists("keytap") {
         return Err(anyhow!(
-            "neither AGE_SECRET_KEY nor the keytap CLI is available"
+            "neither AGE_SECRET_KEY nor the keytap CLI is available to decrypt {secret_path}"
         ));
     }
-    let out = Runner::new(reporter, "keytap")
-        .args(["reveal", "clipkitty", "--format", "age"])
-        .output()?;
-    let key = out.stdout_string()?.trim().to_string();
-    if key.is_empty() {
-        return Err(anyhow!("keytap reveal produced an empty key"));
+    reporter.info(&format!("Decrypting {secret_path} with keytap"));
+    let file = File::open(secret_path.as_std_path())
+        .with_context(|| format!("opening {secret_path}"))?;
+    let output = Command::new("keytap")
+        .args(["decrypt", "--key", "clipkitty"])
+        .stdin(Stdio::from(file))
+        .stdout(Stdio::piped())
+        // The passkey ceremony (Touch ID notice, nearby-flow QR) renders on
+        // stderr; it must reach the user.
+        .stderr(Stdio::inherit())
+        .output()
+        .context("spawning keytap decrypt")?;
+    if !output.status.success() {
+        return Err(anyhow!("keytap decrypt failed for {secret_path}"));
     }
-    Ok(REVEALED_KEY.get_or_init(|| key).clone())
+    Ok(output.stdout)
 }
 
 fn age_decrypt(identity: &str, secret_path: &Utf8Path) -> Result<Vec<u8>> {

--- a/tools/xtask/src/cmd/secrets.rs
+++ b/tools/xtask/src/cmd/secrets.rs
@@ -53,7 +53,7 @@ fn keytap_decrypt(secret_path: &Utf8Path, reporter: &Reporter) -> Result<Vec<u8>
     let file = File::open(secret_path.as_std_path())
         .with_context(|| format!("opening {secret_path}"))?;
     let output = Command::new("keytap")
-        .args(["decrypt", "--key", "clipkitty"])
+        .args(["decrypt", "clipkitty"])
         .stdin(Stdio::from(file))
         .stdout(Stdio::piped())
         // The passkey ceremony (Touch ID notice, nearby-flow QR) renders on

--- a/tools/xtask/src/cmd/secrets.rs
+++ b/tools/xtask/src/cmd/secrets.rs
@@ -5,6 +5,7 @@
 use std::env;
 use std::io::Write;
 use std::process::{Command, Stdio};
+use std::sync::OnceLock;
 
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -28,98 +29,42 @@ fn secret_path(repo: &RepoRoot, name: &str) -> Utf8PathBuf {
     repo.join(format!("secrets/{stem}.age"))
 }
 
-/// Resolve an age-encrypted secret to plaintext, mirroring the keytap +
-/// keychain + `$AGE_SECRET_KEY` fallback used by the existing signing/release
-/// flows.
-pub(crate) fn read_secret(
-    repo: &RepoRoot,
-    secret_path: &Utf8Path,
-    reporter: &Reporter,
-) -> Result<Vec<u8>> {
-    match age_identity_source(repo)? {
-        AgeIdentitySource::EnvVar(key) => age_decrypt(&key, secret_path),
-        AgeIdentitySource::Keychain { account } => match read_keychain(&account) {
-            Some(key) => match age_decrypt(&key, secret_path) {
-                Ok(bytes) => Ok(bytes),
-                Err(_) => fallback_to_keytap(&account, secret_path, reporter),
-            },
-            None => fallback_to_keytap(&account, secret_path, reporter),
-        },
-    }
+/// Resolve an age-encrypted secret to plaintext. The age identity comes from
+/// `$AGE_SECRET_KEY` (CI) or `keytap reveal` (local development). Key
+/// persistence is keytap's job: `keytap remember clipkitty` makes reveals
+/// prompt-free on this machine.
+pub(crate) fn read_secret(secret_path: &Utf8Path, reporter: &Reporter) -> Result<Vec<u8>> {
+    let identity = age_identity(reporter)
+        .with_context(|| format!("resolving age identity to decrypt {secret_path}"))?;
+    age_decrypt(&identity, secret_path)
 }
 
-enum AgeIdentitySource {
-    EnvVar(String),
-    Keychain { account: String },
-}
+/// Key revealed by keytap during this run, so commands that decrypt several
+/// secrets (e.g. signing setup) invoke keytap at most once.
+static REVEALED_KEY: OnceLock<String> = OnceLock::new();
 
-fn age_identity_source(repo: &RepoRoot) -> Result<AgeIdentitySource> {
+fn age_identity(reporter: &Reporter) -> Result<String> {
     if let Ok(key) = env::var("AGE_SECRET_KEY") {
         if !key.is_empty() {
-            return Ok(AgeIdentitySource::EnvVar(key));
+            return Ok(key);
         }
     }
-    let project_name = repo
-        .as_path()
-        .file_name()
-        .ok_or_else(|| anyhow!("repo root has no filename"))?
-        .to_owned();
-    Ok(AgeIdentitySource::Keychain {
-        account: format!("AGE_SECRET_KEY_{project_name}"),
-    })
-}
-
-fn read_keychain(account: &str) -> Option<String> {
-    let output = Command::new("security")
-        .args(["find-generic-password", "-s", "keytap", "-a", account, "-w"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
+    if let Some(key) = REVEALED_KEY.get() {
+        return Ok(key.clone());
     }
-    let raw = String::from_utf8(output.stdout).ok()?;
-    let trimmed = raw.trim_end_matches('\n').to_string();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed)
-    }
-}
-
-fn cache_keychain(account: &str, key: &str) {
-    let _ = Command::new("security")
-        .args([
-            "add-generic-password",
-            "-U",
-            "-s",
-            "keytap",
-            "-a",
-            account,
-            "-w",
-            key,
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
-}
-
-fn fallback_to_keytap(
-    account: &str,
-    secret_path: &Utf8Path,
-    reporter: &Reporter,
-) -> Result<Vec<u8>> {
     if !tool_exists("keytap") {
         return Err(anyhow!(
-            "Neither AGE_SECRET_KEY, keychain, nor keytap available to decrypt {secret_path}"
+            "neither AGE_SECRET_KEY nor the keytap CLI is available"
         ));
     }
     let out = Runner::new(reporter, "keytap")
         .args(["reveal", "clipkitty", "--format", "age"])
         .output()?;
     let key = out.stdout_string()?.trim().to_string();
-    let plaintext = age_decrypt(&key, secret_path)?;
-    cache_keychain(account, &key);
-    Ok(plaintext)
+    if key.is_empty() {
+        return Err(anyhow!("keytap reveal produced an empty key"));
+    }
+    Ok(REVEALED_KEY.get_or_init(|| key).clone())
 }
 
 fn age_decrypt(identity: &str, secret_path: &Utf8Path) -> Result<Vec<u8>> {
@@ -180,7 +125,7 @@ pub(crate) fn resolve_asc_field(
     for name in [primary, fallback] {
         let path = secret_path(repo, name);
         if path.as_std_path().is_file() {
-            let bytes = read_secret(repo, &path, reporter)?;
+            let bytes = read_secret(&path, reporter)?;
             return Ok(String::from_utf8(bytes)
                 .context("ASC secret is not UTF-8")?
                 .trim()

--- a/tools/xtask/src/cmd/sign.rs
+++ b/tools/xtask/src/cmd/sign.rs
@@ -492,11 +492,8 @@ fn temp_p12_secret(
 }
 
 fn decode_secret_base64(repo: &RepoRoot, name: &str, reporter: &Reporter) -> Result<Vec<u8>> {
-    let bytes = crate::cmd::secrets::read_secret(
-        repo,
-        &repo.join(format!("secrets/{name}.age")),
-        reporter,
-    )?;
+    let bytes =
+        crate::cmd::secrets::read_secret(&repo.join(format!("secrets/{name}.age")), reporter)?;
     let text =
         String::from_utf8(bytes).map_err(|err| anyhow!("{name} secret is not UTF-8: {err}"))?;
     // Some secrets are line-wrapped base64 (standard `base64` CLI output wraps
@@ -509,11 +506,8 @@ fn decode_secret_base64(repo: &RepoRoot, name: &str, reporter: &Reporter) -> Res
 }
 
 fn secret_text(repo: &RepoRoot, name: &str, reporter: &Reporter) -> Result<String> {
-    let bytes = crate::cmd::secrets::read_secret(
-        repo,
-        &repo.join(format!("secrets/{name}.age")),
-        reporter,
-    )?;
+    let bytes =
+        crate::cmd::secrets::read_secret(&repo.join(format!("secrets/{name}.age")), reporter)?;
     String::from_utf8(bytes)
         .map(|text| text.trim().to_string())
         .map_err(|err| anyhow!("{name} secret is not UTF-8: {err}"))


### PR DESCRIPTION
## What

Built on jul-sh/keytap#21 (merged) and the keytap v6.0.0 release.

- `tools/xtask/src/cmd/secrets.rs`: delete the hand-rolled keychain cache and stop pulling the age identity into xtask at all. With `$AGE_SECRET_KEY` set (CI, unchanged) the `age` CLI decrypts as before; otherwise each `.age` file is handed to `keytap decrypt clipkitty` on stdin, so the derived identity (a master key to every clipkitty secret) never enters this process's memory. No identity memo, no `security` subprocesses.
- `read_secret` no longer needs the repo root (it was only used to derive the cache account name); callers in `sign.rs` and `release.rs` updated.
- Pin the `keytap` flake input to keytap main's post-release flake bump (`a29f8c5`), which ships the signed v6.0.0 release binaries.

## Flake

keytap's flake packages **pre-built release binaries** (the signed macOS app bundle is what makes native passkeys work, so building from source in nix is not an option on macOS). The pin targets keytap main's post-v6.0.0-release flake bump, so the dev shell ships the real signed v6 binary; the packaged keytap was built through this exact pin and verified live (`keytap 6.0.0`, `remember` present, stdin/stdout decrypt). The flake's package version is now derived from the release artifact URL, so it can never drift from what it ships.

## Did keytap#21 make life easier for clipkitty?

Yes, unambiguously. clipkitty had hand-rolled exactly this feature: on first reveal it silently wrote the derived age key into the login keychain (`security add-generic-password -s keytap -a AGE_SECRET_KEY_clipkitty`), read it back on later runs, and re-revealed when the cached key went stale. `keytap remember` replaces that with something strictly better:

- clipkitty no longer holds, persists, or manages the raw identity at all; with direct `keytap decrypt`, xtask only ever sees the plaintexts it is about to use.
- Remembered keys are scoped to the active root and wiped on `keytap init`; the DIY cache had no invalidation story beyond "decryption failed, silently overwrite".
- Persistence is an explicit user decision (`keytap remember clipkitty`) instead of a side effect the tool imposed on first use.
- Works everywhere: `keytap remember clipkitty` saves a plain 0600 file in the XDG state dir, silently upgraded to the OS keychain when one is available (macOS Keychain; Secret Service on desktop Linux), so servers and containers get prompt-free decrypts too; the DIY cache shelled out to `security` and was macOS-only.

Honest costs:

- One-time migration per dev machine: run `keytap remember clipkitty`. Without it, every secret decrypt is its own passkey ceremony, and a signing run touches four or five secrets; that sting is deliberate, remember is the intended state.
- The legacy cache entry lingers in the login keychain. `keytap forget --all` deliberately spares user-managed entries under the `keytap` service, so clean it up manually if desired: `security delete-generic-password -s keytap -a AGE_SECRET_KEY_clipkitty`.

CI is unaffected; every workflow that decrypts secrets injects `AGE_SECRET_KEY`, which remains the first branch. All `secrets/*.age` files are binary-format age (verified), which keytap's no-armor age build reads fine.

## Testing

`cargo check` and `cargo clippy` on the xtask crate are clean (the two dead-code warnings are pre-existing in `marketing.rs`). `nix flake update keytap` resolved the pin and `nix eval` confirms the pinned flake evaluates. On the keytap side, a prompt-free `encrypt | decrypt` pipe round-trip was run live against a remembered file-store key. Local clipkitty test suites intentionally not run per request.
