### PR TITLE
Update ClipKitty to Keytap v8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Install CI tools from Nix
         run: |
           # Install tools from flake-locked nixpkgs (pinned via flake.lock)
-          nix profile install --no-update-lock-file --inputs-from . keytap#default
+          nix profile install --no-update-lock-file .#keytap
           nix profile install --no-update-lock-file .#tuist
           tuist version
 
@@ -567,7 +567,7 @@ jobs:
       - name: Install CI tools from Nix
         run: |
           # age decrypts the ASC auth key below
-          nix profile install --no-update-lock-file --inputs-from . keytap#default
+          nix profile install --no-update-lock-file .#keytap
           nix profile install --no-update-lock-file .#tuist
           tuist version
 
@@ -772,7 +772,7 @@ jobs:
       - name: Install CI tools from Nix
         run: |
           # keytap decrypts the screenshot fixtures via $KEYTAP_KEY_CLIPKITTY
-          nix profile install --no-update-lock-file --inputs-from . keytap#default
+          nix profile install --no-update-lock-file .#keytap
           nix profile install --no-update-lock-file .#tuist
           tuist version
 
@@ -861,7 +861,7 @@ jobs:
 
       - name: Install CI tools from Nix
         run: |
-          nix profile install --no-update-lock-file --inputs-from . keytap#default
+          nix profile install --no-update-lock-file .#keytap
           nix profile install --no-update-lock-file --inputs-from . nixpkgs#ffmpeg
           nix profile install --no-update-lock-file .#tuist
           tuist version
@@ -1459,7 +1459,7 @@ jobs:
 
       - name: Install CI tools from Nix
         run: |
-          nix profile install --no-update-lock-file --inputs-from . keytap#default
+          nix profile install --no-update-lock-file .#keytap
           nix profile install --no-update-lock-file .#tuist
           nix profile install --no-update-lock-file .#asc
           tuist version
@@ -1620,7 +1620,7 @@ jobs:
 
       - name: Install CI tools from Nix
         run: |
-          nix profile install --no-update-lock-file --inputs-from . keytap#default
+          nix profile install --no-update-lock-file .#keytap
           nix profile install --no-update-lock-file .#tuist
           nix profile install --no-update-lock-file .#asc
           tuist version

--- a/.github/workflows/promote-appstore-release.yml
+++ b/.github/workflows/promote-appstore-release.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Install release publishing tools
         if: steps.promotion.outputs.state == 'ready' || steps.promotion.outputs.state == 'reconcile_existing'
         run: |
-          nix profile install --no-update-lock-file --inputs-from . keytap#default
+          nix profile install --no-update-lock-file .#keytap
           make install-sparkle-cli
 
       - name: Validate publication credentials

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1783390305,
-        "narHash": "sha256-riKXErneQuHoKTl8YDYFvD2jYgk07A6rhFCprDc+8gc=",
+        "lastModified": 1785452246,
+        "narHash": "sha256-4cZGztSHTdD0mQAEzLrocJml2CqGH8nVLst+ZxObmS0=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "9e1fc2930df7f6810ce2ca347822195cee0785d9",
+        "rev": "0ca23721e42442c00252ec51cc85f7b8b236c5ac",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
+        "ref": "0ca2372",
         "repo": "keytap",
-        "rev": "9e1fc2930df7f6810ce2ca347822195cee0785d9",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1785452246,
-        "narHash": "sha256-4cZGztSHTdD0mQAEzLrocJml2CqGH8nVLst+ZxObmS0=",
+        "lastModified": 1786557404,
+        "narHash": "sha256-hLre25gRiSHvN/pbfV/0KEnn0sRcw02fco/qZ6VSTq8=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "0ca23721e42442c00252ec51cc85f7b8b236c5ac",
+        "rev": "69171ac03112ff3553483256abb917ac724971b2",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
-        "ref": "0ca2372",
         "repo": "keytap",
+        "rev": "69171ac03112ff3553483256abb917ac724971b2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/9e1fc2930df7f6810ce2ca347822195cee0785d9";
+    keytap.url = "github:jul-sh/keytap/0ca2372";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:
@@ -20,7 +20,31 @@
         # Darwin; other systems keep a portable Rust/test audit surface plus
         # general CLI tooling, but not Apple build products.
         isDarwin = lib.hasSuffix "-darwin" system;
