### PR TITLE
Update ClipKitty to Keytap v9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1786557404,
-        "narHash": "sha256-hLre25gRiSHvN/pbfV/0KEnn0sRcw02fco/qZ6VSTq8=",
+        "lastModified": 1786574590,
+        "narHash": "sha256-gt5TEnyRYWmUZ1zgVyEITVUkFF/miOcLyt91VYvbM4o=",
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "69171ac03112ff3553483256abb917ac724971b2",
+        "rev": "099f2e1d00bcd999ecd2cd6ad815ff5bc33f3f6f",
         "type": "github"
       },
       "original": {
         "owner": "jul-sh",
         "repo": "keytap",
-        "rev": "69171ac03112ff3553483256abb917ac724971b2",
+        "rev": "099f2e1d00bcd999ecd2cd6ad815ff5bc33f3f6f",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611"; # nixpkgs-unstable
     rust-overlay.url = "github:oxalica/rust-overlay/cc80954a95f6f356c303ed9f08d0b63ca86216ac";
     flake-utils.url = "github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b";
-    keytap.url = "github:jul-sh/keytap/69171ac03112ff3553483256abb917ac724971b2";
+    keytap.url = "github:jul-sh/keytap/099f2e1d00bcd999ecd2cd6ad815ff5bc33f3f6f";
   };
 
   outputs = { self, nixpkgs, rust-overlay, flake-utils, keytap, ... }:


### PR DESCRIPTION
## Summary

- pin Keytap to the v9.0.0 post-release flake commit
- refresh only the Keytap input in `flake.lock`

This makes ClipKitty CI and local Nix shells use the stable Keytap 9 package, including automatic native-to-QR fallback.

## Validation

- `nix flake metadata --no-update-lock-file`
- `nix flake check --no-update-lock-file --no-build`
- `nix build --no-update-lock-file .#keytap --no-link --print-out-paths -L`
- packaged `keytap --version` reports `9.0.0`
- `codesign --verify --deep --strict` on packaged `Keytap.app`
- `make check`
- `git diff --check`