-        keytapPackage = keytap.packages.${system}.default or null;
+        keytapRelease = {
+          aarch64-darwin = {
+            url = "https://github.com/jul-sh/keytap/releases/download/0ca2372/keytap-0ca2372-arm64.zip";
+            hash = "sha256-PKtTkm10J4AuEKx2xUUs5/RnG68UtBKKON8hd33Y3eU=";
+          };
+          x86_64-linux = {
+            url = "https://github.com/jul-sh/keytap/releases/download/0ca2372/keytap-0ca2372-linux-x86_64.zip";
+            hash = "sha256-Bl69cQnlTdFiQFte1kJaA6MUjGg4XMjhsuZIzW5gcyE=";
+          };
+        }.${system} or null;
+        keytapPackage =
+          if keytapRelease == null then null else
+          keytap.packages.${system}.default.overrideAttrs (old: {
+            version = "8.0.0";
+            src = pkgs.fetchurl keytapRelease;
+          } // lib.optionalAttrs isDarwin {
+            nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.makeWrapper ];
+            installPhase = ''
+              app="$out/share/keytap/Keytap.app"
+              mkdir -p "$out/share/keytap" "$out/bin"
+              cp -R Keytap.app "$out/share/keytap/"
+              makeWrapper "$app/Contents/MacOS/keytap" "$out/bin/keytap" \
+                --run "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f '$app' >/dev/null 2>&1 || true"
+            '';
+          });
 
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" "rust-std" ];
@@ -148,6 +172,7 @@
             clipkitty-rust-tests = rustOutputs.rustTests;
             xtask = xtaskPackage;
           }
+          // lib.optionalAttrs (keytapPackage != null) { keytap = keytapPackage; }
           // lib.optionalAttrs isDarwin {
             # Re-export tools CI workflows install with
             # `nix profile install .#<name>` so they come from this

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/0ca2372";
+    keytap.url = "github:jul-sh/keytap/69171ac03112ff3553483256abb917ac724971b2";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:
@@ -20,31 +20,7 @@
         # Darwin; other systems keep a portable Rust/test audit surface plus
         # general CLI tooling, but not Apple build products.
         isDarwin = lib.hasSuffix "-darwin" system;
-        keytapRelease = {
-          aarch64-darwin = {
-            url = "https://github.com/jul-sh/keytap/releases/download/0ca2372/keytap-0ca2372-arm64.zip";
-            hash = "sha256-PKtTkm10J4AuEKx2xUUs5/RnG68UtBKKON8hd33Y3eU=";
-          };
-          x86_64-linux = {
-            url = "https://github.com/jul-sh/keytap/releases/download/0ca2372/keytap-0ca2372-linux-x86_64.zip";
-            hash = "sha256-Bl69cQnlTdFiQFte1kJaA6MUjGg4XMjhsuZIzW5gcyE=";
-          };
-        }.${system} or null;
-        keytapPackage =
-          if keytapRelease == null then null else
-          keytap.packages.${system}.default.overrideAttrs (old: {
-            version = "8.0.0";
-            src = pkgs.fetchurl keytapRelease;
-          } // lib.optionalAttrs isDarwin {
-            nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.makeWrapper ];
-            installPhase = ''
-              app="$out/share/keytap/Keytap.app"
-              mkdir -p "$out/share/keytap" "$out/bin"
-              cp -R Keytap.app "$out/share/keytap/"
-              makeWrapper "$app/Contents/MacOS/keytap" "$out/bin/keytap" \
-                --run "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f '$app' >/dev/null 2>&1 || true"
-            '';
-          });
+        keytapPackage = keytap.packages.${system}.default or null;
 
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [ "rust-src" "rust-std" ];


### PR DESCRIPTION
## Summary

- pin Keytap to post-release packaging commit `69171ac03112ff3553483256abb917ac724971b2`
- consume the upstream stable Keytap 8.0.0 package directly
- expose that package as `packages.keytap` for local development and CI
- install the same package in build and App Store promotion workflows
- remove ClipKitty’s temporary `0ca2372` artifact and launcher overrides

## Root cause

ClipKitty was pinned to an older Keytap client while the production relay serves the v8 encrypted `/room` contract. The temporary consumer-side package override was needed before Keytap’s stable flake owned the v8 artifacts and native macOS launcher. Keytap now publishes those pieces itself and preserves the signed app during Nix packaging.

## Impact

Local development and CI use the same stable, production-compatible Keytap 8 package without restoring any legacy relay endpoint or duplicating Keytap packaging logic in ClipKitty.

## Validation

- `nix flake metadata --json` locks Keytap to `69171ac03112ff3553483256abb917ac724971b2`
- `nix eval --raw .#keytap.version` reports `8.0.0`
- `nix build --no-link .#keytap`
- `nix shell .#keytap --command keytap --version` reports `keytap 8.0.0`
- `nix shell .#keytap --command keytap remembered` exits successfully for uninitialized state
- strict deep code-signature verification passes for the built app
- stapled notarization ticket validation passes
- `nix flake check --all-systems --no-build`
- staged README/App Store copy alignment hook